### PR TITLE
move helper functions out of ImageLoader and ImageLoader1x class

### DIFF
--- a/src/nyx/dirs_and_files.cpp
+++ b/src/nyx/dirs_and_files.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <regex>
 #include <sstream>
+#include <tiffio.h>
 
 namespace Nyxus
 {
@@ -180,6 +181,26 @@ namespace Nyxus
 	{
 		std::filesystem::path p(fpath);
 		return p.filename().string();
+	}
+
+	// Helper function to determine Tile Status
+	bool check_tile_status(const std::string& filePath)
+	{
+		TIFF* tiff_ = TIFFOpen(filePath.c_str(), "r");
+		if (tiff_ != nullptr)
+		{
+			if (TIFFIsTiled(tiff_) == 0)
+			{
+				TIFFClose(tiff_);
+				return false;
+			}
+			else
+			{
+				TIFFClose(tiff_);
+				return true;
+			}
+		}
+		else { throw (std::runtime_error("Tile Loader ERROR: The file can not be opened.")); }
 	}
 
 } // namespace Nyxus

--- a/src/nyx/dirs_and_files.h
+++ b/src/nyx/dirs_and_files.h
@@ -46,4 +46,7 @@ namespace Nyxus
 		std::vector <std::string>& intensFiles,
 		std::vector <std::string>& labelFiles);
 
+	/// @brief checks if the Tiff file is tiled or not
+	/// @param filePath File name with complete path
+	bool check_tile_status(const std::string& filePath);
 } // namespace Nyxus

--- a/src/nyx/image_loader.h
+++ b/src/nyx/image_loader.h
@@ -29,9 +29,6 @@ public:
 	size_t get_within_tile_idx (size_t pixel_row, size_t pixel_col);
 	size_t get_full_width();
 	size_t get_full_height();
-	std::tuple<uint32_t, uint32_t, uint32_t>  get_image_dimensions (const std::string& filePath); 
-	std::tuple<uint32_t, uint32_t, uint32_t>  calculate_tile_dimensions (const std::string& filePath);
-	bool checkTileStatus(const std::string& filePath);
 private:
 	fl::AbstractTileLoader<fl::DefaultView<uint32_t>> *segFL = nullptr, *intFL = nullptr; 
 	std::shared_ptr<std::vector<uint32_t>> ptrI = nullptr; 

--- a/src/nyx/image_loader1x.h
+++ b/src/nyx/image_loader1x.h
@@ -25,9 +25,6 @@ public:
 	size_t get_tile_x(size_t pixel_col);
 	size_t get_tile_y(size_t pixel_row);
 	size_t get_within_tile_idx(size_t pixel_row, size_t pixel_col);
-	std::tuple<uint32_t, uint32_t, uint32_t>  get_image_dimensions(const std::string& filePath);
-	std::tuple<uint32_t, uint32_t, uint32_t>  calculate_tile_dimensions(const std::string& filePath);
-	bool checkTileStatus(const std::string& filePath);
 private:
 	std::unique_ptr<fl::AbstractTileLoader<fl::DefaultView<uint32_t>>> FL = nullptr;	
 	std::shared_ptr<std::vector<uint32_t>> ptr = nullptr;


### PR DESCRIPTION
Now that ImageLoader and ImageLoader1x class support both OmeZarr and OmeTiff files, it feels better to move those tiff related helper function out of these classes and consolidate in NyxusGrayscaleTiffStripLoader class