### PR TITLE
Add preinstall script

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,9 @@ build:
     python: "3.7"
   apt_packages:
     - cmake
-
+  jobs:
+    pre_install:
+      - bash ./ci-utils/install_prereq_linux.sh
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py

--- a/docs/source/References/Classes.rst
+++ b/docs/source/References/Classes.rst
@@ -1,3 +1,5 @@
+Nyxus Classes
+================
 .. autosummary::
     :toctree: stubs 
 


### PR DESCRIPTION
Since Sphinx-autodoc needs the nyxus module to be imported, I see no way but to build nyxus Python package for the docs to be generated in ReadTheDocs. 
Running the `install_prereq_linux.sh` fixes the build issue inside the RTD environment. 