### PR TITLE
fixes in feature output table header and enforcing finite numbers

### DIFF
--- a/src/nyx/environment.h
+++ b/src/nyx/environment.h
@@ -204,6 +204,9 @@ public:
   // implementation of Apache options
 	bool arrow_is_enabled();
 
+	// NAN substitute in feature values
+	double nan_substitute = 0.0;
+
 private:
 
 	std::vector<std::tuple<std::string, std::string>> recognizedArgs;	// Accepted command line arguments

--- a/src/nyx/globals.h
+++ b/src/nyx/globals.h
@@ -27,6 +27,12 @@ namespace py = pybind11;
 
 namespace Nyxus
 {
+	// Permanent column names of the feature output table
+	const char colname_intensity_image[] = "intensity_image",
+		colname_mask_image[] = "mask_image",
+		colname_roi_label[] = "ROI_label";
+
+	// Global instances
 	extern FeatureManager theFeatureMgr;
 	extern ImageLoader theImLoader;
 
@@ -59,8 +65,6 @@ namespace Nyxus
 	
 	std::vector<std::tuple<std::vector<std::string>, int, std::vector<double>>> get_feature_values();	
 	std::vector<std::string> get_header(const std::vector<std::tuple<std::string, AvailableFeatures>>& F );
-
-
 
 	void init_feature_buffers();
 	void clear_feature_buffers();	

--- a/src/nyx/helpers/helpers.h
+++ b/src/nyx/helpers/helpers.h
@@ -316,5 +316,13 @@ namespace Nyxus
 	{
 		return x / 180. * 3.14159265358979323846;
 	}
+
+	inline double force_finite_number (double x, double nan_substitute = 0.0)
+	{
+		if (std::isnan(x) || std::isinf(x))
+			return nan_substitute;
+		else
+			return x;
+	}
 }
 

--- a/src/nyx/output_2_buffer.cpp
+++ b/src/nyx/output_2_buffer.cpp
@@ -41,7 +41,7 @@ namespace Nyxus
 		// -- Header
 		if (fill_header)
 		{
-			rescache.add_to_header({"mask_image", "intensity_image", "label"});
+			rescache.add_to_header ({ Nyxus::colname_intensity_image, Nyxus::colname_mask_image, Nyxus::colname_roi_label });
 
 			for (auto& enabdF : F)
 			{

--- a/src/nyx/output_2_csv.cpp
+++ b/src/nyx/output_2_csv.cpp
@@ -183,7 +183,7 @@ namespace Nyxus
 		return retval;
 	}
 
-	const std::vector<std::string> mandatory_output_columns {"intensity_image", "mask_image", "ROI_label"};
+	const std::vector<std::string> mandatory_output_columns { Nyxus::colname_intensity_image, Nyxus::colname_mask_image, Nyxus::colname_roi_label };
 
 	// Saves the result of image scanning and feature calculation. Must be called after the reduction phase.
 	bool save_features_2_csv (const std::string & intFpath, const std::string & segFpath, const std::string & outputDir)
@@ -235,14 +235,16 @@ namespace Nyxus
 
 			auto head_vector = Nyxus::get_header(F);
 
-			for(const auto& column: head_vector){
-				ssHead << column << ", ";
+			// Make sure that the header is in format "column1","column2",...,"columnN" without spaces
+			for(int i=0; i<head_vector.size(); i++)
+			{
+				const auto& column = head_vector[i];
+				if (i)
+					ssHead << ',';
+				ssHead << '\"' << column << '\"';
 			}
 
 			auto head_string = ssHead.str();
-
-			head_string.pop_back(); // remove trailing comma
-
 			fprintf(fp, "%s\n", head_string.c_str());
 
 			// Prevent rendering the header again for another image's portion of labels
@@ -286,7 +288,8 @@ namespace Nyxus
 					int nAng = GLCMFeature::angles.size();
 					for (int i=0; i < nAng; i++)
 					{
-						snprintf (rvbuf, VAL_BUF_LEN, rvfmt, vv[i]);
+						double fv = Nyxus::force_finite_number (vv[i], theEnvironment.nan_substitute);	// safe feature value (no NAN, no inf)
+						snprintf (rvbuf, VAL_BUF_LEN, rvfmt, fv);
 						#ifndef DIAGNOSE_NYXUS_OUTPUT
 							ssVals << "," << rvbuf;
 						#else
@@ -306,7 +309,8 @@ namespace Nyxus
 					int nAng = 4;
 					for (int i=0; i < nAng; i++)
 					{
-						snprintf (rvbuf, VAL_BUF_LEN, rvfmt, vv[i]);
+						double fv = Nyxus::force_finite_number(vv[i], theEnvironment.nan_substitute);	// safe feature value (no NAN, no inf)
+						snprintf (rvbuf, VAL_BUF_LEN, rvfmt, fv);
 						#ifndef DIAGNOSE_NYXUS_OUTPUT
 							ssVals << "," << rvbuf;
 						#else
@@ -323,7 +327,8 @@ namespace Nyxus
 				{
 					for (auto i = 0; i < GaborFeature::f0_theta_pairs.size(); i++)
 					{
-						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, vv[i]);
+						double fv = Nyxus::force_finite_number(vv[i], theEnvironment.nan_substitute);	// safe feature value (no NAN, no inf)
+						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
 						#ifndef DIAGNOSE_NYXUS_OUTPUT
 							ssVals << "," << rvbuf;
 						#else	
@@ -341,7 +346,8 @@ namespace Nyxus
 				{
 					for (int i = 0; i < ZernikeFeature::num_feature_values_calculated; i++)
 					{
-						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, vv[i]);
+						double fv = Nyxus::force_finite_number(vv[i], theEnvironment.nan_substitute);	// safe feature value (no NAN, no inf)
+						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
 						#ifndef DIAGNOSE_NYXUS_OUTPUT
 							ssVals << "," << rvbuf;
 						#else
@@ -359,7 +365,8 @@ namespace Nyxus
 				{
 					for (auto i = 0; i < RadialDistributionFeature::num_features_FracAtD; i++)
 					{
-						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, vv[i]);
+						double fv = Nyxus::force_finite_number(vv[i], theEnvironment.nan_substitute);	// safe feature value (no NAN, no inf)
+						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
 						#ifndef DIAGNOSE_NYXUS_OUTPUT
 							ssVals << "," << rvbuf;
 						#else
@@ -374,7 +381,8 @@ namespace Nyxus
 				{
 					for (auto i = 0; i < RadialDistributionFeature::num_features_MeanFrac; i++)
 					{
-						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, vv[i]);
+						double fv = Nyxus::force_finite_number(vv[i], theEnvironment.nan_substitute);	// safe feature value (no NAN, no inf)
+						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
 						#ifndef DIAGNOSE_NYXUS_OUTPUT
 							ssVals << "," << rvbuf;
 						#else
@@ -389,7 +397,8 @@ namespace Nyxus
 				{
 					for (auto i = 0; i < RadialDistributionFeature::num_features_RadialCV; i++)
 					{
-						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, vv[i]);
+						double fv = Nyxus::force_finite_number(vv[i], theEnvironment.nan_substitute);	// safe feature value (no NAN, no inf)
+						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
 						#ifndef DIAGNOSE_NYXUS_OUTPUT
 							ssVals << "," << rvbuf;
 						#else
@@ -402,7 +411,7 @@ namespace Nyxus
 				}
 
 				// Regular feature
-				snprintf(rvbuf, VAL_BUF_LEN, rvfmt, vv[0]);
+				snprintf(rvbuf, VAL_BUF_LEN, rvfmt, Nyxus::force_finite_number (vv[0], theEnvironment.nan_substitute));
 				#ifndef DIAGNOSE_NYXUS_OUTPUT
 				ssVals << "," << rvbuf; // Alternatively: auto_precision(ssVals, vv[0]);
 				#else


### PR DESCRIPTION
In this PR:
1) Output table header further unified between CSV and Python API buffer ;
2) header's trailing character bug - fixed ; 
3) NANs and INFs are suppressed in the CSV output, leaving freedom to have them them in Python API output .