### PR TITLE
Add Apache Arrow support to Mac and Ubuntu PyPI wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -44,7 +44,7 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BEFORE_ALL_MACOS:  brew install llvm libomp && 
                                    python3 -m pip install setuptools==68.2.2 &&
-                                   bash ci-utils/install_prereq_linux.sh --on_mac yes &&
+                                   bash ci-utils/install_prereq_linux.sh --build_arrow yes &&
                                    mkdir -p /tmp/nyxus_bld &&
                                    cp -r local_install /tmp/nyxus_bld 
           CIBW_BEFORE_ALL_LINUX:  yum install -y llvm libevent-devel openssl-devel && 
@@ -62,6 +62,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_REQUIRES: numpy pandas pytest requests
+          CIBW_TEST_SKIP: "*-windows"
           CIBW_TEST_COMMAND: pytest {project}/tests/python
 
       - name: Upload Artifact

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -12,7 +12,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: "10.15"
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-latest]
+        os: [macos-11]
         cibw_archs: ["auto64"]
         cibw_build: ["cp38-*", "cp39-*", "cp310-*", "cp311-*"]
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -62,8 +62,9 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_REQUIRES: numpy pandas pytest requests
-          CIBW_TEST_SKIP: "*-win*"
-          CIBW_TEST_COMMAND: pytest {project}/tests/python
+          CIBW_TEST_COMMAND_MACOS: pytest {project}/tests/python
+          CIBW_TEST_COMMAND_LINUX: pytest {project}/tests/python
+          CIBW_TEST_COMMAND_WINDOW: pytest {project}/tests/python -m "not arrow"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -47,7 +47,8 @@ jobs:
                                    bash ci-utils/install_prereq_linux.sh --on_mac yes &&
                                    mkdir -p /tmp/nyxus_bld &&
                                    cp -r local_install /tmp/nyxus_bld 
-          CIBW_BEFORE_ALL_LINUX:  yum install -y llvm libevent-devel openssl-devel && bash ci-utils/install_arrow_centos.sh &&
+          CIBW_BEFORE_ALL_LINUX:  yum install -y llvm libevent-devel openssl-devel && 
+                                   bash ci-utils/install_arrow_yum.sh &&
                                    bash ci-utils/install_prereq_linux.sh &&
                                    mkdir -p /tmp/nyxus_bld &&
                                    cp -r local_install /tmp/nyxus_bld

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -42,8 +42,9 @@ jobs:
           CIBW_SKIP: "*musllinux*"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BEFORE_ALL_MACOS: brew install llvm libomp && 
-                                   bash ci-utils/install_prereq_linux.sh &&
+          CIBW_BEFORE_ALL_MACOS:  brew install llvm libomp && 
+                                   python3 -m pip install setuptools==68.2.2 &&
+                                   bash ci-utils/install_prereq_linux.sh --on_mac yes &&
                                    mkdir -p /tmp/nyxus_bld &&
                                    cp -r local_install /tmp/nyxus_bld 
           CIBW_BEFORE_ALL_LINUX:  bash ci-utils/install_prereq_linux.sh &&

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -47,7 +47,8 @@ jobs:
                                    bash ci-utils/install_prereq_linux.sh --on_mac yes &&
                                    mkdir -p /tmp/nyxus_bld &&
                                    cp -r local_install /tmp/nyxus_bld 
-          CIBW_BEFORE_ALL_LINUX:  bash ci-utils/install_prereq_linux.sh &&
+          CIBW_BEFORE_ALL_LINUX:  yum install -y llvm libevent-devel openssl-devel && bash ci-utils/install_arrow_centos.sh &&
+                                   bash ci-utils/install_prereq_linux.sh &&
                                    mkdir -p /tmp/nyxus_bld &&
                                    cp -r local_install /tmp/nyxus_bld
           CIBW_BEFORE_ALL_WINDOWS: ci-utils\install_prereq_win.bat &&
@@ -60,7 +61,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_REQUIRES: numpy pandas pytest requests
-          CIBW_TEST_COMMAND: pytest {project}/tests/python -m "not arrow"
+          CIBW_TEST_COMMAND: pytest {project}/tests/python
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -64,7 +64,7 @@ jobs:
           CIBW_TEST_REQUIRES: numpy pandas pytest requests
           CIBW_TEST_COMMAND_MACOS: pytest {project}/tests/python
           CIBW_TEST_COMMAND_LINUX: pytest {project}/tests/python
-          CIBW_TEST_COMMAND_WINDOW: pytest {project}/tests/python -m "not arrow"
+          CIBW_TEST_COMMAND_WINDOWS: pytest {project}/tests/python -m "not arrow"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -49,7 +49,7 @@ jobs:
                                    cp -r local_install /tmp/nyxus_bld 
           CIBW_BEFORE_ALL_LINUX:  yum install -y llvm libevent-devel openssl-devel && 
                                    bash ci-utils/install_arrow_yum.sh &&
-                                   bash ci-utils/install_prereq_linux.sh &&
+                                   bash ci-utils/install_prereq_linux.sh --build_arrow no &&
                                    mkdir -p /tmp/nyxus_bld &&
                                    cp -r local_install /tmp/nyxus_bld
           CIBW_BEFORE_ALL_WINDOWS: ci-utils\install_prereq_win.bat &&

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -12,7 +12,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: "10.15"
     strategy:
       matrix:
-        os: [macos-11]
+        os: [ubuntu-20.04, macos-11, windows-latest]
         cibw_archs: ["auto64"]
         cibw_build: ["cp38-*", "cp39-*", "cp310-*", "cp311-*"]
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -62,7 +62,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_REQUIRES: numpy pandas pytest requests
-          CIBW_TEST_SKIP: "*-windows"
+          CIBW_TEST_SKIP: "*-win*"
           CIBW_TEST_COMMAND: pytest {project}/tests/python
 
       - name: Upload Artifact

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,7 +349,7 @@ if(USE_ARROW)
 	endif()
 	
 	find_package(Parquet)
-	if (NOT Arrow_FOUND) 
+	if (NOT Parquet_FOUND) 
 		message(WARNING "The Parquet library was not found. The build will continue without Arrow support.")
 		set(USE_ARROW OFF)
 	endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,48 +343,17 @@ if(USE_ARROW)
 	option(PARQUET_LINK_SHARED "Link to the Parquet shared library" ON)
 	# Look for installed packages the system
 	find_package(Arrow)
-	if (Arrow_FOUND) 
-		# Look for installed packages the system
-		find_package(Parquet)
-		if (Parquet_FOUND)
-			if (BUILD_LIB)
-				# Find Python
-				find_package(Python REQUIRED COMPONENTS Interpreter)
-				# Execute the Python script to find pyarrow include path
-				execute_process(
-					COMMAND ${Python_EXECUTABLE} -c "import pyarrow as pa; print(pa.get_include())"
-					OUTPUT_VARIABLE PATH_OUTPUT
-					OUTPUT_STRIP_TRAILING_WHITESPACE
-				)
-				# Store the path in a CMake variable
-				set(PYARROW_INCLUDE_PATH "${PATH_OUTPUT}" CACHE INTERNAL "Path to pyarrow include directory")
-				# Execute the Python script to find pyarrow library path
-				execute_process(
-					COMMAND ${Python_EXECUTABLE} -c "import pyarrow as pa; print(pa.get_library_dirs()[0])"
-					OUTPUT_VARIABLE LIB_PATH_OUTPUT
-					OUTPUT_STRIP_TRAILING_WHITESPACE
-				)
-				# Store the path in a CMake variable
-				set(PYARROW_LIB_PATH "${LIB_PATH_OUTPUT}" CACHE INTERNAL "Path to pyarrow library directory")
-				if (PYARROW_INCLUDE_PATH STREQUAL "" OR PYARROW_LIB_PATH STREQUAL "")
-					message(STATUS "Pyarrow library not found. The build will continue without Arrow support.")
-					set(USE_ARROW OFF)
-				endif()
-
-				# Print the path
-				message(STATUS "PyArrow Include Path: ${PYARROW_INCLUDE_PATH}")
-				message(STATUS "PyArrow Library Path: ${PYARROW_LIB_PATH}")
-			endif()
-		
-		else()
-			message(WARNING "The Parquet library was not found. The build will continue without Arrow support.")
-			set(USE_ARROW OFF)
-		endif()
-
-	else ()
+	if (NOT Arrow_FOUND) 
 		message(WARNING "The Arrow library was not found. The build will continue without Arrow support.")
 		set(USE_ARROW OFF)
 	endif()
+	
+	find_package(Parquet)
+	if (NOT Arrow_FOUND) 
+		message(WARNING "The Parquet library was not found. The build will continue without Arrow support.")
+		set(USE_ARROW OFF)
+	endif()
+
 endif()
 
 if(USE_ARROW)
@@ -395,13 +364,6 @@ if(USE_ARROW)
 		list(APPEND Nyxus_LIBRARIES parquet_shared)
 	else()
 		list(APPEND Nyxus_LIBRARIES parquet_static)
-	endif()
-	if (BUILD_LIB)
-		# add pyarrow include path
-		include_directories(${PYARROW_INCLUDE_PATH})
-		#add pyarrow library
-		list(APPEND Nyxus_LIBRARIES arrow_python)
-		target_link_directories(backend PRIVATE ${PYARROW_LIB_PATH})
 	endif()
 endif()
 

--- a/ci-utils/install_arrow_yum.sh
+++ b/ci-utils/install_arrow_yum.sh
@@ -1,0 +1,9 @@
+yum install -y epel-release || sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1).noarch.rpm
+yum install -y https://apache.jfrog.io/artifactory/arrow/centos/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm
+yum install -y --enablerepo=epel arrow-devel # For C++
+yum install -y --enablerepo=epel arrow-glib-devel # For GLib (C)
+yum install -y --enablerepo=epel arrow-dataset-devel # For Apache Arrow Dataset C++
+yum install -y --enablerepo=epel arrow-dataset-glib-devel # For Apache Arrow Dataset GLib (C)
+yum install -y --enablerepo=epel arrow-acero-devel # For Apache Arrow Acero
+yum install -y --enablerepo=epel parquet-devel # For Apache Parquet C++
+yum install -y --enablerepo=epel parquet-glib-devel # For Apache Parquet GLib (C)

--- a/ci-utils/install_prereq_linux.sh
+++ b/ci-utils/install_prereq_linux.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# Usage: $bash install_prereq_linux.sh --min_build yes --on_mac yes --install_dir <LOCATION>
+# Usage: $bash install_prereq_linux.sh --min_build yes --build_arrow yes --install_dir <LOCATION>
 # Defaults:
 #   $install_dir = ./local_install
 #   $min_build == no
-#   $on_mac == no
+#   $build_arrow == no
 #
 # $min_build = yes will only install pybind11, libtiff and libdeflate
 #
@@ -12,6 +12,7 @@ BUILD_Z5_DEP=1
 BULD_DCMTK_DEP=1
 BUILD_ARROW_DEP=1
 BUILD_LLVM=1
+BUILD_ARROW=0
 
 while [ $# -gt 0 ]; do
     if [[ $1 == "--"* ]]; then
@@ -25,10 +26,11 @@ done
 if [[ "${min_build,,}" == "yes" ]]; then
     BUILD_Z5_DEP=0
     BULD_DCMTK_DEP=0
+    BUILD_ARROW=0
 fi
 
-if [[ "${on_mac,,}" == "yes" ]]; then
-    BUILD_LLVM=0
+if [[ "${build_arrow,,}" == "yes" ]]; then
+    BUILD_ARROW=1
 fi
 
 if [[ -z $install_dir ]]
@@ -214,23 +216,6 @@ if [[ $BULD_DCMTK_DEP -eq 1 ]]; then
 fi
 
 if [[ $BUILD_ARROW_DEP -eq 1 ]]; then
-    
-    ROOTDIR=$(pwd) 
-
-    if [[ $BUILD_LLVM -eq 1 ]]; then
-
-        curl -L https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-14.0.0.zip -o llvmorg-14.0.0.zip
-        unzip llvmorg-14.0.0.zip
-        cd llvm-project-llvmorg-14.0.0
-        mkdir build
-        cd build
-        cmake -G "Unix Makefiles" -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra" -DCMAKE_INSTALL_PREFIX=$ROOTDIR/$Z5_INSTALL_DIR -DCMAKE_BUILD_TYPE=Release ../llvm
-        make -j4
-        make install
-
-        cd $ROOTDIR
-
-    fi
 
     curl -L https://github.com/apache/arrow/archive/refs/tags/apache-arrow-13.0.0.zip -o  arrow-apache-arrow-13.0.0.zip
     unzip arrow-apache-arrow-13.0.0.zip
@@ -238,9 +223,9 @@ if [[ $BUILD_ARROW_DEP -eq 1 ]]; then
     cd cpp
     mkdir build
     cd build
-    cmake -DCMAKE_INSTALL_PREFIX=$ROOTDIR/$Z5_INSTALL_DIR \
-            -DCMAKE_PREFIX_PATH=$ROOTDIR/$Z5_INSTALL_DIR \
-            -DCMAKE_INSTALL_LIBDIR=arrow_lib \
+    cmake -DCMAKE_INSTALL_PREFIX=../../../$Z5_INSTALL_DIR \
+            -DCMAKE_PREFIX_PATH=../../../$Z5_INSTALL_DIR \
+            -DCMAKE_INSTALL_LIBDIR=lib \
             -DCMAKE_BUILD_TYPE=Release \
             -DARROW_COMPUTE=ON \
             -DARROW_CSV=ON \
@@ -252,5 +237,5 @@ if [[ $BUILD_ARROW_DEP -eq 1 ]]; then
     make -j4
     make install
 
-    cd $ROOTDIR
+    cd ../../../
 fi

--- a/ci-utils/install_prereq_linux.sh
+++ b/ci-utils/install_prereq_linux.sh
@@ -240,25 +240,4 @@ if [[ $BUILD_ARROW_DEP -eq 1 ]]; then
     make install
 
     cd ../../../
-
-
-    curl -L https://github.com/apache/arrow/archive/refs/tags/apache-arrow-12.0.0.zip -o  arrow-apache-arrow-12.0.0.zip
-unzip arrow-apache-arrow-12.0.0.zip
-cd arrow-apache-arrow-12.0.0/
-cd cpp/
-mkdir build
-cd build/
-cmake -DCMAKE_INSTALL_PREFIX=../../../$Z5_INSTALL_DIR \
-        -DCMAKE_INSTALL_LIBDIR=lib \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DARROW_COMPUTE=ON \
-        -DARROW_CSV=ON \
-        -DARROW_DATASET=ON \
-        -DARROW_ACERO=ON \
-        -DARROW_PARQUET=ON \
-        -DARROW_WITH_SNAPPY=ON \
-        .. 
-make -j4
-make install
-cd ../../../
 fi

--- a/ci-utils/install_prereq_linux.sh
+++ b/ci-utils/install_prereq_linux.sh
@@ -225,8 +225,8 @@ if [[ $BUILD_ARROW_DEP -eq 1 ]]; then
     cd cpp
     mkdir build
     cd build
-    cmake -DCMAKE_INSTALL_PREFIX=../../../$Z5_INSTALL_DIR \
-            -DCMAKE_PREFIX_PATH=../../../$Z5_INSTALL_DIR \
+    cmake -DCMAKE_INSTALL_PREFIX=../../../"$LOCAL_INSTALL_DIR"/ \
+            -DCMAKE_PREFIX_PATH=../../../"$LOCAL_INSTALL_DIR"/ \
             -DCMAKE_INSTALL_LIBDIR=lib \
             -DCMAKE_BUILD_TYPE=Release \
             -DARROW_COMPUTE=ON \

--- a/ci-utils/install_prereq_linux.sh
+++ b/ci-utils/install_prereq_linux.sh
@@ -10,8 +10,6 @@
 
 BUILD_Z5_DEP=1
 BULD_DCMTK_DEP=1
-BUILD_ARROW_DEP=1
-BUILD_LLVM=1
 BUILD_ARROW=0
 
 while [ $# -gt 0 ]; do
@@ -217,7 +215,7 @@ if [[ $BULD_DCMTK_DEP -eq 1 ]]; then
     cd ../../
 fi
 
-if [[ $BUILD_ARROW_DEP -eq 1 ]]; then
+if [[ $BUILD_ARROW -eq 1 ]]; then
 
     curl -L https://github.com/apache/arrow/archive/refs/tags/apache-arrow-13.0.0.zip -o  arrow-apache-arrow-13.0.0.zip
     unzip arrow-apache-arrow-13.0.0.zip

--- a/ci-utils/install_prereq_linux.sh
+++ b/ci-utils/install_prereq_linux.sh
@@ -29,9 +29,11 @@ if [[ "${min_build,,}" == "yes" ]]; then
     BUILD_ARROW=0
 fi
 
-if [[ "${build_arrow,,}" == "yes" ]]; then
+if [[ "${build_arrow}" == "yes" ]]; then
     BUILD_ARROW=1
 fi
+
+echo build arrow $BUILD_ARROW
 
 if [[ -z $install_dir ]]
 then
@@ -238,4 +240,25 @@ if [[ $BUILD_ARROW_DEP -eq 1 ]]; then
     make install
 
     cd ../../../
+
+
+    curl -L https://github.com/apache/arrow/archive/refs/tags/apache-arrow-12.0.0.zip -o  arrow-apache-arrow-12.0.0.zip
+unzip arrow-apache-arrow-12.0.0.zip
+cd arrow-apache-arrow-12.0.0/
+cd cpp/
+mkdir build
+cd build/
+cmake -DCMAKE_INSTALL_PREFIX=../../../$Z5_INSTALL_DIR \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DARROW_COMPUTE=ON \
+        -DARROW_CSV=ON \
+        -DARROW_DATASET=ON \
+        -DARROW_ACERO=ON \
+        -DARROW_PARQUET=ON \
+        -DARROW_WITH_SNAPPY=ON \
+        .. 
+make -j4
+make install
+cd ../../../
 fi

--- a/ci-utils/install_prereq_linux.sh
+++ b/ci-utils/install_prereq_linux.sh
@@ -217,7 +217,7 @@ if [[ $BUILD_ARROW_DEP -eq 1 ]]; then
     
     ROOTDIR=$(pwd) 
 
-    if [[ $BUILD_LLVM eq 1 ]]; then
+    if [[ $BUILD_LLVM -eq 1 ]]; then
 
         curl -L https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-14.0.0.zip -o llvmorg-14.0.0.zip
         unzip llvmorg-14.0.0.zip

--- a/src/nyx/python/new_bindings_py.cpp
+++ b/src/nyx/python/new_bindings_py.cpp
@@ -6,14 +6,6 @@
 #include <pybind11/stl.h>
 #include <pybind11/numpy.h>
 
-#ifdef USE_ARROW
-#include <arrow/table.h>
-#include <arrow/python/platform.h>
-#include <arrow/python/datetime.h>
-#include <arrow/python/init.h>
-#include <arrow/python/pyarrow.h>
-#endif
-
 #include "../version.h"
 #include "../dirs_and_files.h"   
 #include "../environment.h"

--- a/src/nyx/python/new_bindings_py.cpp
+++ b/src/nyx/python/new_bindings_py.cpp
@@ -12,21 +12,9 @@
 #include "../globals.h"
 #include "../nested_feature_aggregation.h"
 #include "../features/gabor.h"
+#include "../output_writers.h" 
+#include "../arrow_output_stream.h"
 
-#ifdef USE_ARROW
-    #include "../output_writers.h" 
-
-    #include "../arrow_output_stream.h"
-
-    #include <arrow/table.h>
-
-    #include <arrow/python/platform.h>
-    #include <arrow/python/datetime.h>
-    #include <arrow/python/init.h>
-    #include <arrow/python/pyarrow.h>
-
-    #include "table_caster.h"
-#endif
 
 namespace py = pybind11;
 using namespace Nyxus;
@@ -566,27 +554,6 @@ std::string get_parquet_file_imp() {
 #endif
 }
 
-#ifdef USE_ARROW
-
-std::shared_ptr<arrow::Table> get_arrow_table_imp(const std::string& file_path) {
-
-    auto table = theEnvironment.arrow_stream.get_arrow_table(file_path);
-    
-    if (table == nullptr) {
-        std::cerr << "Error creating Arrow table." << std::endl;
-    }
-    
-    return table;
-
-}
-
-#else
-
-void get_arrow_table_imp(const std::string& file_path) {
-    throw std::runtime_error("Arrow functionality is not available. Rebuild Nyxus with Arrow enabled.");
-}
-
-#endif
 
 bool arrow_is_enabled_imp() {
     return theEnvironment.arrow_is_enabled();
@@ -624,7 +591,6 @@ PYBIND11_MODULE(backend, m)
     m.def("arrow_is_enabled_imp", &arrow_is_enabled_imp, "Check if arrow is enabled.");
     m.def("get_arrow_file_imp", &get_arrow_file_imp, "Get path to arrow file");
     m.def("get_parquet_file_imp", &get_parquet_file_imp, "Returns path to parquet file");
-    m.def("get_arrow_table_imp", &get_arrow_table_imp, py::call_guard<py::gil_scoped_release>());
 }
 
 ///

--- a/src/nyx/python/new_bindings_py.cpp
+++ b/src/nyx/python/new_bindings_py.cpp
@@ -561,16 +561,6 @@ bool arrow_is_enabled_imp() {
 
 PYBIND11_MODULE(backend, m)
 {
-
-#ifdef USE_ARROW
-    Py_Initialize();
-
-    int success = arrow::py::import_pyarrow();
-
-    if (success != 0) {
-        throw std::runtime_error("Error initializing pyarrow.");
-    } 
-#endif
     m.doc() = "Nyxus";
     
     m.def("initialize_environment", &initialize_environment, "Environment initialization");

--- a/src/nyx/python/nyxus/nyxus.py
+++ b/src/nyx/python/nyxus/nyxus.py
@@ -33,8 +33,7 @@ if (arrow_headers_found() and arrow_is_enabled_imp()):
         
         from .backend import (
             get_arrow_file_imp, 
-            get_parquet_file_imp, 
-            get_arrow_table_imp,
+            get_parquet_file_imp,
         )
             
         import pyarrow as pa
@@ -755,25 +754,6 @@ class Nyxus:
             return array
         else:
             raise RuntimeError("Apache arrow is not enabled. Please rebuild Nyxus with Arrow support to enable this functionality.")
-    
-    
-    def get_arrow_table(self, arrow_file_path: str):
-        """Returns an arrow table containing the feature calculations.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        pyarrow.Table 
-
-        """
-        
-        if self.arrow_is_enabled():
-            return get_arrow_table_imp(str(arrow_file_path))
-        else:
-            raise RuntimeError("Nyxus was not built with Arrow. To use this functionality, rebuild Nyxus with Arrow support on.")
     
     def arrow_is_enabled(self):
         """Returns true if arrow support is enabled.


### PR DESCRIPTION
- Add Apache Arrow builds for PyPI wheels
- Remove pyarrow linking from C++ since the arrow::table is no longer constructed in C++
- Add Apache Arrow build to build script
- Add additional build script for installing Apache Arrow through yum