### PR TITLE
Fix output_path docstrings for featurize methods

### DIFF
--- a/src/nyx/python/nyxus/nyxus.py
+++ b/src/nyx/python/nyxus/nyxus.py
@@ -239,10 +239,10 @@ class Nyxus:
             Output format for the features values. Valid options are "pandas", "arrowipc", and "parquet".
         output_path: str (optional, default "")
             Output filepath for Arrow IPC and Parquet output formats. Default is "", which is the current directory.
-            The output_path can either be to a directory or filename. For example:
-            -If 'output_path=/path/to/directory' then a file with the default name NyxusFeatures.<extension> will be created. If the directory does not exist, it will be created.
-            -If 'output_path=/path/to/directory/some_file_name.arrow' then this file will be created. If the directory does not exist, it will also be created.
-            -If 'output_path=some_file_name.arrow' then this file will be created in the current working directory.
+            The output_path can either be to a directory or filename. For example,
+                - If 'output_path=/path/to/directory' then a file with the default name NyxusFeatures.<extension> will be created. If the directory does not exist, it will be created.
+                - If 'output_path=/path/to/directory/some_file_name.arrow' then this file will be created. If the directory does not exist, it will also be created.
+                - If 'output_path=some_file_name.arrow' then this file will be created in the current working directory.
 
         Returns
         -------
@@ -326,10 +326,10 @@ class Nyxus:
             Output format for the features values. Valid options are "pandas", "arrowipc", and "parquet".
         output_path: str (optional, default "")
             Output filepath for Arrow IPC and Parquet output formats. Default is "", which is the current directory.
-            The output_path can either be to a directory or filename. For example:
-            -If 'output_path=/path/to/directory' then a file with the default name NyxusFeatures.<extension> will be created. If the directory does not exist, it will be created.
-            -If 'output_path=/path/to/directory/some_file_name.arrow' then this file will be created. If the directory does not exist, it will also be created.
-            -If 'output_path=some_file_name.arrow' then this file will be created in the current working directory.
+            The output_path can either be to a directory or filename. For example,
+                - If 'output_path=/path/to/directory' then a file with the default name NyxusFeatures.<extension> will be created. If the directory does not exist, it will be created.
+                - If 'output_path=/path/to/directory/some_file_name.arrow' then this file will be created. If the directory does not exist, it will also be created.
+                - If 'output_path=some_file_name.arrow' then this file will be created in the current working directory.
             
         Returns
         -------
@@ -452,10 +452,10 @@ class Nyxus:
             Output format for the features values. Valid options are "pandas", "arrowipc", and "parquet".
         output_path: str (optional, default "")
             Output filepath for Arrow IPC and Parquet output formats. Default is "", which is the current directory.
-            The output_path can either be to a directory or filename. For example:
-            -If 'output_path=/path/to/directory' then a file with the default name NyxusFeatures.<extension> will be created. If the directory does not exist, it will be created.
-            -If 'output_path=/path/to/directory/some_file_name.arrow' then this file will be created. If the directory does not exist, it will also be created.
-            -If 'output_path=some_file_name.arrow' then this file will be created in the current working directory.
+            The output_path can either be to a directory or filename. For example,
+                - If 'output_path=/path/to/directory' then a file with the default name NyxusFeatures.<extension> will be created. If the directory does not exist, it will be created.
+                - If 'output_path=/path/to/directory/some_file_name.arrow' then this file will be created. If the directory does not exist, it will also be created.
+                - If 'output_path=some_file_name.arrow' then this file will be created in the current working directory.
 
         Returns
         -------

--- a/src/nyx/python/nyxus/nyxus.py
+++ b/src/nyx/python/nyxus/nyxus.py
@@ -239,12 +239,10 @@ class Nyxus:
             Output format for the features values. Valid options are "pandas", "arrowipc", and "parquet".
         output_path: str (optional, default "")
             Output filepath for Arrow IPC and Parquet output formats. Default is "", which is the current directory.
-            The output_path can either be to a directory or filename. For example,
-                - If 'output_path=/path/to/directory' then a file with the default name NyxusFeatures.<extension> will be created.
-                  If the directory does not exist, it will be created.
-                - If 'output_path=/path/to/directory/some_file_name.arrow' then this file will be created. 
-                  If the directory does not exist, it will also be created.
-                - If 'output_path=some_file_name.arrow' then this file will be created in the current working directory.
+            The output_path can either be to a directory or filename. For example:
+            -If 'output_path=/path/to/directory' then a file with the default name NyxusFeatures.<extension> will be created. If the directory does not exist, it will be created.
+            -If 'output_path=/path/to/directory/some_file_name.arrow' then this file will be created. If the directory does not exist, it will also be created.
+            -If 'output_path=some_file_name.arrow' then this file will be created in the current working directory.
 
         Returns
         -------
@@ -328,12 +326,10 @@ class Nyxus:
             Output format for the features values. Valid options are "pandas", "arrowipc", and "parquet".
         output_path: str (optional, default "")
             Output filepath for Arrow IPC and Parquet output formats. Default is "", which is the current directory.
-            The output_path can either be to a directory or filename. For example,
-                - If 'output_path=/path/to/directory' then a file with the default name NyxusFeatures.<extension> will be created.
-                  If the directory does not exist, it will be created.
-                - If 'output_path=/path/to/directory/some_file_name.arrow' then this file will be created. 
-                  If the directory does not exist, it will also be created.
-                - If 'output_path=some_file_name.arrow' then this file will be created in the current working directory.
+            The output_path can either be to a directory or filename. For example:
+            -If 'output_path=/path/to/directory' then a file with the default name NyxusFeatures.<extension> will be created. If the directory does not exist, it will be created.
+            -If 'output_path=/path/to/directory/some_file_name.arrow' then this file will be created. If the directory does not exist, it will also be created.
+            -If 'output_path=some_file_name.arrow' then this file will be created in the current working directory.
             
         Returns
         -------
@@ -456,12 +452,10 @@ class Nyxus:
             Output format for the features values. Valid options are "pandas", "arrowipc", and "parquet".
         output_path: str (optional, default "")
             Output filepath for Arrow IPC and Parquet output formats. Default is "", which is the current directory.
-            The output_path can either be to a directory or filename. For example,
-                - If 'output_path=/path/to/directory' then a file with the default name NyxusFeatures.<extension> will be created.
-                  If the directory does not exist, it will be created.
-                - If 'output_path=/path/to/directory/some_file_name.arrow' then this file will be created. 
-                  If the directory does not exist, it will also be created.
-                - If 'output_path=some_file_name.arrow' then this file will be created in the current working directory.
+            The output_path can either be to a directory or filename. For example:
+            -If 'output_path=/path/to/directory' then a file with the default name NyxusFeatures.<extension> will be created. If the directory does not exist, it will be created.
+            -If 'output_path=/path/to/directory/some_file_name.arrow' then this file will be created. If the directory does not exist, it will also be created.
+            -If 'output_path=some_file_name.arrow' then this file will be created in the current working directory.
 
         Returns
         -------

--- a/src/nyx/python/nyxus/nyxus.py
+++ b/src/nyx/python/nyxus/nyxus.py
@@ -318,9 +318,9 @@ class Nyxus:
             2D image or 3D collection of intensity images.
         label_images : np.ndarray
             2D image or 3D collection of label images.
-        intensity_names (optional): list
+        intensity_names: list (optional, default []) 
             names for the images in for the DataFrame output. 
-        label_names (optional): list
+        label_names: list (optional, default []) 
             names for the labels in for the DataFrame output.
         output_type: str (optional, default "pandas")
             Output format for the features values. Valid options are "pandas", "arrowipc", and "parquet".


### PR DESCRIPTION
- Fix formatting of output_path docstrings in featurize methods so it shows up correctly in Read the Docs