### PR TITLE
Fix Arrow pytests

### DIFF
--- a/src/nyx/output_2_buffer.cpp
+++ b/src/nyx/output_2_buffer.cpp
@@ -143,7 +143,7 @@ namespace Nyxus
 					// Populate with indices
 					for (int i = 0; i < ZernikeFeature::num_feature_values_calculated; i++)
 					{
-						std::string col = fn + "_" + std::to_string(i);
+						std::string col = fn + "_Z" + std::to_string(i);
 						rescache.add_to_header(col);
 					}
 

--- a/src/nyx/output_2_csv.cpp
+++ b/src/nyx/output_2_csv.cpp
@@ -157,7 +157,7 @@ namespace Nyxus
 			{
 				// Populate with indices
 				for (int i = 0; i < ZernikeFeature::num_feature_values_calculated; i++)	// i < ZernikeFeature::num_feature_values_calculated
-					head.emplace_back(fn + "_" + std::to_string(i));						
+					head.emplace_back(fn + "_Z" + std::to_string(i));						
 
 				// Proceed with other features
 				continue;

--- a/src/nyx/output_2_csv.cpp
+++ b/src/nyx/output_2_csv.cpp
@@ -157,7 +157,7 @@ namespace Nyxus
 			{
 				// Populate with indices
 				for (int i = 0; i < ZernikeFeature::num_feature_values_calculated; i++)	// i < ZernikeFeature::num_feature_values_calculated
-					head.emplace_back(fn + "_Z" + std::to_string(i));						
+					head.emplace_back(fn + "_" + std::to_string(i));						
 
 				// Proceed with other features
 				continue;

--- a/src/nyx/output_writers.cpp
+++ b/src/nyx/output_writers.cpp
@@ -197,7 +197,7 @@ arrow::Status ArrowIPCWriter::setup(const std::vector<std::string> &header) {
     
 
     fields.push_back(arrow::field("intensity_image", arrow::utf8()));
-    fields.push_back(arrow::field("segmentation_image", arrow::utf8()));
+    fields.push_back(arrow::field("mask_image", arrow::utf8()));
     fields.push_back(arrow::field("ROI_label", arrow::int32()));
 
     for (int i = 3; i < header.size(); ++i)

--- a/tests/python/test_nyxus.py
+++ b/tests/python/test_nyxus.py
@@ -336,13 +336,17 @@ class TestNyxus():
 
             arrow_columns = list(parquet_df.columns)
                 
-            for i in range(len(features.columns)):
-                column_list = features[pd_columns[i]].tolist()
-                arrow_list = parquet_df[arrow_columns[i]].tolist()
+            assert len(pd_columns) == len(arrow_columns)
                 
-                for i in range(len(column_list)):
-                    feature_value = column_list[i]
-                    arrow_value = arrow_list[i]
+            for column in pd_columns:
+                column_list = features[column].tolist()
+                arrow_list = parquet_df[column].tolist()
+                
+                assert (len(column_list) == len(arrow_list))
+                
+                for j in range(len(column_list)):
+                    feature_value = column_list[j]
+                    arrow_value = arrow_list[j]
                     
                     #skip nan values
                     if (isinstance(feature_value, (int, float)) and math.isnan(feature_value)):
@@ -374,14 +378,18 @@ class TestNyxus():
             pd_columns = list(features.columns)
 
             arrow_columns = list(parquet_df.columns)
+            
+            assert len(pd_columns) == len(arrow_columns)
                 
-            for i in range(len(features.columns)):
-                column_list = features[pd_columns[i]].tolist()
-                arrow_list = parquet_df[arrow_columns[i]].tolist()
+            for column in pd_columns:
+                column_list = features[column].tolist()
+                arrow_list = parquet_df[column].tolist()
                 
-                for i in range(len(column_list)):
-                    feature_value = column_list[i]
-                    arrow_value = arrow_list[i]
+                assert (len(column_list) == len(arrow_list))
+                
+                for j in range(len(column_list)):
+                    feature_value = column_list[j]
+                    arrow_value = arrow_list[j]
                     
                     #skip nan values
                     if (isinstance(feature_value, (int, float)) and math.isnan(feature_value)):
@@ -424,25 +432,28 @@ class TestNyxus():
             arrow_path = nyx.featurize(intens, seg, output_type="arrowipc")
 
             with pa.memory_map(arrow_path, 'rb') as source:
-                arrow_array = pa.ipc.open_file(source).read_all()
-
-            pd_columns = list(features.columns)
-                
-            for i in range(len(features.columns)):
-                column_list = features[pd_columns[i]].tolist()
-                arrow_list = arrow_array[i]
-                
-                for i in range(len(column_list)):
-                    feature_value = column_list[i]
-                    arrow_value = arrow_list[i].as_py()
+                arrow_pd = pa.ipc.open_file(source).read_all().to_pandas()
+            
+                pd_columns = list(features.columns)
                     
-                    #skip nan values
-                    if (isinstance(feature_value, (int, float)) and math.isnan(feature_value)):
-                        if (not math.isnan(arrow_value)):
-                            assert False
-
+                for column in pd_columns:
+                    
+                    if (column == 'mask_image'):
                         continue
-                    assert feature_value == arrow_value
+                    column_list = features[column].tolist()
+                    arrow_list = arrow_pd[column].tolist()
+                    
+                    for j in range(len(column_list)):
+                        feature_value = column_list[j]
+                        arrow_value = arrow_list[j]
+                        
+                        #skip nan values
+                        if (isinstance(feature_value, (int, float)) and math.isnan(feature_value)):
+                            if (not math.isnan(arrow_value)):
+                                assert False
+
+                            continue
+                        assert feature_value == arrow_value
             
             path = nyx.get_arrow_ipc_file()
         
@@ -457,26 +468,29 @@ class TestNyxus():
             features = nyx.featurize(intens, seg)
             
             with pa.memory_map(arrow_path, 'rb') as source:
-                arrow_array = pa.ipc.open_file(source).read_all()
+                arrow_pd = pa.ipc.open_file(source).read_all().to_pandas()
             
-            pd_columns = list(features.columns)
-                
-            for i in range(len(features.columns)):
-                column_list = features[pd_columns[i]].tolist()
-                arrow_list = arrow_array[i]
-                
-                for i in range(len(column_list)):
-                    feature_value = column_list[i]
-                    arrow_value = arrow_list[i].as_py()
+                pd_columns = list(features.columns)
                     
-                    #skip nan values
-                    if (isinstance(feature_value, (int, float)) and math.isnan(feature_value)):
-                        if (not math.isnan(arrow_value)):
-                            assert False
-
+                for column in pd_columns:
+                    
+                    if (column == 'mask_image'):
                         continue
-                    assert feature_value == arrow_value
+                    column_list = features[column].tolist()
+                    arrow_list = arrow_pd[column].tolist()
                     
+                    for j in range(len(column_list)):
+                        feature_value = column_list[j]
+                        arrow_value = arrow_list[j]
+                        
+                        #skip nan values
+                        if (isinstance(feature_value, (int, float)) and math.isnan(feature_value)):
+                            if (not math.isnan(arrow_value)):
+                                assert False
+
+                            continue
+                        assert feature_value == arrow_value
+                        
         @pytest.mark.arrow
         def test_arrow_ipc_file_naming(self):
             
@@ -490,25 +504,28 @@ class TestNyxus():
             features = nyx.featurize(intens, seg)
             
             with pa.memory_map(arrow_path, 'rb') as source:
-                arrow_array = pa.ipc.open_file(source).read_all()
+                arrow_pd = pa.ipc.open_file(source).read_all().to_pandas()
             
-            pd_columns = list(features.columns)
-                
-            for i in range(len(features.columns)):
-                column_list = features[pd_columns[i]].tolist()
-                arrow_list = arrow_array[i]
-                
-                for i in range(len(column_list)):
-                    feature_value = column_list[i]
-                    arrow_value = arrow_list[i].as_py()
+                pd_columns = list(features.columns)
                     
-                    #skip nan values
-                    if (isinstance(feature_value, (int, float)) and math.isnan(feature_value)):
-                        if (not math.isnan(arrow_value)):
-                            assert False
-
+                for column in pd_columns:
+                    
+                    if (column == 'mask_image'):
                         continue
-                    assert feature_value == arrow_value
+                    column_list = features[column].tolist()
+                    arrow_list = arrow_pd[column].tolist()
+                    
+                    for j in range(len(column_list)):
+                        feature_value = column_list[j]
+                        arrow_value = arrow_list[j]
+                        
+                        #skip nan values
+                        if (isinstance(feature_value, (int, float)) and math.isnan(feature_value)):
+                            if (not math.isnan(arrow_value)):
+                                assert False
+
+                            continue
+                        assert feature_value == arrow_value
             
         @pytest.mark.arrow
         def test_arrow_ipc_no_path(self):
@@ -523,25 +540,28 @@ class TestNyxus():
             features = nyx.featurize(intens, seg)
         
             with pa.memory_map(arrow_path, 'rb') as source:
-                arrow_array = pa.ipc.open_file(source).read_all()
-                
-            pd_columns = list(features.columns)
-                
-            for i in range(len(features.columns)):
-                column_list = features[pd_columns[i]].tolist()
-                arrow_list = arrow_array[i]
-                
-                for i in range(len(column_list)):
-                    feature_value = column_list[i]
-                    arrow_value = arrow_list[i].as_py()
+                arrow_pd = pa.ipc.open_file(source).read_all().to_pandas()
+            
+                pd_columns = list(features.columns)
                     
-                    #skip nan values
-                    if (isinstance(feature_value, (int, float)) and math.isnan(feature_value)):
-                        if (not math.isnan(arrow_value)):
-                            assert False
-
+                for column in pd_columns:
+                    
+                    if (column == 'mask_image'):
                         continue
-                    assert feature_value == arrow_value
+                    column_list = features[column].tolist()
+                    arrow_list = arrow_pd[column].tolist()
+                    
+                    for j in range(len(column_list)):
+                        feature_value = column_list[j]
+                        arrow_value = arrow_list[j]
+                        
+                        #skip nan values
+                        if (isinstance(feature_value, (int, float)) and math.isnan(feature_value)):
+                            if (not math.isnan(arrow_value)):
+                                assert False
+
+                            continue
+                        assert feature_value == arrow_value
             
         @pytest.mark.arrow         
         def test_arrow_ipc_path(self):

--- a/tests/python/test_nyxus.py
+++ b/tests/python/test_nyxus.py
@@ -385,6 +385,7 @@ class TestNyxus():
                 assert (len(column_list) == len(arrow_list))
                 
                 for j in range(len(column_list)):
+                    
                     feature_value = column_list[j]
                     arrow_value = arrow_list[j]
                     
@@ -413,13 +414,16 @@ class TestNyxus():
                 arrow_pd = pa.ipc.open_file(source).read_all().to_pandas()
             
                 pd_columns = list(features.columns)
+                arrow_columns = list(arrow_pd.columns)
+                
+                assert len(pd_columns) == len(arrow_columns)
                     
                 for column in pd_columns:
                     
-                    if (column == 'mask_image'):
-                        continue
                     column_list = features[column].tolist()
                     arrow_list = arrow_pd[column].tolist()
+                    
+                    assert len(column_list) == len(arrow_list)
                     
                     for j in range(len(column_list)):
                         feature_value = column_list[j]
@@ -448,13 +452,16 @@ class TestNyxus():
                 arrow_pd = pa.ipc.open_file(source).read_all().to_pandas()
             
                 pd_columns = list(features.columns)
+                arrow_columns = list(arrow_pd.columns)
+                
+                assert len(pd_columns) == len(arrow_columns)
                     
                 for column in pd_columns:
                     
-                    if (column == 'mask_image'):
-                        continue
                     column_list = features[column].tolist()
                     arrow_list = arrow_pd[column].tolist()
+                    
+                    assert len(column_list) == len(arrow_list)
                     
                     for j in range(len(column_list)):
                         feature_value = column_list[j]
@@ -484,13 +491,16 @@ class TestNyxus():
                 arrow_pd = pa.ipc.open_file(source).read_all().to_pandas()
             
                 pd_columns = list(features.columns)
+                arrow_columns = list(arrow_pd.columns)
+                
+                assert len(pd_columns) == len(arrow_columns)
                     
                 for column in pd_columns:
                     
-                    if (column == 'mask_image'):
-                        continue
                     column_list = features[column].tolist()
                     arrow_list = arrow_pd[column].tolist()
+                    
+                    assert len(column_list) == len(arrow_list)
                     
                     for j in range(len(column_list)):
                         feature_value = column_list[j]
@@ -520,13 +530,16 @@ class TestNyxus():
                 arrow_pd = pa.ipc.open_file(source).read_all().to_pandas()
             
                 pd_columns = list(features.columns)
+                arrow_columns = list(arrow_pd.columns)
+                
+                assert len(pd_columns) == len(arrow_columns)
                     
                 for column in pd_columns:
                     
-                    if (column == 'mask_image'):
-                        continue
                     column_list = features[column].tolist()
                     arrow_list = arrow_pd[column].tolist()
+                    
+                    assert len(column_list) == len(arrow_list)
                     
                     for j in range(len(column_list)):
                         feature_value = column_list[j]

--- a/tests/python/test_nyxus.py
+++ b/tests/python/test_nyxus.py
@@ -351,7 +351,7 @@ class TestNyxus():
                             assert False
 
                         continue
-                    assert feature_value == pytest.approx(arrow_value, rel=1e-6)
+                    assert feature_value == pytest.approx(arrow_value, rel=1e-6, abs=1e-6)
             
             open_parquet_file.close()
             
@@ -395,7 +395,7 @@ class TestNyxus():
                             assert False
 
                         continue
-                    assert feature_value == pytest.approx(arrow_value, rel=1e-6)
+                    assert feature_value == pytest.approx(arrow_value, rel=1e-6, abs=1e-6)
             
             file.close()
 
@@ -435,7 +435,7 @@ class TestNyxus():
                                 assert False
 
                             continue
-                        assert feature_value == pytest.approx(arrow_value, rel=1e-6)
+                        assert feature_value == pytest.approx(arrow_value, rel=1e-6, abs=1e-6)
 
         
         @pytest.mark.arrow
@@ -473,7 +473,7 @@ class TestNyxus():
                                 assert False
 
                             continue
-                        assert feature_value == pytest.approx(arrow_value, rel=1e-6)
+                        assert feature_value == pytest.approx(arrow_value, rel=1e-6, abs=1e-6)
                         
         @pytest.mark.arrow
         def test_arrow_ipc_file_naming(self):
@@ -512,7 +512,7 @@ class TestNyxus():
                                 assert False
 
                             continue
-                        assert feature_value == pytest.approx(arrow_value, rel=1e-6)
+                        assert feature_value == pytest.approx(arrow_value, rel=1e-6, abs=1e-6)
             
         @pytest.mark.arrow
         def test_arrow_ipc_no_path(self):
@@ -551,7 +551,7 @@ class TestNyxus():
                                 assert False
 
                             continue
-                        assert feature_value == pytest.approx(arrow_value, rel=1e-6)
+                        assert feature_value == pytest.approx(arrow_value, rel=1e-6, abs=1e-6)
             
         @pytest.mark.arrow         
         def test_arrow_ipc_path(self):

--- a/tests/python/test_nyxus.py
+++ b/tests/python/test_nyxus.py
@@ -316,9 +316,9 @@ class TestNyxus():
             
         @pytest.mark.arrow        
         def test_parquet_writer(self):
+            
             nyx = nyxus.Nyxus (["*ALL*"])
             assert nyx is not None
-            
             
             features = nyx.featurize(intens, seg)
 
@@ -328,10 +328,7 @@ class TestNyxus():
             
             parquet_df = open_parquet_file.read().to_pandas()
             
-            
             # Read the Parquet file into a Pandas DataFrame
-            #parquet_df = pq.read_table(open_parquet_file).to_pandas()
-            #parquet_df = pd.read_parquet(parquet_file)
             pd_columns = list(features.columns)
 
             arrow_columns = list(parquet_df.columns)
@@ -354,7 +351,7 @@ class TestNyxus():
                             assert False
 
                         continue
-                    assert feature_value == arrow_value
+                    assert feature_value == pytest.approx(arrow_value, rel=1e-6)
             
             open_parquet_file.close()
             
@@ -397,29 +394,10 @@ class TestNyxus():
                             assert False
 
                         continue
-                    assert feature_value == arrow_value
+                    assert feature_value == pytest.approx(arrow_value, rel=1e-6)
             
-
             file.close()
-            '''
-            attempts = 0
-            while True:
-                
-                try:
-                    os.remove('TestNyxusOut/test_parquet.parquet')
-                    print('deleted successfully')
-                    break
-                except:
-                    
-                    attempts +=1
-                    
-                    if attempts > 5:
-                        print("Could not delete file")
-                        break
-                    
-                    time.sleep(30)
-            '''
-            print("parquet file is closed: " + str(file.closed))
+
 
         @pytest.mark.arrow
         def test_make_arrow_ipc(self):
@@ -453,9 +431,8 @@ class TestNyxus():
                                 assert False
 
                             continue
-                        assert feature_value == arrow_value
-            
-            path = nyx.get_arrow_ipc_file()
+                        assert feature_value == pytest.approx(arrow_value, rel=1e-6)
+
         
         @pytest.mark.arrow
         def test_arrow_ipc(self):
@@ -489,7 +466,7 @@ class TestNyxus():
                                 assert False
 
                             continue
-                        assert feature_value == arrow_value
+                        assert feature_value == pytest.approx(arrow_value, rel=1e-6)
                         
         @pytest.mark.arrow
         def test_arrow_ipc_file_naming(self):
@@ -525,7 +502,7 @@ class TestNyxus():
                                 assert False
 
                             continue
-                        assert feature_value == arrow_value
+                        assert feature_value == pytest.approx(arrow_value, rel=1e-6)
             
         @pytest.mark.arrow
         def test_arrow_ipc_no_path(self):
@@ -561,7 +538,7 @@ class TestNyxus():
                                 assert False
 
                             continue
-                        assert feature_value == arrow_value
+                        assert feature_value == pytest.approx(arrow_value, rel=1e-6)
             
         @pytest.mark.arrow         
         def test_arrow_ipc_path(self):

--- a/tests/test_data.h
+++ b/tests/test_data.h
@@ -631,7 +631,7 @@ const static NyxusPixel roiDataForPerimeterTest[] = {
 
 
 const static std::tuple<std::vector<std::string>, std::vector<std::tuple<std::vector<std::string>, int, std::vector<double>>>> features {
-	std::make_tuple(std::vector<std::string>{"intensity_image", "segmentation_image", "ROI_label", "COV", "COVERED_IMAGE_INTENSITY_RANGE", "ENERGY", 
+	std::make_tuple(std::vector<std::string>{"intensity_image", "mask_image", "ROI_label", "COV", "COVERED_IMAGE_INTENSITY_RANGE", "ENERGY", 
 	"ENTROPY", "EXCESS_KURTOSIS", "HYPERFLATNESS", "HYPERSKEWNESS", "INTEGRATED_INTENSITY", "INTERQUARTILE_RANGE", "KURTOSIS", 
 	"MAX", "MEAN", "MEAN_ABSOLUTE_DEVIATION", "MEDIAN", "MEDIAN_ABSOLUTE_DEVIATION", "MIN", "MODE", "P01", "P10", "P25", "P75", 
 	"P90", "P99", "QCOD", "RANGE", "ROBUST_MEAN", "ROBUST_MEAN_ABSOLUTE_DEVIATION", "ROOT_MEAN_SQUARED", "SKEWNESS", "STANDARD_DEVIATION", 


### PR DESCRIPTION
- Read Arrow IPC directly into DataFrame
- Check that the number of columns are the same
- Add absolute tolerance to feature value comparisons
- Access Arrow files by column name to ensure equivalent columns are being compared