### PR TITLE
POL3837 Polus-style file patterns in 3D 

### DIFF
--- a/src/nyx/environment.cpp
+++ b/src/nyx/environment.cpp
@@ -453,7 +453,7 @@ bool Environment::parse_cmdline(int argc, char** argv)
 		case 3:
 			if (check_3d_file_pattern(rawFilePattern) == false)
 			{
-				std::cerr << "Error: invalid 3D file pattern '" << rawFilePattern << "' \n";
+				std::cerr << "Error: invalid 3D file pattern " << rawFilePattern << " : " << this->file_pattern_3D.get_ermsg() << '\n';
 				return false;
 			}
 			break;

--- a/src/nyx/environment_basic.cpp
+++ b/src/nyx/environment_basic.cpp
@@ -34,7 +34,7 @@ bool BasicEnvironment::check_2d_file_pattern(const std::string& pat)
 
 bool BasicEnvironment::check_3d_file_pattern(const std::string& pat)
 {
-	return file_pattern_3D.set_pattern (pat);
+	return file_pattern_3D.set_filepattern (pat);
 }
 
 std::string BasicEnvironment::get_file_pattern()

--- a/src/nyx/python/new_bindings_py.cpp
+++ b/src/nyx/python/new_bindings_py.cpp
@@ -263,8 +263,9 @@ py::tuple featurize_directory_3D_imp(
     theEnvironment.set_dim(3);
     
     // Check and cache the file pattern
+    std::string ermsg;
     if (!theEnvironment.check_3d_file_pattern(file_pattern))
-        throw std::invalid_argument("Invalid file pattern " + file_pattern);
+        throw std::invalid_argument("Invalid file pattern " + file_pattern + " : " + theEnvironment.file_pattern_3D.get_ermsg());
 
     // No need to set the raw file pattern separately for 3D
     //      theEnvironment.set_file_pattern(file_pattern);

--- a/src/nyx/strpat.h
+++ b/src/nyx/strpat.h
@@ -8,16 +8,21 @@ class StringPattern
 public:
 	StringPattern();
 
-	// initialize the file pattern object with a string
-	bool set_pattern(const std::string& s);
+	// Initialize the instance using a Polus-stype filepattern (example: BRATS_{d+}_z{set d+}_t{d+}.ome.tif)
+	// Error details are available via get_ermsg()
+	bool set_filepattern(const std::string & pat);
 
-	// returns whether the file pattern is initialized and usable
+	// Initialize the instance using anexplicit definition (example: "TEXT=BRATS SEP=_ NUM SEP=_ TEXT=z NUM=* SEP=_ TEXT=t NUM SEP=. TEXT=ome SEP=. TEXT=tif")
+	// Error details are available via get_ermsg()
+	bool set_raw_pattern(const std::string & pat);
+
+	// Returns whether the file pattern is initialized and usable
 	bool good() const;
 
-	// returns the last error message
+	// Returns the last error message
 	std::string get_ermsg() const;
 
-	// returns true if a string matches the pattern
+	// Returns true if a string matches the pattern
 	bool match (const std::string& s, std::map<std::string, std::vector<std::string>>& imgDirs, std::string& external_ermsg) const;
 
 	std::string get_cached_pattern_string() const;
@@ -28,12 +33,18 @@ protected:
 	std::string ermsg_;
 	std::vector<std::string> grammar_;
 
-	// if successful, sets tokCodes and tokVals
+	// If successful, sets tokCodes and tokVals
 	bool tokenize(
 		const std::string & s, 
 		std::vector<std::string> & tokCodes,
 		std::vector<std::string> & tokVals) const;
 
 	bool filepatt_to_grammar (const std::string& filePatt, std::vector<std::string>& grammar, std::string& errMsg);
+
+	std::string get_term_context (const std::string& term);
+
+private:
+	// Terminals
+	const char *t_TEXT = "TEXT", *t_NUM = "NUM", *t_SEP = "SEP", *t_STAR = "STAR";
 
 };

--- a/tests/test_initialization.h
+++ b/tests/test_initialization.h
@@ -21,7 +21,6 @@
 
 using Nyxus::allocateTrivialRoisBuffers;
 using Nyxus::freeTrivialRoisBuffers;
-using namespace Nyxus;
 
 void test_initialization() {
 


### PR DESCRIPTION
Selector **{set d+}** treats the corresponding numbers as Z-indices.

**Example:** 
```
from nyxus import Nyxus3D 
n = Nyxus3D(["*3D_ALL*"]) 
F = n.featurize_directory (intensity_dir="path/to/dataset/int", label_dir="path/to/dataset/seg", file_pattern="BRATS_{d+}_z{set d+}_t{d+}.ome.tif")
```

to extract features from files BRATS_001_z001_t002.ome.tif, BRATS_001_z002_t002.ome.tif, ..., BRATS_001_z154_t002.ome.tif