### PR TITLE
update mac runner and CentOS Yum repos

### DIFF
--- a/.github/workflows/build_and_test_mac.yml
+++ b/.github/workflows/build_and_test_mac.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   Build_and_Run_GTest:
     name: Build and Run GoogleTest
-    runs-on: macos-11
+    runs-on: macos-12
     defaults:
       run:
         shell: bash -l {0}
@@ -49,7 +49,7 @@ jobs:
 
   Build_and_Run_PyTest:
     name: Build and Run PyTest
-    runs-on: macos-11
+    runs-on: macos-12
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/build_cuda11_wheels.yml
+++ b/.github/workflows/build_cuda11_wheels.yml
@@ -57,7 +57,10 @@ jobs:
           CIBW_SKIP: "*musllinux*"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BEFORE_ALL_LINUX:  yum install -y llvm libevent-devel openssl-devel &&
+          CIBW_BEFORE_ALL_LINUX:  sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo &&
+                                   sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo &&
+                                   sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && 
+                                   yum install -y llvm libevent-devel openssl-devel && 
                                    bash ci-utils/install_cuda_yum.sh 11 && 
                                    bash ci-utils/install_arrow_yum.sh &&
                                    bash ci-utils/install_prereq_linux.sh --build_arrow no &&

--- a/.github/workflows/build_cuda12_wheels.yml
+++ b/.github/workflows/build_cuda12_wheels.yml
@@ -57,7 +57,10 @@ jobs:
           CIBW_SKIP: "*musllinux*"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BEFORE_ALL_LINUX:  yum install -y llvm libevent-devel openssl-devel &&
+          CIBW_BEFORE_ALL_LINUX:  sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo &&
+                                   sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo &&
+                                   sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && 
+                                   yum install -y llvm libevent-devel openssl-devel && 
                                    bash ci-utils/install_cuda_yum.sh 12 && 
                                    bash ci-utils/install_arrow_yum.sh &&
                                    bash ci-utils/install_prereq_linux.sh --build_arrow no &&

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -46,7 +46,10 @@ jobs:
                                    bash ci-utils/install_prereq_linux.sh --build_arrow yes &&
                                    mkdir -p /tmp/nyxus_bld &&
                                    cp -r local_install /tmp/nyxus_bld 
-          CIBW_BEFORE_ALL_LINUX:  yum install -y llvm libevent-devel openssl-devel && 
+          CIBW_BEFORE_ALL_LINUX:  sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo &&
+                                   sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo &&
+                                   sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && 
+                                   yum install -y llvm libevent-devel openssl-devel && 
                                    bash ci-utils/install_arrow_yum.sh &&
                                    bash ci-utils/install_prereq_linux.sh --build_arrow no &&
                                    mkdir -p /tmp/nyxus_bld &&

--- a/.github/workflows/publish_cuda11_pypi.yml
+++ b/.github/workflows/publish_cuda11_pypi.yml
@@ -59,7 +59,10 @@ jobs:
           CIBW_SKIP: "*musllinux*"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BEFORE_ALL_LINUX:  yum install -y llvm libevent-devel openssl-devel &&
+          CIBW_BEFORE_ALL_LINUX:  sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo &&
+                                   sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo &&
+                                   sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && 
+                                   yum install -y llvm libevent-devel openssl-devel && 
                                    bash ci-utils/install_cuda_yum.sh 11 && 
                                    bash ci-utils/install_arrow_yum.sh &&
                                    bash ci-utils/install_prereq_linux.sh --build_arrow no &&

--- a/.github/workflows/publish_cuda12_pypi.yml
+++ b/.github/workflows/publish_cuda12_pypi.yml
@@ -58,8 +58,10 @@ jobs:
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_SKIP: "*musllinux*"
           CIBW_BUILD_VERBOSITY: 3
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_BEFORE_ALL_LINUX:  yum install -y llvm libevent-devel openssl-devel &&
+          CIBW_BEFORE_ALL_LINUX:  sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo &&
+                                   sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo &&
+                                   sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && 
+                                   yum install -y llvm libevent-devel openssl-devel && 
                                    bash ci-utils/install_cuda_yum.sh 12 && 
                                    bash ci-utils/install_arrow_yum.sh &&
                                    bash ci-utils/install_prereq_linux.sh --build_arrow no &&

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -48,7 +48,10 @@ jobs:
                                    bash ci-utils/install_prereq_linux.sh --build_arrow yes &&
                                    mkdir -p /tmp/nyxus_bld &&
                                    cp -r local_install /tmp/nyxus_bld
-          CIBW_BEFORE_ALL_LINUX:  yum install -y llvm libevent-devel openssl-devel && 
+          CIBW_BEFORE_ALL_LINUX:  sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo &&
+                                   sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo &&
+                                   sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo && 
+                                   yum install -y llvm libevent-devel openssl-devel && 
                                    bash ci-utils/install_arrow_yum.sh &&
                                    bash ci-utils/install_prereq_linux.sh --build_arrow no &&
                                    mkdir -p /tmp/nyxus_bld &&


### PR DESCRIPTION
CentOS 7 EOL needs some [yum fixes](https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve).
MacOS 11 runners are also deprecated. Updating to MacOS 12