### PR TITLE
Skip tests for GPU wheels in CI

### DIFF
--- a/.github/workflows/build_cuda11_wheels.yml
+++ b/.github/workflows/build_cuda11_wheels.yml
@@ -76,7 +76,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_REQUIRES: numpy pandas pyarrow pytest bfio
           CIBW_BEFORE_TEST_WINDOWS: xcopy /E /I /y "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\bin" %SystemRoot%\System32
-          CIBW_TEST_COMMAND: pytest -vv {project}/tests/python -m "not skip_ci"
+          CIBW_TEST_COMMAND: python -m pip check
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_cuda12_wheels.yml
+++ b/.github/workflows/build_cuda12_wheels.yml
@@ -76,7 +76,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_REQUIRES: numpy pandas pyarrow pytest bfio
           CIBW_BEFORE_TEST_WINDOWS: xcopy /E /I /y "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0\bin" %SystemRoot%\System32
-          CIBW_TEST_COMMAND: pytest -vv {project}/tests/python -m "not skip_ci"
+          CIBW_TEST_COMMAND: python -m pip check
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/publish_cuda11_pypi.yml
+++ b/.github/workflows/publish_cuda11_pypi.yml
@@ -78,7 +78,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_REQUIRES: numpy pandas pyarrow pytest bfio
           CIBW_BEFORE_TEST_WINDOWS: xcopy /E /I /y "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\bin" %SystemRoot%\System32
-          CIBW_TEST_COMMAND: pytest -vv {project}/tests/python -m "not skip_ci"
+          CIBW_TEST_COMMAND: python -m pip check
 
       - name: Install Dependencies
         run: python -m pip install --upgrade twine requests

--- a/.github/workflows/publish_cuda12_pypi.yml
+++ b/.github/workflows/publish_cuda12_pypi.yml
@@ -77,7 +77,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_REQUIRES: numpy pandas pyarrow pytest bfio
           CIBW_BEFORE_TEST_WINDOWS: xcopy /E /I /y "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0\bin" %SystemRoot%\System32
-          CIBW_TEST_COMMAND: pytest -vv {project}/tests/python -m "not skip_ci"
+          CIBW_TEST_COMMAND: python -m pip check
 
       - name: Install Dependencies
         run: python -m pip install --upgrade twine requests


### PR DESCRIPTION
Since in CI, GPU tests are not being run anyways, so skipping all the GPU and CPU tests in CUDA wheels are OK. We are running all the CPU tests in non GPU wheels. 