### PR TITLE
POL5598 SLURM-friendliness for CLI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ set(SOURCE
 	src/nyx/cli_fpimage_options.cpp
 	src/nyx/cli_gabor_options.cpp
 	src/nyx/cli_glcm_options.cpp
+	src/nyx/cli_gpu_options.cpp
 	src/nyx/cli_nested_roi_options.cpp
 	src/nyx/common_stats.cpp
 	src/nyx/dirs_and_files.cpp

--- a/README.md
+++ b/README.md
@@ -358,23 +358,25 @@ Assuming you [built the Nyxus binary](#building-from-source) as outlined below, 
 --intDir | Directory of intensity image collection | path
 --outDir | Output directory | path
 --segDir | Directory of labeled image collection | path
---coarseGrayDepth | (optional) Custom number of greyscale level bins used in texture features. Default: '--coarseGrayDepth=256' | integer
---glcmAngles | (optional) Enabled direction angles of the GLCM feature. Superset of values: 0, 45, 90, and 135. Default: '--glcmAngles=0,45,90,135' | list of integer constants
---intSegMapDir | (optional) Data collection of the ad-hoc intensity-to-mask file mapping. Must be used in combination with parameter '--intSegMapFile' | path
---intSegMapFile | (optional) Name of the text file containing an ad-hoc intensity-to-mask file mapping. The files are assumed to reside in corresponding intensity and label collections. Must be used in combination with parameter '--intSegMapDir' | string
---pixelDistance | (optional) Number of pixels to treat ROIs within specified distance as neighbors. Default value: '--pixelDistance=5' | integer
---pixelsPerCentimeter | (optional) Number of pixels in centimeter used by unit length-related features. Default value: 0 | real
---ramLimit | (optional) Amount of memory not to exceed by Nyxus, in megabytes. Default value: 50\% of available memory. Example: '--ramLimit=2000' to use 2,000 megabytes | integer
---reduceThreads | (optional) Number of CPU threads used on the feature calculation step. Default: '--reduceThreads=1' | integer
---skiproi | (optional) Skip ROIs having specified labels. Example: '--skiproi=image1.tif:2,3,4;image2.tif:45,56' | string
---tempDir | (optional) Directory used by temporary out-of-RAM objects. Default value: system temporary directory | path
---hsig | (optional) Channel signature Example: "--hsig=_c" to match images whose file names have channel info starting substring '_c' like in 'p0_y1_r1_c1.ome.tiff' | string
---hpar | (optional) Channel number that should be used as a provider of parent segments. Example: '--hpar=1' | integer
---hchi | (optional) Channel number that should be used as a provider of child segments. Example: '--hchi=0' | integer
---hag | (optional) Name of a method how to aggregate features of segments recognized as children of same parent segment. Valid options are 'SUM', 'MEAN', 'MIN', 'MAX', 'WMA' (weighted mean average), and 'NONE' (no aggregation, instead, same parent child segments will be laid out horizontally) | string
---fpimgdr | (optional) Desired dynamic range of voxels of a floating point TIFF image. Example: --fpimgdr=240 makes intensities be read in range 0-240. Default value: 10e4 | unsigned integer
---fpimgmin | (optional) Minimum intensity of voxels of a floating point TIFF image. Default value: 0.0 | real
---fpimgdr | (optional) Maximum intensity of voxels of a floating point TIFF image. Default value: 1.0 | real
+--useGpu | ${\color{red}\textsf{(optional)}}$ Calculate compute-expensive features on an NVIDIA GPU device specified by parameter --gpuDeviceID. Default: '--useGpu=false'. Example: --useGpu=true | boolean
+--gpuDeviceID | ${\color{red}\textsf{(optional)}}$ ID of a GPU device to be used when '--useGpu=true'. Default: '--gpuDeviceID=0'. Example 1 (single GPU device): '--useGpu=true --gpuDeviceID=2' to strictly use device 2. Example 2 (multiple GPU devices, usually in SLURM scenarios): '--useGpu=true --gpuDeviceID=0,1,3' to use the GPU device having maximum free RAM of devices 0, 1, and 3. | integer or list of integers
+--coarseGrayDepth | ${\color{red}\textsf{(optional)}}$ Custom number of greyscale level bins used in texture features. Default: '--coarseGrayDepth=256' | integer
+--glcmAngles | ${\color{red}\textsf{(optional)}}$ Enabled direction angles of the GLCM feature. Superset of values: 0, 45, 90, and 135. Default: '--glcmAngles=0,45,90,135' | list of integers
+--intSegMapDir | ${\color{red}\textsf{(optional)}}$ Data collection of the ad-hoc intensity-to-mask file mapping. Must be used in combination with parameter '--intSegMapFile' | path
+--intSegMapFile | ${\color{red}\textsf{(optional)}}$ Name of the text file containing an ad-hoc intensity-to-mask file mapping. The files are assumed to reside in corresponding intensity and label collections. Must be used in combination with parameter '--intSegMapDir' | string
+--pixelDistance | ${\color{red}\textsf{(optional)}}$ Number of pixels to treat ROIs within specified distance as neighbors. Default value: '--pixelDistance=5' | integer
+--pixelsPerCentimeter | ${\color{red}\textsf{(optional)}}$ Number of pixels in centimeter used by unit length-related features. Default value: 0 | real
+--ramLimit | ${\color{red}\textsf{(optional)}}$ Amount of memory not to exceed by Nyxus, in megabytes. Default value: 50\% of available memory. Example: '--ramLimit=2000' to use 2,000 megabytes | integer
+--reduceThreads | ${\color{red}\textsf{(optional)}}$ Number of CPU threads used on the feature calculation step. Default: '--reduceThreads=1' | integer
+--skiproi | ${\color{red}\textsf{(optional)}}$ Skip ROIs having specified labels. Example: '--skiproi=image1.tif:2,3,4;image2.tif:45,56' | string
+--tempDir | ${\color{red}\textsf{(optional)}}$ Directory used by temporary out-of-RAM objects. Default value: system temporary directory | path
+--hsig | ${\color{red}\textsf{(optional)}}$ Channel signature Example: "--hsig=_c" to match images whose file names have channel info starting substring '_c' like in 'p0_y1_r1_c1.ome.tiff' | string
+--hpar | ${\color{red}\textsf{(optional)}}$ Channel number that should be used as a provider of parent segments. Example: '--hpar=1' | integer
+--hchi | ${\color{red}\textsf{(optional)}}$ Channel number that should be used as a provider of child segments. Example: '--hchi=0' | integer
+--hag | ${\color{red}\textsf{(optional)}}$ Name of a method how to aggregate features of segments recognized as children of same parent segment. Valid options are 'SUM', 'MEAN', 'MIN', 'MAX', 'WMA' (weighted mean average), and 'NONE' (no aggregation, instead, same parent child segments will be laid out horizontally) | string
+--fpimgdr | ${\color{red}\textsf{(optional)}}$ Desired dynamic range of voxels of a floating point TIFF image. Example: --fpimgdr=240 makes intensities be read in range 0-240. Default value: 10e4 | unsigned integer
+--fpimgmin | ${\color{red}\textsf{(optional)}}$ Minimum intensity of voxels of a floating point TIFF image. Default value: 0.0 | real
+--fpimgdr | ${\color{red}\textsf{(optional)}}$ Maximum intensity of voxels of a floating point TIFF image. Default value: 1.0 | real
 
 ---
 
@@ -595,7 +597,7 @@ These packages also have underlying dependencies and at times, these dependency 
 
 By default, Nyxus can be built with a minimal set of dependecies (Tiff support and Python interface). To build Nyxus with all the supported IO options mentioned above, pass `-DALLEXTRAS=ON` in the `cmake` command.
 
-### __GPU Support__
+### __Adding GPU Support__
 Nyxus also can be build with NVIDIA GPU support. To do so, a `CUDA` Development toolkit compatible with the host `C++` compiler need to be present in the system. For building with GPU support, pass `-DUSEGPU=ON` flag in the `cmake` command. 
 
 ### __Inside Conda__

--- a/src/nyx/cli_gpu_options.cpp
+++ b/src/nyx/cli_gpu_options.cpp
@@ -1,6 +1,7 @@
 #include "cli_gpu_options.h"
 #include "helpers/helpers.h"
 
+#ifdef USE_GPU
 namespace NyxusGpu
 {
 	bool get_best_device(
@@ -10,6 +11,7 @@ namespace NyxusGpu
 		int& best_id,
 		std::string& lastCuErmsg);
 }
+#endif
 
 bool GpuOptions::empty()
 {
@@ -44,6 +46,8 @@ int GpuOptions::get_single_device_id()
 
 bool GpuOptions::parse_input (std::string & ermsg)
 {
+#ifdef USE_GPU
+
 	auto u = Nyxus::toupper (this->raw_use_gpu);
 	if (u.length() == 0)
 	{
@@ -104,4 +108,12 @@ bool GpuOptions::parse_input (std::string & ermsg)
 	}
 
 	return true;
+
+#else
+	
+	ermsg = "To have GPU options available, use a Nyxus version with GPU support enabled";
+	set_using_gpu (false);
+	return false;
+
+#endif
 }

--- a/src/nyx/cli_gpu_options.cpp
+++ b/src/nyx/cli_gpu_options.cpp
@@ -1,0 +1,124 @@
+#include <cuda_runtime.h>
+#include "cli_gpu_options.h"
+#include "helpers/helpers.h"
+
+bool GpuOptions::empty()
+{
+	return raw_use_gpu.empty();
+}
+
+void GpuOptions::set_using_gpu(bool use)
+{
+	using_gpu_ = use;
+}
+
+bool GpuOptions::get_using_gpu()
+{
+	return using_gpu_;
+}
+
+bool GpuOptions::set_single_device_id(int id)
+{
+	if (get_using_gpu())
+	{
+		this->best_device_id_ = id;
+		return true;
+	}
+	else
+		return false;
+}
+
+int GpuOptions::get_single_device_id()
+{
+	return best_device_id_;
+}
+
+bool GpuOptions::parse_input (std::string & ermsg)
+{
+	auto u = Nyxus::toupper (this->raw_use_gpu);
+	if (u.length() == 0)
+	{
+		set_using_gpu (false);
+	}
+	else
+	{
+		auto t = Nyxus::toupper("true"),
+			f = Nyxus::toupper("false");
+		if (u != t && u != f)
+		{
+			ermsg = "valid values are " + t + " or " + f;
+			return false;
+		}
+		set_using_gpu (u == t);
+
+		// process user's GPU device choice
+		if (get_using_gpu())
+		{
+			std::vector<int> devIds;
+
+			if (! this->raw_requested_device_ids.empty())
+			{
+				// user input -> vector of IDs
+				std::vector<std::string> S;
+				Nyxus::parse_delimited_string (this->raw_requested_device_ids, ",", S);
+				// examine those IDs
+				for (const auto& s : S)
+				{
+					if (!s.empty())
+					{
+						// string -> int
+						int id;
+						if (sscanf (s.c_str(), "%d", &id) != 1 || id < 0)
+						{
+							ermsg = s + ": expecting a non-negative integer";
+							return false;
+						}
+						devIds.push_back (id);
+					}
+				}
+			}
+			else
+				devIds.push_back (0); // user did not requested a specific ID, so default it to 0
+
+			// given a set of suggested devices, choose the least memory-busy one
+			size_t max_freemem_amt = 0;
+			int best_id = -1;
+			std::string lastCuErmsg;
+			for (int k : devIds)
+			{
+				if (cudaSetDevice(k) != cudaSuccess)
+				{
+					lastCuErmsg = "invalid device ID " + std::to_string(k);
+					continue;
+				}
+
+				size_t f, t; // free and total bytes
+				auto e = cudaMemGetInfo(&f, &t);
+				if (e != cudaSuccess)
+				{
+					lastCuErmsg = "cuda error " + std::to_string(e) + " : " + cudaGetErrorString(e);
+					continue;
+				}
+
+				// this device worked
+				if (f > max_freemem_amt)
+				{
+					max_freemem_amt = f;
+					best_id = k;
+				}
+			}
+
+			// did user's dev-ID list reference at least one workable GPU device?
+			if (best_id < 0)
+			{
+				ermsg = "cannot use any of GPU devices in " + Nyxus::virguler<int> (devIds) + " due to " + lastCuErmsg;
+				return false;
+			}
+
+			// we found at least one workable
+			this->best_device_id_ = best_id;
+		}
+	}
+
+	return true;
+}

--- a/src/nyx/cli_gpu_options.h
+++ b/src/nyx/cli_gpu_options.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+class GpuOptions
+{
+public:
+	// parses "raw_use_gpu" and "raw_requested_device_ids"
+	bool parse_input (std::string & ermsg);
+
+	// true if the parameters have never been specified via "raw_*"
+	bool empty();
+
+	// accessor of the "using" status 
+	void set_using_gpu(bool use);
+	bool get_using_gpu();
+
+	// accessor of active device ID
+	bool set_single_device_id(int id);
+	int get_single_device_id();
+
+	// exposed to command line processor
+	std::string raw_use_gpu;	
+	std::string raw_requested_device_ids;
+
+private:
+	bool using_gpu_ = false;
+	int best_device_id_ = -1;
+};

--- a/src/nyx/environment.h
+++ b/src/nyx/environment.h
@@ -15,6 +15,7 @@
 
 #ifdef USE_GPU
 	#include <cuda_runtime.h>
+	#include "cli_gpu_options.h"
 #endif
 
 // Command line arguments
@@ -162,12 +163,14 @@ public:
 	void set_ibsi_compliance(bool skip);
 
 #ifdef USE_GPU
-	/// @brief Returns GPU device ID of choice
-	/// @return 0-based GPU device ID (default: 0) or -1 not to use GPU even if it is available
+	GpuOptions gpuOptions;
+	bool parse_gpu_options_raw_string (const std::string& raw_params_string, std::string& error_message);
+
+	// these are called from Python API's side
 	int get_gpu_device_choice();
-	void set_gpu_device_id(int choice);
-	void set_use_gpu(bool yes);
+	void set_gpu_device_id (int id);
 	bool using_gpu();	
+	void set_using_gpu (bool yes);
 	static std::vector<std::map<std::string, std::string>> get_gpu_properties();
 #endif
 
@@ -215,14 +218,6 @@ private:
 	bool spellcheck_raw_featurelist (const std::string & comma_separated_fnames, std::vector<std::string> & fnames);
 
 	std::string rawTempDirPath = "";
-
-#ifdef USE_GPU
-	std::string rawUseGpu = "";		// boolean
-	bool use_gpu_ = false;
-	std::string rawGpuDeviceID = "";		// integer
-	int gpu_device_id_ = -1;
-	std::vector<std::map<std::string, std::string>> gpu_props_;
-#endif
 
 	int floating_point_precision = 10;	
 

--- a/src/nyx/gpu/gpu_helpers.cu
+++ b/src/nyx/gpu/gpu_helpers.cu
@@ -3,6 +3,9 @@
 #include <cuda_runtime_api.h>
 #include <builtin_types.h>
 #include <iostream>
+#include <map>
+#include <string>
+#include <vector>
 
 namespace NyxusGpu
 {
@@ -22,6 +25,29 @@ namespace NyxusGpu
 		return true;
 	}
 
+	std::vector<std::map<std::string, std::string>> get_gpu_properties() 
+	{
+		int n_devices;
+		std::vector<std::map<std::string, std::string>> props;
 
+		cudaGetDeviceCount(&n_devices);
+
+		for (int i = 0; i < n_devices; ++i) 
+		{
+			cudaDeviceProp prop;
+			cudaGetDeviceProperties(&prop, i);
+
+			std::map<std::string, std::string> temp;
+
+			temp["Device number"] = std::to_string(i);
+			temp["Device name"] = prop.name;
+			temp["Memory"] = std::to_string(prop.totalGlobalMem / pow(2, 30)) + " GB";
+			temp["Capability"] = std::to_string(prop.major) + std::to_string(prop.minor);
+
+			props.push_back(temp);
+		}
+
+		return props;
+	}
 
 }

--- a/src/nyx/gpu/gpu_helpers.cu
+++ b/src/nyx/gpu/gpu_helpers.cu
@@ -50,4 +50,40 @@ namespace NyxusGpu
 		return props;
 	}
 
+	bool get_best_device (
+		// in
+		const std::vector<int> & devIds, 
+		// out
+		int & best_id,
+		std::string & lastCuErmsg)
+	{
+		// given a set of suggested devices, choose the least memory-busy one
+		size_t max_freemem_amt = 0;
+		for (int k : devIds)
+		{
+			if (cudaSetDevice(k) != cudaSuccess)
+			{
+				lastCuErmsg = "invalid device ID " + std::to_string(k);
+				continue;
+			}
+
+			size_t f, t; // free and total bytes
+			auto e = cudaMemGetInfo(&f, &t);
+			if (e != cudaSuccess)
+			{
+				lastCuErmsg = "cuda error " + std::to_string(e) + " : " + cudaGetErrorString(e);
+				continue;
+			}
+
+			// this device worked
+			if (f > max_freemem_amt)
+			{
+				max_freemem_amt = f;
+				best_id = k;
+			}
+		}
+
+		return best_id >= 0;
+	}
+
 }

--- a/src/nyx/helpers/helpers.h
+++ b/src/nyx/helpers/helpers.h
@@ -423,6 +423,15 @@ namespace Nyxus
 		return s2;
 	}
 
+	template <typename T>
+	inline std::string virguler (const std::vector<T> & x)
+	{
+		std::string rv;
+		for (auto i = 0; i < x.size(); i++)
+			rv += (i ? "," : "") + std::to_string(x[i]);
+		return rv;
+	}
+
 	inline std::string remove_whitespaces (const std::string & s)
 	{
 		std::string s2;

--- a/src/nyx/main_nyxus.cpp
+++ b/src/nyx/main_nyxus.cpp
@@ -46,10 +46,10 @@ int main (int argc, char** argv)
 	#ifdef USE_GPU
 	if (theEnvironment.using_gpu())
 	{
-		int gpuDevNo = theEnvironment.get_gpu_device_choice();
-		if (gpuDevNo >= 0 && NyxusGpu::gpu_initialize(gpuDevNo) == false)
+		int devid = theEnvironment.get_gpu_device_choice();
+		if (NyxusGpu::gpu_initialize(devid) == false)
 		{
-			std::cerr << "Error: cannot use GPU device ID " << gpuDevNo << ". You can disable GPU usage via command line option " << USEGPU << "=false\n";
+			std::cerr << "Error: cannot use GPU device ID " << devid << ". You can disable GPU usage via command line option " << USEGPU << "=false\n";
 			return 1;
 		}
 	}

--- a/src/nyx/python/new_bindings_py.cpp
+++ b/src/nyx/python/new_bindings_py.cpp
@@ -105,15 +105,19 @@ void initialize_environment(
     if (ram_limit_mb >= 0) theEnvironment.set_ram_limit(ram_limit_mb);
 
     #ifdef USE_GPU
-        if(using_gpu == -1) {
-            theEnvironment.set_use_gpu(false);
-        } else {
+        if(using_gpu == -1) 
+        {
+            theEnvironment.set_using_gpu(false);
+        } 
+        else 
+        {
             theEnvironment.set_gpu_device_id(using_gpu);
-            theEnvironment.set_use_gpu(true);
+            theEnvironment.set_using_gpu(true);
         }
     #else 
-        if (using_gpu != -1) {
-            std::cout << "No gpu available." << std::endl;
+        if (using_gpu != -1) 
+        {
+            throw std::runtime_error ("this Nyxus backend was built without the GPU support");
         }
     #endif
 }
@@ -644,11 +648,12 @@ py::tuple findrelations_imp(
  * 
  * @param yes True to use gpu
  */
-void use_gpu(bool yes){
+void use_gpu(bool yes)
+{
     #ifdef USE_GPU
-        theEnvironment.set_use_gpu(yes);
+        theEnvironment.set_using_gpu(yes);
     #else 
-        std::cout << "GPU is not available." << std::endl;
+        throw std::runtime_error("this Nyxus backend was built without the GPU support");
     #endif
 }
 


### PR DESCRIPTION
Nyxus CLI can now be instructed to not only use a specific GPU device (0, 1, 2, etc) but also consume a SLURM-provided list of available devices and auto-select the best single device in terms of maximum free memory.