### PR TITLE
POL5688 fixed grammar to permit layout-A's variable length nonnumeric chains

### DIFF
--- a/src/nyx/strpat.cpp
+++ b/src/nyx/strpat.cpp
@@ -223,7 +223,7 @@ bool StringPattern::tokenize (
 	std::vector<std::pair<std::string, std::string>> v
 	{
 		{ "[0-9]+" , t_NUM } ,
-		{ "[a-z]+|[A-Z]+" , t_TEXT },
+		{ "[a-z|A-Z]+" , t_TEXT },
 		{ "~|`|!|@|#|\\$|%|\\^|&|\\(|\\)|_|-|\\+|=|\\{|\\}|\\[|]|'|;|,|\\.", t_SEP },
 		{ "\\*", t_STAR }
 	};


### PR DESCRIPTION
This PR extends the 3D-slice file pattern functionality to permit not only fixed-length numeric sequences (e.g. BRATS_012_z005_t76.ome.tif) but also variable-length ones (e.g. BRATS_012_z005_t76456.ome.tif, e.g. BRATS_012_z005_t7662456789.ome.tif). The thing that was needed for one of our users