### PR TITLE
chore: migrate to macos 14 and add python 3.13 build wheel

### DIFF
--- a/.github/workflows/build_and_test_mac.yml
+++ b/.github/workflows/build_and_test_mac.yml
@@ -3,8 +3,11 @@ name: Build And Run Test on Mac
 on:
   push:
     branches: [ main ]
-  pull_request: 
+  pull_request:
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 env:
   BUILD_TYPE: Release
@@ -12,71 +15,97 @@ env:
 jobs:
   Build_and_Run_GTest:
     name: Build and Run GoogleTest
-    runs-on: macos-13
+    runs-on: macos-14-large
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el {0}
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-        
-    - uses: conda-incubator/setup-miniconda@v3
-      with:
-        activate-environment: anaconda-client-env
-        miniconda-version: "latest"
-        python-version: "3.10"
-        channels: conda-forge
-        auto-activate-base: false
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: anaconda-client-env
+          miniconda-version: "latest"
+          python-version: "3.10"
+          channels: conda-forge
+          auto-activate-base: false
 
-    - name: Install Conda Dependencies
-      run: |
-        conda install mamba
-        mamba install compilers --file ${{github.workspace}}/ci-utils/envs/conda_cpp.txt
+      # - name: Ensure Rosetta 2 (mac)
+      #   if: runner.os == 'macOS'
+      #   run: |
+      #       sudo softwareupdate --install-rosetta --agree-to-license || true
 
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_CLI=ON -DRUN_GTEST=ON -DALLEXTRAS=ON -DCMAKE_PREFIX_PATH=$CONDA_PREFIX -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
+      # # Recreate the env as x86_64 so dcmtk/fmjpeg2koj resolve from conda-forge
+      # - name: Recreate Conda env as osx-64 (Rosetta)
+      #   if: runner.os == 'macOS'
+      #   shell: bash -el {0}
+      #   run: |
+      #     conda deactivate || true
+      #     conda env remove -n anaconda-client-env || true
+      #     CONDA_SUBDIR=osx-64 conda create -y -n anaconda-client-env python=3.10 -c conda-forge
+      #     conda activate anaconda-client-env
+      #     conda config --env --set subdir osx-64
 
-    - name: Build
-      run: cmake --build ${{github.workspace}} --config ${{env.BUILD_TYPE}} --parallel 2
+      - name: Install Conda Dependencies
+        run: |
+          conda install -y mamba
+          mamba install -y compilers --file "${{ github.workspace }}/ci-utils/envs/conda_cpp.txt"
 
-    - name: Run GTest Suite
-      working-directory: ${{github.workspace}}
-      # Execute tests.  
-      run: ./tests/runAllTests  -C ${{env.BUILD_TYPE}}
-      
+      - name: Configure CMake
+        run: >
+          cmake -B "${{ github.workspace }}"
+          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+          -DBUILD_CLI=ON
+          -DRUN_GTEST=ON
+          -DALLEXTRAS=ON
+          -DCMAKE_PREFIX_PATH="$CONDA_PREFIX"
+          -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX"
+
+      - name: Build
+        run: cmake --build "${{ github.workspace }}" --config "${{ env.BUILD_TYPE }}" --parallel 2
+
+      - name: Run GTest Suite
+        working-directory: ${{ github.workspace }}
+        run: ./tests/runAllTests -C "${{ env.BUILD_TYPE }}"
 
   Build_and_Run_PyTest:
     name: Build and Run PyTest
-    runs-on: macos-13
+    runs-on: macos-14-large
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el {0}
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-        
-    - uses: conda-incubator/setup-miniconda@v3
-      with:
-        activate-environment: anaconda-client-env
-        miniconda-version: "latest"
-        python-version: "3.10"
-        channels: conda-forge
-        auto-activate-base: false
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-    - name: Install Conda Dependencies
-      run: |
-        conda install mamba
-        mamba install compilers pytest bfio --file ${{github.workspace}}/ci-utils/envs/conda_cpp.txt --file ${{github.workspace}}/ci-utils/envs/conda_py.txt
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: anaconda-client-env
+          miniconda-version: "latest"
+          python-version: "3.10"
+          channels: conda-forge
+          auto-activate-base: false
 
-    - name: Install Nyxus
-      working-directory: ${{github.workspace}}
-      run: CMAKE_ARGS="-DCMAKE_PREFIX_PATH=$CONDA_PREFIX -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DALLEXTRAS=ON" python -m pip install . -vv
+      - name: Install Conda Dependencies
+        run: |
+          conda install -y mamba
+          mamba install -y compilers pytest bfio \
+            --file "${{ github.workspace }}/ci-utils/envs/conda_cpp.txt" \
+            --file "${{ github.workspace }}/ci-utils/envs/conda_py.txt"
 
-    - name: Run PyTest
-      working-directory: ${{github.workspace}}
-      run: python -m pytest tests/python/ -vv
+      - name: Install Nyxus
+        working-directory: ${{ github.workspace }}
+        run: >
+          CMAKE_ARGS="-DCMAKE_PREFIX_PATH=$CONDA_PREFIX
+          -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
+          -DALLEXTRAS=ON"
+          python -m pip install . -vv
+
+      - name: Run PyTest
+        working-directory: ${{ github.workspace }}
+        run: python -m pytest tests/python/ -vv

--- a/.github/workflows/build_and_test_mac.yml
+++ b/.github/workflows/build_and_test_mac.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 env:
   BUILD_TYPE: Release
 
@@ -32,22 +29,6 @@ jobs:
           python-version: "3.10"
           channels: conda-forge
           auto-activate-base: false
-
-      # - name: Ensure Rosetta 2 (mac)
-      #   if: runner.os == 'macOS'
-      #   run: |
-      #       sudo softwareupdate --install-rosetta --agree-to-license || true
-
-      # # Recreate the env as x86_64 so dcmtk/fmjpeg2koj resolve from conda-forge
-      # - name: Recreate Conda env as osx-64 (Rosetta)
-      #   if: runner.os == 'macOS'
-      #   shell: bash -el {0}
-      #   run: |
-      #     conda deactivate || true
-      #     conda env remove -n anaconda-client-env || true
-      #     CONDA_SUBDIR=osx-64 conda create -y -n anaconda-client-env python=3.10 -c conda-forge
-      #     conda activate anaconda-client-env
-      #     conda config --env --set subdir osx-64
 
       - name: Install Conda Dependencies
         run: |

--- a/.github/workflows/build_cuda11_wheels.yml
+++ b/.github/workflows/build_cuda11_wheels.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         cibw_archs: ["auto64"]
-        cibw_build: ["cp39", "cp310", "cp311", "cp312"]
+        cibw_build: ["cp310", "cp311", "cp312", "cp313"]
 
     steps:
       - uses: actions/checkout@v4
@@ -22,7 +22,7 @@ jobs:
         with:
           submodules: recursive
 
-      # ---------- Linux-only: reclaim space on the host BEFORE Docker pulls ----------
+
       - name: Free disk space on Linux host
         uses: jlumbroso/free-disk-space@main
         with:
@@ -43,7 +43,8 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.16.2 delvewheel wheel
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel==3.0.0 delvewheel wheel
 
 
       - name: Building wheels on Linux

--- a/.github/workflows/build_cuda11_wheels.yml
+++ b/.github/workflows/build_cuda11_wheels.yml
@@ -27,7 +27,7 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           large-packages: true
-          docker-images: true
+          docker-images: false
           swap-storage: true
           tool-cache: false
 

--- a/.github/workflows/build_cuda12_wheels.yml
+++ b/.github/workflows/build_cuda12_wheels.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [windows-2022, ubuntu-22.04]
         cibw_archs: ["auto64"]
-        cibw_build: ["cp39", "cp310", "cp311", "cp312"]
+        cibw_build: ["cp310", "cp311", "cp312", "cp313"]
 
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
           ls $env:CUDA_PATH\bin
           ls $env:CUDA_PATH\include
 
-      # ---------- Linux-only: reclaim space on the host BEFORE Docker pulls ----------
+
       - name: Free disk space on Linux host
         if: runner.os == 'Linux'
         uses: jlumbroso/free-disk-space@main
@@ -65,9 +65,10 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.16.2 delvewheel wheel
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel==3.0.0 delvewheel wheel
 
-      - name: Building wheels 
+      - name: Building wheels
         run: |
           python -m cibuildwheel --output-dir dist
         env:
@@ -75,18 +76,33 @@ jobs:
           CIBW_SKIP: "*musllinux*"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64:latest
-          CIBW_BEFORE_ALL_LINUX: dnf -y install llvm libevent-devel openssl-devel && 
-                                   bash ci-utils/install_cuda_yum.sh 12 && 
-                                   bash ci-utils/install_prereq_linux.sh --build_arrow yes &&
-                                   mkdir -p /tmp/nyxus_bld &&
-                                   cp -r local_install /tmp/nyxus_bld
-          CIBW_BEFORE_ALL_WINDOWS: nvcc -V &&
-                                   ci-utils\install_prereq_win.bat &&
-                                   xcopy /E /I /y local_install C:\TEMP\nyxus_bld\local_install
-          CIBW_ENVIRONMENT_LINUX: LD_LIBRARY_PATH="/tmp/nyxus_bld/local_install/lib:/tmp/nyxus_bld/local_install/lib64:/usr/local/cuda/targets/x86_64-linux/lib:$LD_LIBRARY_PATH" CPATH="/usr/local/cuda/targets/x86_64-linux/include:$CPATH" PATH="/usr/local/cuda/bin:$PATH" NYXUS_DEP_DIR="/tmp/nyxus_bld/local_install" CXXFLAGS="-I /usr/local/cuda/include" CMAKE_ARGS="-DUSEGPU=ON -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DCMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES=/usr/local/cuda/include" NYXUS_GPU_WHEEL="ON" 
-          CIBW_ENVIRONMENT_WINDOWS: PATH="C:\\TEMP\\nyxus_bld\\local_install\\bin;$PATH" NYXUS_DEP_DIR="C:\\TEMP\\nyxus_bld\\local_install" CMAKE_ARGS="-DUSEGPU=ON" NYXUS_GPU_WHEEL="ON" 
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel} --no-dll cufft64_11.dll;cufftw64_11.dll;cudart32_120.dll;cudart64_120.dll"
-          CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel repair --exclude=libcufft.so --exclude=libcufft.so.11 --exclude=libcufft.so.11.0.12.1  --exclude=libcudart.so --exclude=libcudart.so.12 --exclude=libcudart.so.12.3.101  -w {dest_dir} {wheel}
+          CIBW_BEFORE_ALL_LINUX: >
+            dnf -y install llvm libevent-devel openssl-devel &&
+            bash ci-utils/install_cuda_yum.sh 12 &&
+            bash ci-utils/install_prereq_linux.sh --build_arrow yes &&
+            mkdir -p /tmp/nyxus_bld &&
+            cp -r local_install /tmp/nyxus_bld
+          CIBW_BEFORE_ALL_WINDOWS: >
+            nvcc -V &&
+            ci-utils\install_prereq_win.bat &&
+            xcopy /E /I /y local_install C:\TEMP\nyxus_bld\local_install
+          CIBW_ENVIRONMENT_LINUX: >
+            LD_LIBRARY_PATH="/tmp/nyxus_bld/local_install/lib:/tmp/nyxus_bld/local_install/lib64:/usr/local/cuda/targets/x86_64-linux/lib:$LD_LIBRARY_PATH"
+            CPATH="/usr/local/cuda/targets/x86_64-linux/include:$CPATH"
+            PATH="/usr/local/cuda/bin:$PATH"
+            NYXUS_DEP_DIR="/tmp/nyxus_bld/local_install"
+            CXXFLAGS="-I /usr/local/cuda/include"
+            CMAKE_ARGS="-DUSEGPU=ON -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DCMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES=/usr/local/cuda/include"
+            NYXUS_GPU_WHEEL="ON"
+          CIBW_ENVIRONMENT_WINDOWS: >
+            PATH="C:\\TEMP\\nyxus_bld\\local_install\\bin;$PATH"
+            NYXUS_DEP_DIR="C:\\TEMP\\nyxus_bld\\local_install"
+            CMAKE_ARGS="-DUSEGPU=ON"
+            NYXUS_GPU_WHEEL="ON"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
+            delvewheel repair -w {dest_dir} {wheel} --no-dll cufft64_11.dll;cufftw64_11.dll;cudart32_120.dll;cudart64_120.dll
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
+            auditwheel repair --exclude=libcufft.so --exclude=libcufft.so.11 --exclude=libcufft.so.11.0.12.1 --exclude=libcudart.so --exclude=libcudart.so.12 --exclude=libcudart.so.12.3.101 -w {dest_dir} {wheel}
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_REQUIRES: numpy pandas pyarrow pytest bfio
           CIBW_BEFORE_TEST_WINDOWS: xcopy /E /I /y "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\bin" %SystemRoot%\System32

--- a/.github/workflows/build_cuda12_wheels.yml
+++ b/.github/workflows/build_cuda12_wheels.yml
@@ -48,7 +48,7 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           large-packages: true
-          docker-images: true
+          docker-images: false
           swap-storage: true
           tool-cache: false
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -13,9 +13,9 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: "10.15"
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-latest, ubuntu-22.04-arm]
+        os: [ubuntu-22.04, windows-latest, macos-14-large, ubuntu-22.04-arm]
         cibw_archs: ["auto64"]
-        cibw_build: ["cp39", "cp310", "cp311", "cp312"]
+        cibw_build: ["cp310", "cp311", "cp312", "cp313"]
 
     steps:
       - uses: actions/checkout@v3
@@ -33,7 +33,8 @@ jobs:
  
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.16.2 delvewheel wheel
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel==3.0.0 delvewheel wheel
 
       - name: Building wheels 
         run: |
@@ -44,7 +45,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 3
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64:latest
           CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64:latest
-          CIBW_BEFORE_ALL_MACOS:  brew install llvm@16 && 
+          CIBW_BEFORE_ALL_MACOS: |
                                    bash ci-utils/install_prereq_linux.sh --build_arrow yes &&
                                    mkdir -p /tmp/nyxus_bld &&
                                    cp -r local_install /tmp/nyxus_bld 
@@ -55,21 +56,27 @@ jobs:
           CIBW_BEFORE_ALL_WINDOWS: ci-utils\install_prereq_win.bat &&
                                    xcopy /E /I /y local_install C:\TEMP\nyxus_bld\local_install                     
           CIBW_ENVIRONMENT_MACOS: >
+            MACOSX_DEPLOYMENT_TARGET=10.15
             SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
             CMAKE_OSX_SYSROOT="$SDKROOT"
-            LLVM_PREFIX="/usr/local/opt/llvm@16"
-            PATH="$LLVM_PREFIX/bin:$PATH"
-            CC="$LLVM_PREFIX/bin/clang"
-            CXX="$LLVM_PREFIX/bin/clang++"
-            COMPILER="$LLVM_PREFIX/bin/clang++"
-            CXXFLAGS="-isysroot $SDKROOT -stdlib=libc++"
-            LDFLAGS="-isysroot $SDKROOT -lc++ -lc++abi"
+            CC="$(xcrun -f clang)"
+            CXX="$(xcrun -f clang++)"
+            CMAKE_C_COMPILER="$CC"
+            CMAKE_CXX_COMPILER="$CXX"
+            CXXFLAGS="-isysroot $SDKROOT -stdlib=libc++ -mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET"
+            LDFLAGS="-isysroot $SDKROOT -lc++ -lc++abi -mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET"
             ARROW_HAVE_LIBATOMIC=OFF
             REPAIR_LIBRARY_PATH="/tmp/nyxus_bld/local_install/lib:/tmp/nyxus_bld/local_install/lib64"
             NYXUS_DEP_DIR="/tmp/nyxus_bld/local_install"
           CIBW_ENVIRONMENT_LINUX: LD_LIBRARY_PATH="/tmp/nyxus_bld/local_install/lib:/tmp/nyxus_bld/local_install/lib64:$LD_LIBRARY_PATH" NYXUS_DEP_DIR="/tmp/nyxus_bld/local_install" 
           CIBW_ENVIRONMENT_WINDOWS: PATH="C:\\TEMP\\nyxus_bld\\local_install\\bin;$PATH" NYXUS_DEP_DIR="C:\\TEMP\\nyxus_bld\\local_install"
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel} && DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
+            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel} &&
+            MACOSX_DEPLOYMENT_TARGET=10.15 DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel \
+            --require-archs {delocate_archs} \
+            --require-target-macos-version $MACOSX_DEPLOYMENT_TARGET \
+            -w {dest_dir} {wheel} \
+            -e libssl -e libzstd -e libcrypto -e libwebp -e libsharpyuv
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_REQUIRES: numpy pandas pyarrow pytest bfio
@@ -91,9 +98,9 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: "11.0"
     strategy:
       matrix:
-        os: [macos-13-xlarge]
+        os: [macos-14-xlarge]
         cibw_archs: ["arm64"]
-        cibw_build: ["cp39", "cp310", "cp311",  "cp312"]
+        cibw_build: ["cp310", "cp311",  "cp312", "cp313"]
 
     steps:
       - uses: actions/checkout@v3
@@ -106,7 +113,8 @@ jobs:
   
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.16.2 delocate wheel
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel==3.0.0 delvewheel wheel
 
       - name: Building wheels 
         run: |
@@ -115,25 +123,26 @@ jobs:
           CIBW_BUILD: ${{ matrix.cibw_build }}-*
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_MACOS: arm64
-          CIBW_BEFORE_ALL_MACOS:  brew install llvm@16 && 
-                                    sudo xcode-select -s /Applications/Xcode_14.2.app &&
-                                    bash ci-utils/install_prereq_linux.sh --build_arrow yes &&
-                                    mkdir -p /tmp/nyxus_bld &&
-                                    cp -r local_install /tmp/nyxus_bld                    
+          CIBW_BEFORE_ALL_MACOS: |
+            bash ci-utils/install_prereq_linux.sh --build_arrow yes || true
+            mkdir -p /tmp/nyxus_bld && cp -r local_install /tmp/nyxus_bld || true
           CIBW_ENVIRONMENT_MACOS: >
+            MACOSX_DEPLOYMENT_TARGET=11.0
             SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
             CMAKE_OSX_SYSROOT="$SDKROOT"
-            LLVM_PREFIX="/opt/homebrew/opt/llvm@16"
-            PATH="$LLVM_PREFIX/bin:$PATH"
-            CC="$LLVM_PREFIX/bin/clang"
-            CXX="$LLVM_PREFIX/bin/clang++"
-            COMPILER="$LLVM_PREFIX/bin/clang++"
+            CC="clang" CXX="clang++"
+            CMAKE_C_COMPILER="$CC" CMAKE_CXX_COMPILER="$CXX"
             CXXFLAGS="-isysroot $SDKROOT -stdlib=libc++"
             LDFLAGS="-isysroot $SDKROOT -lc++ -lc++abi"
-            ARROW_HAVE_LIBATOMIC=OFF
             REPAIR_LIBRARY_PATH="/tmp/nyxus_bld/local_install/lib:/tmp/nyxus_bld/local_install/lib64"
             NYXUS_DEP_DIR="/tmp/nyxus_bld/local_install"
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel} && DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
+            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel} &&
+            MACOSX_DEPLOYMENT_TARGET=11.0 DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel \
+            --require-archs {delocate_archs} \
+            --require-target-macos-version $MACOSX_DEPLOYMENT_TARGET \
+            -w {dest_dir} {wheel} \
+            -e libssl -e libzstd -e libcrypto
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_REQUIRES: numpy pandas pyarrow pytest bfio
           CIBW_TEST_COMMAND: pytest -vv {project}/tests/python

--- a/.github/workflows/publish_cuda11_pypi.yml
+++ b/.github/workflows/publish_cuda11_pypi.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         cibw_archs: ["auto64"]
-        cibw_build: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+        cibw_build: ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
 
     steps:
       - uses: actions/checkout@v4
@@ -22,7 +22,7 @@ jobs:
         with:
           submodules: recursive
 
-      # ---------- Linux-only: reclaim space on the host BEFORE Docker pulls ----------
+
       - name: Free disk space on Linux host
         uses: jlumbroso/free-disk-space@main
         with:
@@ -43,7 +43,8 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.16.2 delvewheel wheel
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel==3.0.0 delvewheel wheel
 
       - name: Building wheels on Linux
         run: |

--- a/.github/workflows/publish_cuda11_pypi.yml
+++ b/.github/workflows/publish_cuda11_pypi.yml
@@ -27,7 +27,7 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           large-packages: true
-          docker-images: true
+          docker-images: false
           swap-storage: true
           tool-cache: false
 

--- a/.github/workflows/publish_cuda12_pypi.yml
+++ b/.github/workflows/publish_cuda12_pypi.yml
@@ -47,7 +47,7 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           large-packages: true
-          docker-images: true
+          docker-images: false
           swap-storage: true
           tool-cache: false
 

--- a/.github/workflows/publish_cuda12_pypi.yml
+++ b/.github/workflows/publish_cuda12_pypi.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [windows-2022, ubuntu-22.04]
         cibw_archs: ["auto64"]
-        cibw_build: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+        cibw_build: ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
 
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
           ls $env:CUDA_PATH\bin
           ls $env:CUDA_PATH\include
 
-      # ---------- Linux-only: reclaim space on the host BEFORE Docker pulls ----------
+
       - name: Free disk space on Linux host
         uses: jlumbroso/free-disk-space@main
         with:
@@ -64,7 +64,8 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.16.2 delvewheel wheel
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel==3.0.0 delvewheel wheel
 
       - name: Building wheels 
         run: |

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, macos-13, windows-latest, ubuntu-22.04-arm]
         cibw_archs: ["auto64"]
-        cibw_build: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+        cibw_build: ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
 
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +34,8 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.16.2 delvewheel wheel
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel==3.0.0 delvewheel wheel
 
       - name: Building wheels 
         run: |
@@ -45,7 +46,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 3
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64:latest
           CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64:latest
-          CIBW_BEFORE_ALL_MACOS: brew install llvm@16 &&
+          CIBW_BEFORE_ALL_MACOS: |
                                    bash ci-utils/install_prereq_linux.sh --build_arrow yes &&
                                    mkdir -p /tmp/nyxus_bld &&
                                    cp -r local_install /tmp/nyxus_bld
@@ -56,21 +57,27 @@ jobs:
           CIBW_BEFORE_ALL_WINDOWS: ci-utils\install_prereq_win.bat &&
                                    xcopy /E /I /y local_install C:\TEMP\nyxus_bld\local_install 
           CIBW_ENVIRONMENT_MACOS: >
+            MACOSX_DEPLOYMENT_TARGET=10.15
             SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
             CMAKE_OSX_SYSROOT="$SDKROOT"
-            LLVM_PREFIX="/usr/local/opt/llvm@16"
-            PATH="$LLVM_PREFIX/bin:$PATH"
-            CC="$LLVM_PREFIX/bin/clang"
-            CXX="$LLVM_PREFIX/bin/clang++"
-            COMPILER="$LLVM_PREFIX/bin/clang++"
-            CXXFLAGS="-isysroot $SDKROOT -stdlib=libc++"
-            LDFLAGS="-isysroot $SDKROOT -lc++ -lc++abi"
+            CC="$(xcrun -f clang)"
+            CXX="$(xcrun -f clang++)"
+            CMAKE_C_COMPILER="$CC"
+            CMAKE_CXX_COMPILER="$CXX"
+            CXXFLAGS="-isysroot $SDKROOT -stdlib=libc++ -mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET"
+            LDFLAGS="-isysroot $SDKROOT -lc++ -lc++abi -mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET"
             ARROW_HAVE_LIBATOMIC=OFF
             REPAIR_LIBRARY_PATH="/tmp/nyxus_bld/local_install/lib:/tmp/nyxus_bld/local_install/lib64"
             NYXUS_DEP_DIR="/tmp/nyxus_bld/local_install"
           CIBW_ENVIRONMENT_LINUX: LD_LIBRARY_PATH="/tmp/nyxus_bld/local_install/lib:/tmp/nyxus_bld/local_install/lib64:$LD_LIBRARY_PATH" NYXUS_DEP_DIR="/tmp/nyxus_bld/local_install" 
           CIBW_ENVIRONMENT_WINDOWS: PATH="C:\\TEMP\\nyxus_bld\\local_install\\bin;$PATH" NYXUS_DEP_DIR="C:\\TEMP\\nyxus_bld\\local_install"
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel} && DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
+            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel} &&
+            MACOSX_DEPLOYMENT_TARGET=10.15 DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel \
+            --require-archs {delocate_archs} \
+            --require-target-macos-version $MACOSX_DEPLOYMENT_TARGET \
+            -w {dest_dir} {wheel} \
+            -e libssl -e libzstd -e libcrypto -e libwebp -e libsharpyuv
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_REQUIRES: numpy pandas pyarrow pytest bfio
@@ -93,9 +100,9 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: "11.0"
     strategy:
       matrix:
-        os: [macos-13-xlarge]
+        os: [macos-14-xlarge]
         cibw_archs: ["arm64"]
-        cibw_build: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
+        cibw_build: ["cp310-*", "cp311-*", "cp312-*", "cp313-*"]
 
     steps:
       - uses: actions/checkout@v3
@@ -108,8 +115,9 @@ jobs:
   
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.16.2 delocate wheel
-
+          python -m pip install --upgrade pip
+          python -m pip install cibuildwheel==3.0.0 delvewheel wheel
+      
       - name: Building wheels 
         run: |
           python -m cibuildwheel --output-dir dist
@@ -117,25 +125,30 @@ jobs:
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_MACOS: arm64
-          CIBW_BEFORE_ALL_MACOS:  brew install llvm@16 && 
-                                    sudo xcode-select -s /Applications/Xcode_14.2.app &&
-                                    bash ci-utils/install_prereq_linux.sh --build_arrow yes &&
-                                    mkdir -p /tmp/nyxus_bld &&
-                                    cp -r local_install /tmp/nyxus_bld                         
+          CIBW_BEFORE_ALL_MACOS: |
+                                   bash ci-utils/install_prereq_linux.sh --build_arrow yes &&
+                                   mkdir -p /tmp/nyxus_bld &&
+                                   cp -r local_install /tmp/nyxus_bld 
           CIBW_ENVIRONMENT_MACOS: >
+            MACOSX_DEPLOYMENT_TARGET=11.0
             SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
             CMAKE_OSX_SYSROOT="$SDKROOT"
-            LLVM_PREFIX="/opt/homebrew/opt/llvm@16"
-            PATH="$LLVM_PREFIX/bin:$PATH"
-            CC="$LLVM_PREFIX/bin/clang"
-            CXX="$LLVM_PREFIX/bin/clang++"
-            COMPILER="$LLVM_PREFIX/bin/clang++"
-            CXXFLAGS="-isysroot $SDKROOT -stdlib=libc++"
-            LDFLAGS="-isysroot $SDKROOT -lc++ -lc++abi"
+            CC="$(xcrun -f clang)"
+            CXX="$(xcrun -f clang++)"
+            CMAKE_C_COMPILER="$CC"
+            CMAKE_CXX_COMPILER="$CXX"
+            CXXFLAGS="-isysroot $SDKROOT -stdlib=libc++ -mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET"
+            LDFLAGS="-isysroot $SDKROOT -lc++ -lc++abi -mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET"
             ARROW_HAVE_LIBATOMIC=OFF
             REPAIR_LIBRARY_PATH="/tmp/nyxus_bld/local_install/lib:/tmp/nyxus_bld/local_install/lib64"
             NYXUS_DEP_DIR="/tmp/nyxus_bld/local_install"
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel} && DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: |
+            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel} &&
+            MACOSX_DEPLOYMENT_TARGET=11.0 DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel \
+            --require-archs {delocate_archs} \
+            --require-target-macos-version $MACOSX_DEPLOYMENT_TARGET \
+            -w {dest_dir} {wheel} \
+            -e libssl -e libzstd -e libcrypto
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_TEST_REQUIRES: numpy pandas pyarrow pytest bfio
           CIBW_TEST_COMMAND: pytest -vv {project}/tests/python


### PR DESCRIPTION
+ macos 13 is EOL. So migrating to macos 14.
+ Added support for cp313
+ drop support for cp39