### PR TITLE
Fix thread-safety bugs: missing future sync, static init races

### DIFF
--- a/src/nyx/features/neighbors.cpp
+++ b/src/nyx/features/neighbors.cpp
@@ -290,6 +290,9 @@ void NeighborsFeature::manual_reduce (
 				idxE = jobSize; // include the tail
 			T.push_back (std::async(std::launch::async, parallel_process_1_batch_of_collision_pairs, std::ref(roiData), idxS, idxE, &CM2, radius));
 		}
+
+		for (auto& f : T)
+			f.get();
 	}
 
 // Collision detection method #1 (kept for the record)

--- a/src/nyx/parallel.h
+++ b/src/nyx/parallel.h
@@ -39,6 +39,9 @@ namespace Nyxus
 				idxE = datasetSize; // include the tail
 			T.push_back(std::async(std::launch::async, f, idxS, idxE, ptrLabels, ptrLabelData, std::cref(f_settings), std::cref(dataset)));
 		}
+
+		for (auto& f : T)
+			f.get();
 	}
 
 	void parallelReduceConvHull (size_t start, size_t end, std::vector<int>* ptrLabels, std::unordered_map <int, LR>* ptrLabelData, const Fsettings & fst, const Dataset & ds);

--- a/src/nyx/phase2_25d.cpp
+++ b/src/nyx/phase2_25d.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <fstream>
 #include <string>
 #include <sstream>
@@ -108,7 +109,7 @@ namespace Nyxus
 						// Show stayalive progress info
 						if (cnt++ % 4 == 0)
 						{
-							static int prevIntPc = 0;
+							static std::atomic<int> prevIntPc{0};
 							float pc = int((row * nth + col) * 100 / float(nth * ntv) * 100) / 100.;
 							if (int(pc) != prevIntPc)
 							{

--- a/src/nyx/phase2_2d.cpp
+++ b/src/nyx/phase2_2d.cpp
@@ -1,3 +1,4 @@
+#include <atomic>
 #include <fstream>
 #include <string>
 #include <sstream>
@@ -161,7 +162,7 @@ namespace Nyxus
 					// Show stayalive progress info
 					if (cnt++ % 4 == 0)
 					{
-						static int prevIntPc = 0;
+						static std::atomic<int> prevIntPc{0};
 						float pc = int((row * nth + col) * 100 / float(nth * ntv) * 100) / 100.;
 						if (int(pc) != prevIntPc)
 						{


### PR DESCRIPTION
- parallel.h: Add explicit future.get() synchronization in runParallel() (affects 24+ call sites in reduce_trivial_rois.cpp)
- neighbors.cpp: Add future.get() sync in manual_reduce() multi-threading
- zernike.cpp: Replace non-atomic init flag with std::call_once for LUT
- zernike_nontriv.cpp: Replace non-atomic init flag with std::call_once
- phase2_2d.cpp, phase2_25d.cpp: Use std::atomic for progress counter