### PR TITLE
Add cross-run caching for prereq builds

### DIFF
--- a/.github/workflows/build_cuda11_wheels.yml
+++ b/.github/workflows/build_cuda11_wheels.yml
@@ -2,11 +2,20 @@ name: Build CUDA 11 Wheels
 
 on:
   workflow_dispatch:
+    inputs:
+      force_prereqs:
+        description: 'Force rebuild prereqs (ignore cache)'
+        type: boolean
+        default: false
   pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
+
+permissions:
+  actions: write
+  contents: read
 
 jobs:
 
@@ -19,7 +28,28 @@ jobs:
       - uses: actions/checkout@v4
         name: Check out
 
+      - name: Compute cache key
+        id: cache-key
+        run: echo "key=prereqs-cuda11-ubuntu-22.04-${{ hashFiles('ci-utils/install_prereq_linux.sh', 'ci-utils/install_prereq_win.bat', 'ci-utils/validate_prereqs.sh') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete prereq cache (force rebuild)
+        if: inputs.force_prereqs == true
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh actions-cache delete "${{ steps.cache-key.outputs.key }}" \
+            -R ${{ github.repository }} --confirm || true
+
+      - name: Restore cached prereqs
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
+
       - name: Build prereqs (Linux)
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/work" \
@@ -34,11 +64,20 @@ jobs:
             "
 
       - name: Validate prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         shell: bash
         run: bash ci-utils/validate_prereqs.sh
 
       - name: Compress prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         run: tar -czf prereqs.tar.gz local_install
+
+      - name: Save prereqs cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
 
       - name: Upload prereqs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_cuda12_wheels.yml
+++ b/.github/workflows/build_cuda12_wheels.yml
@@ -2,11 +2,20 @@ name: Build CUDA 12 Wheels
 
 on:
   workflow_dispatch:
+    inputs:
+      force_prereqs:
+        description: 'Force rebuild prereqs (ignore cache)'
+        type: boolean
+        default: false
   pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
+
+permissions:
+  actions: write
+  contents: read
 
 jobs:
 
@@ -19,7 +28,28 @@ jobs:
       - uses: actions/checkout@v4
         name: Check out
 
+      - name: Compute cache key
+        id: cache-key
+        run: echo "key=prereqs-cuda12-ubuntu-22.04-${{ hashFiles('ci-utils/install_prereq_linux.sh', 'ci-utils/install_prereq_win.bat', 'ci-utils/validate_prereqs.sh') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete prereq cache (force rebuild)
+        if: inputs.force_prereqs == true
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh actions-cache delete "${{ steps.cache-key.outputs.key }}" \
+            -R ${{ github.repository }} --confirm || true
+
+      - name: Restore cached prereqs
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
+
       - name: Build prereqs (Linux)
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/work" \
@@ -31,11 +61,20 @@ jobs:
             "
 
       - name: Validate prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         shell: bash
         run: bash ci-utils/validate_prereqs.sh
 
       - name: Compress prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         run: tar -czf prereqs.tar.gz local_install
+
+      - name: Save prereqs cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
 
       - name: Upload prereqs
         uses: actions/upload-artifact@v4
@@ -54,18 +93,51 @@ jobs:
       - uses: actions/checkout@v4
         name: Check out
 
+      - name: Compute cache key
+        id: cache-key
+        shell: bash
+        run: echo "key=prereqs-cuda12-windows-2022-${{ hashFiles('ci-utils/install_prereq_linux.sh', 'ci-utils/install_prereq_win.bat', 'ci-utils/validate_prereqs.sh') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete prereq cache (force rebuild)
+        if: inputs.force_prereqs == true
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh actions-cache delete "${{ steps.cache-key.outputs.key }}" \
+            -R ${{ github.repository }} --confirm || true
+
+      - name: Restore cached prereqs
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
+
       - uses: ilammy/msvc-dev-cmd@v1
+        if: steps.cache.outputs.cache-hit != 'true'
         name: Add MSVS Path
 
       - name: Build prereqs (Windows)
+        if: steps.cache.outputs.cache-hit != 'true'
         run: ci-utils\install_prereq_win.bat
 
       - name: Validate prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         shell: bash
         run: bash ci-utils/validate_prereqs.sh
 
       - name: Compress prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         run: tar -czf prereqs.tar.gz local_install
+
+      - name: Save prereqs cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
 
       - name: Upload prereqs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -2,11 +2,20 @@ name: Build Wheels
 
 on:
   workflow_dispatch:
+    inputs:
+      force_prereqs:
+        description: 'Force rebuild prereqs (ignore cache)'
+        type: boolean
+        default: false
   pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
+
+permissions:
+  actions: write
+  contents: read
 
 jobs:
 
@@ -21,7 +30,29 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out
+
+      - name: Compute cache key
+        id: cache-key
+        run: echo "key=prereqs-ubuntu-22.04-${{ hashFiles('ci-utils/install_prereq_linux.sh', 'ci-utils/install_prereq_win.bat', 'ci-utils/validate_prereqs.sh') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete prereq cache (force rebuild)
+        if: inputs.force_prereqs == true
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh actions-cache delete "${{ steps.cache-key.outputs.key }}" \
+            -R ${{ github.repository }} --confirm || true
+
+      - name: Restore cached prereqs
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
+
       - name: Build prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/work" \
@@ -31,11 +62,23 @@ jobs:
               dnf -y install llvm libevent-devel openssl-devel &&
               bash ci-utils/install_prereq_linux.sh --build_arrow yes
             "
+
       - name: Validate prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         shell: bash
         run: bash ci-utils/validate_prereqs.sh
+
       - name: Compress prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         run: tar -czf prereqs.tar.gz local_install
+
+      - name: Save prereqs cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
+
       - name: Upload prereqs
         uses: actions/upload-artifact@v4
         with:
@@ -51,7 +94,29 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out
+
+      - name: Compute cache key
+        id: cache-key
+        run: echo "key=prereqs-ubuntu-22.04-arm-${{ hashFiles('ci-utils/install_prereq_linux.sh', 'ci-utils/install_prereq_win.bat', 'ci-utils/validate_prereqs.sh') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete prereq cache (force rebuild)
+        if: inputs.force_prereqs == true
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh actions-cache delete "${{ steps.cache-key.outputs.key }}" \
+            -R ${{ github.repository }} --confirm || true
+
+      - name: Restore cached prereqs
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
+
       - name: Build prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/work" \
@@ -61,11 +126,23 @@ jobs:
               dnf -y install llvm libevent-devel openssl-devel &&
               bash ci-utils/install_prereq_linux.sh --build_arrow yes
             "
+
       - name: Validate prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         shell: bash
         run: bash ci-utils/validate_prereqs.sh
+
       - name: Compress prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         run: tar -czf prereqs.tar.gz local_install
+
+      - name: Save prereqs cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
+
       - name: Upload prereqs
         uses: actions/upload-artifact@v4
         with:
@@ -81,15 +158,53 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out
+
+      - name: Compute cache key
+        id: cache-key
+        shell: bash
+        run: echo "key=prereqs-windows-latest-${{ hashFiles('ci-utils/install_prereq_linux.sh', 'ci-utils/install_prereq_win.bat', 'ci-utils/validate_prereqs.sh') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete prereq cache (force rebuild)
+        if: inputs.force_prereqs == true
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh actions-cache delete "${{ steps.cache-key.outputs.key }}" \
+            -R ${{ github.repository }} --confirm || true
+
+      - name: Restore cached prereqs
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
+
       - uses: ilammy/msvc-dev-cmd@v1
+        if: steps.cache.outputs.cache-hit != 'true'
         name: Add MSVS Path
+
       - name: Build prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         run: ci-utils\install_prereq_win.bat
+
       - name: Validate prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         shell: bash
         run: bash ci-utils/validate_prereqs.sh
+
       - name: Compress prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         run: tar -czf prereqs.tar.gz local_install
+
+      - name: Save prereqs cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
+
       - name: Upload prereqs
         uses: actions/upload-artifact@v4
         with:
@@ -105,15 +220,49 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out
+
+      - name: Compute cache key
+        id: cache-key
+        run: echo "key=prereqs-macos-15-intel-${{ hashFiles('ci-utils/install_prereq_linux.sh', 'ci-utils/install_prereq_win.bat', 'ci-utils/validate_prereqs.sh') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete prereq cache (force rebuild)
+        if: inputs.force_prereqs == true
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh actions-cache delete "${{ steps.cache-key.outputs.key }}" \
+            -R ${{ github.repository }} --confirm || true
+
+      - name: Restore cached prereqs
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
+
       - name: Build prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.15"
         run: bash ci-utils/install_prereq_linux.sh --build_arrow yes
+
       - name: Validate prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         shell: bash
         run: bash ci-utils/validate_prereqs.sh
+
       - name: Compress prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         run: tar -czf prereqs.tar.gz local_install
+
+      - name: Save prereqs cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
+
       - name: Upload prereqs
         uses: actions/upload-artifact@v4
         with:
@@ -129,15 +278,49 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Check out
+
+      - name: Compute cache key
+        id: cache-key
+        run: echo "key=prereqs-macos-14-${{ hashFiles('ci-utils/install_prereq_linux.sh', 'ci-utils/install_prereq_win.bat', 'ci-utils/validate_prereqs.sh') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete prereq cache (force rebuild)
+        if: inputs.force_prereqs == true
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh actions-cache delete "${{ steps.cache-key.outputs.key }}" \
+            -R ${{ github.repository }} --confirm || true
+
+      - name: Restore cached prereqs
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
+
       - name: Build prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         env:
           MACOSX_DEPLOYMENT_TARGET: "11.0"
         run: bash ci-utils/install_prereq_linux.sh --build_arrow yes
+
       - name: Validate prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         shell: bash
         run: bash ci-utils/validate_prereqs.sh
+
       - name: Compress prereqs
+        if: steps.cache.outputs.cache-hit != 'true'
         run: tar -czf prereqs.tar.gz local_install
+
+      - name: Save prereqs cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: prereqs.tar.gz
+          key: ${{ steps.cache-key.outputs.key }}
+
       - name: Upload prereqs
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Implement actions/cache for prereq artifacts across workflow runs to save ~20-30 minutes per OS on cache hits. Caching applied to 3 build_* workflows:
- build_wheels.yml (5 prereq jobs)
- build_cuda12_wheels.yml (2 prereq jobs)
- build_cuda11_wheels.yml (1 prereq job)

Changes per prereq job:
- Add workflow_dispatch input 'force_prereqs' for cache override
- Compute cache key: prereqs-{os}-{hash of prereq scripts}
- Restore cache before build
- Skip build/validate/compress if cache hit
- Save cache on miss
- Always upload artifact (from cache or fresh build)

Cache invalidates automatically when install scripts change. Force rebuild available via workflow_dispatch UI.