### PR TITLE
Custom direction glcm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -562,3 +562,13 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 .DS_Store
+
+# CMake build artifacts (when cmake runs in the repo root)
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile
+
+# Test output files
+*.arrow
+*.parquet

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,7 @@ endif()
 
 # Python bindings.
 if(BUILD_LIB)
+	set(PYBIND11_FINDPYTHON ON)
 	find_package(pybind11 CONFIG REQUIRED)
 	pybind11_add_module(backend 
 		${SOURCE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,9 @@ set(SOURCE
 	src/nyx/slideprops.cpp
 	src/nyx/strpat.cpp
 	src/nyx/workflow_2d_segmented.cpp
+	src/nyx/workflow_2d_fmaps.cpp
 	src/nyx/workflow_2d_whole.cpp
+	src/nyx/workflow_3d_fmaps.cpp
 	src/nyx/workflow_3d_segmented.cpp
 	src/nyx/workflow_3d_whole.cpp
 	src/nyx/workflow_pythonapi.cpp

--- a/README.md
+++ b/README.md
@@ -234,6 +234,54 @@ f = nyx.featurize_directory (intensity_dir=dir, label_dir=dir)
 ```
 
 
+### Feature maps (sliding kernel) mode
+
+Feature maps mode computes features at every position of a sliding kernel across each ROI, producing spatial feature maps instead of a single feature vector per ROI. This is useful for generating spatially resolved feature representations for downstream analysis or machine learning.
+
+#### 2D feature maps
+
+```python
+from nyxus import Nyxus, save_fmaps_to_tiff
+
+nyx = Nyxus(["*ALL_INTENSITY*"], fmaps=True, fmaps_radius=2)  # 5x5 kernel
+results = nyx.featurize_directory("/path/to/intensities", "/path/to/labels")
+
+# results is a list of dicts, one per parent ROI:
+# [
+#     {
+#         "parent_roi_label": 1,
+#         "intensity_image": "img1.tif",
+#         "mask_image": "seg1.tif",
+#         "origin_x": 10, "origin_y": 20,
+#         "features": {
+#             "MEAN": numpy.array(shape=(map_h, map_w)),
+#             "STDDEV": numpy.array(shape=(map_h, map_w)),
+#             ...
+#         }
+#     },
+#     ...
+# ]
+
+# Save feature maps as TIFF stacks (requires tifffile)
+save_fmaps_to_tiff(results, "output/tiff/")
+```
+
+#### 3D feature maps
+
+```python
+from nyxus import Nyxus3D, save_fmaps_to_nifti
+
+nyx = Nyxus3D(["*3D_ALL_INTENSITY*"], fmaps=True, fmaps_radius=1)  # 3x3x3 kernel
+results = nyx.featurize_directory("/path/to/volumes", "/path/to/masks")
+
+# Each feature map is a 3D numpy array shaped (map_d, map_h, map_w)
+
+# Save as NIfTI volumes (requires nibabel)
+save_fmaps_to_nifti(results, "output/nifti/", voxel_size=(0.5, 0.5, 1.0))
+```
+
+Note: Feature maps mode returns numpy arrays rather than DataFrames, since the output is inherently image-shaped. Arrow/Parquet output is not supported in this mode.
+
 ## Further steps
 
 For more information on all of the available options and features, check out [the documentation](#).
@@ -271,19 +319,19 @@ print(nyx.get_params())
 will print the dictionary
 
 ```bash
-{'coarse_gray_depth': 256, 
-'features': ['*ALL*'], 
-'gabor_f0': 0.1, 
-'gabor_freqs': [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0], 
-'gabor_gamma': 0.1, 
-'gabor_kersize': 16, 
-'gabor_sig2lam': 0.8, 
-'gabor_theta': 45.0, 
-'gabor_thold': 0.025, 
-'ibsi': 0, 
-'n_loader_threads': 1, 
-'n_feature_calc_threads': 4, 
-'neighbor_distance': 5, 
+{'coarse_gray_depth': 256,
+'features': ['*ALL*'],
+'gabor_f0': 0.1,
+'gabor_freqs': [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0],
+'gabor_gamma': 0.1,
+'gabor_kersize': 16,
+'gabor_sig2lam': 0.8,
+'gabor_theta': 45.0,
+'gabor_thold': 0.025,
+'ibsi': 0,
+'n_loader_threads': 1,
+'n_feature_calc_threads': 4,
+'neighbor_distance': 5,
 'pixels_per_micron': 1.0}
 ```
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,82 @@ mdir = [
 nyx.featurize_files (idir, mdir, False) # pass True to featurize intensity files as whole segments
 ```
 
+### GLCM with Custom Direction Fields
+
+Nyxus supports computing GLCM texture features using custom, spatially-varying directions instead of traditional fixed angles (0°, 45°, 90°, 135°). This is useful when analyzing anisotropic structures where texture orientation varies across the image.
+
+**Important:** Direction field support requires **feature maps (fmaps) mode** to be enabled, as it produces spatially-resolved texture maps following local tissue orientation.
+
+**Python API:
+
+```python
+from nyxus import Nyxus
+
+# REQUIRED: Enable feature maps mode for direction field support
+nyx = Nyxus(['*ALL_GLCM*'], fmaps=True, fmaps_radius=2)
+
+# Option 1: Load direction field from file (NIfTI or TIFF)
+nyx.set_glcm_direction_field('path/to/direction_field.nii.gz')
+
+# Option 2: Provide direction field as NumPy array
+import numpy as np
+direction_array = np.load('directions.npy')  # Shape: (height, width, 2)
+nyx.set_glcm_direction_field_array(direction_array)
+
+# Extract features (returns feature maps, not scalar values)
+features = nyx.featurize_directory(
+    intensity_dir='/path/to/intensity',
+    label_dir='/path/to/masks'
+)
+
+# Results are spatial arrays, one per parent ROI:
+# results[0]['features']['GLCM_CONTRAST_0'] -> numpy array (map_h, map_w)
+```
+
+**File Format Requirements:**
+
+*NIfTI files (.nii, .nii.gz):*
+- Shape: `(width, height, depth, components)` where `depth=1` for 2D, `components=2` for (dx, dy)
+- Data type: float32 or float64
+
+*TIFF files:*
+- Multi-channel TIFF with 2 channels
+- Shape: `(height, width, 2)`
+- Data type: float32 or float64
+
+*NumPy arrays:*
+- Shape: `(height, width, 2)` for 2D
+- Last dimension contains `[dx, dy]` direction components
+
+**How It Works:**
+
+In feature maps mode with a direction field:
+
+1. **Per-pixel direction binning:** Each pixel's direction vector is binned to the nearest canonical angle (0°, 45°, 90°, 135°)
+2. **Directional GLCMs:** Four separate GLCMs are built within each kernel window, one per canonical direction
+3. **Selective pixel inclusion:** Only pixels whose direction bins to a specific angle contribute to that angle's GLCM
+4. **Feature map output:** Texture features are computed for each canonical direction at every kernel position, producing 4 feature maps per GLCM feature (one per angle)
+
+This produces texture maps that follow the local tissue structure at each position.
+
+**Direction Quantization:**
+
+Direction vectors are binned to the nearest canonical angle using GLCM's 180° rotational symmetry:
+
+**Lower hemisphere (0°-180°):**
+- Right (±22.5°) → 0°
+- Down-right (22.5° to 67.5°) → 45°
+- Down (67.5° to 112.5°) → 90°
+- Down-left (112.5° to 157.5°) → 135°
+
+**Upper hemisphere (180°-360°) - flipped to equivalent lower angles:**
+- Left (180°) → 0° (equivalent)
+- Up-left (225°) → 45° (equivalent)
+- Up (270°) → 90° (equivalent)
+- Up-right (315°) → 135° (equivalent)
+
+This handles GLCM's inherent symmetry: a co-occurrence from pixel A→B at angle θ is the same as B→A at angle θ+180°.
+
 ### Whole-slide and whole-volume feature extraction
 
 Nyxus provides dedicated workflows for extracting features from whole 2D slides and volumes. The workflows scale across CPU cores as controlled by constructor parameter `n_feature_calc_threads` of classes Nyxus and Nyxus3D.
@@ -468,6 +544,7 @@ Nyxus provides a set of pixel intensity, morphology, texture, intensity distribu
 | EROSIONS_2_VANISH_COMPLEMENT | Number of erosion operations for a ROI to vanish in its convex hull |
 | FRACT_DIM_BOXCOUNT, FRACT_DIM_PERIMETER | Fractal dimension features |
 | GLCM | Grey level co-occurrence Matrix features |
+| GLCM with custom direction field | GLCM features computed using spatially-varying directions (e.g., following tissue fiber orientation, gradients, or DTI) instead of fixed angles |
 | GLRLM | Grey level run-length matrix based features |
 | GLDZM | Grey level distance zone matrix based features |
 | GLSZM | Grey level size zone matrix based features |
@@ -749,6 +826,7 @@ Assuming you [built the Nyxus binary](#building-from-source) as outlined below, 
 --gpuDeviceID | ${\color{red}\textsf{(optional)}}$ ID of a GPU device to be used when '--useGpu=true'. Default: '--gpuDeviceID=0'. Example 1 (single GPU device): '--useGpu=true --gpuDeviceID=2' to strictly use device 2. Example 2 (multiple GPU devices, usually in SLURM scenarios): '--useGpu=true --gpuDeviceID=0,1,3' to use the GPU device having maximum free RAM of devices 0, 1, and 3. | integer or list of integers
 --coarseGrayDepth | ${\color{red}\textsf{(optional)}}$ Custom number of greyscale level bins used in texture features. Default: '--coarseGrayDepth=256' | integer
 --glcmAngles | ${\color{red}\textsf{(optional)}}$ Enabled direction angles of the GLCM feature. Superset of values: 0, 45, 90, and 135. Default: '--glcmAngles=0,45,90,135' | list of integers
+--glcmDirectionField | ${\color{red}\textsf{(optional)}}$ Path to a NIfTI or multi-channel TIFF file containing custom per-pixel GLCM directions. When specified, GLCM features use spatially-varying directions instead of fixed angles. File should contain 2D direction vectors (dx, dy). Example: '--glcmDirectionField=/path/to/directions.nii.gz' | path
 --intSegMapDir | ${\color{red}\textsf{(optional)}}$ Data collection of the ad-hoc intensity-to-mask file mapping. Must be used in combination with parameter '--intSegMapFile' | path
 --intSegMapFile | ${\color{red}\textsf{(optional)}}$ Name of the text file containing an ad-hoc intensity-to-mask file mapping. The files are assumed to reside in corresponding intensity and label collections. Must be used in combination with parameter '--intSegMapDir' | string
 --pixelDistance | ${\color{red}\textsf{(optional)}}$ Number of pixels to treat ROIs within specified distance as neighbors. Default value: '--pixelDistance=5' | integer

--- a/ci-utils/envs/conda_cpp.txt
+++ b/ci-utils/envs/conda_cpp.txt
@@ -9,5 +9,7 @@ xsimd >=13,<14
 cmake
 dcmtk >=3.6.9
 fmjpeg2koj >=1.0.3
-libarrow
-libparquet
+# Pin to <=23.0.0 — newer versions introduce breaking API changes
+# that cause build failures.
+libarrow <=23.0.0
+libparquet <=23.0.0

--- a/docs/source/References/Classes.rst
+++ b/docs/source/References/Classes.rst
@@ -1,7 +1,16 @@
 Nyxus Classes
 ================
 .. autosummary::
-    :toctree: stubs 
+    :toctree: stubs
 
     nyxus.Nyxus
+    nyxus.Nyxus3D
     nyxus.Nested
+
+Feature Map I/O
+================
+.. autosummary::
+    :toctree: stubs
+
+    nyxus.save_fmaps_to_tiff
+    nyxus.save_fmaps_to_nifti

--- a/docs/source/cmdline_and_examples.rst
+++ b/docs/source/cmdline_and_examples.rst
@@ -135,9 +135,19 @@ should adhere to columns "WIPP I/O role" and "WIPP type".
      - path
    * - --arrowOutputType
      - (Optional) Type of Arrow file to write the feature results to. Current options are 'arrow' for Arrow IPC or 'parquet' for Parquet
-     - string 
+     - string
      - output
      - enum
+   * - --fmaps
+     - (Optional) Enable feature maps mode. When enabled, a sliding kernel is moved across each ROI and features are computed at every position, producing spatial feature maps instead of a single feature vector per ROI. Acceptable values: true, false. Default: '--fmaps=false'. Not compatible with Arrow/Parquet output.
+     - string constant
+     - input
+     - enum
+   * - --fmapsRadius
+     - (Optional) Radius of the sliding kernel in feature maps mode. The kernel size is (2 * radius + 1). For example, '--fmapsRadius=2' produces a 5x5 kernel (2D) or 5x5x5 kernel (3D). Default: '--fmapsRadius=2'
+     - integer
+     - input
+     - integer
 
 Examples
 ========
@@ -378,19 +388,19 @@ will print the dictionary
 
 .. code-block:: bash
 
-   {'coarse_gray_depth': 256, 
-   'features': ['*ALL*'], 
-   'gabor_f0': 0.1, 
-   'gabor_freqs': [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0], 
-   'gabor_gamma': 0.1, 
-   'gabor_kersize': 16, 
-   'gabor_sig2lam': 0.8, 
-   'gabor_theta': 45.0, 
-   'gabor_thold': 0.025, 
-   'ibsi': 0, 
-   'n_loader_threads': 1, 
-   'n_feature_calc_threads': 4, 
-   'neighbor_distance': 5, 
+   {'coarse_gray_depth': 256,
+   'features': ['*ALL*'],
+   'gabor_f0': 0.1,
+   'gabor_freqs': [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0],
+   'gabor_gamma': 0.1,
+   'gabor_kersize': 16,
+   'gabor_sig2lam': 0.8,
+   'gabor_theta': 45.0,
+   'gabor_thold': 0.025,
+   'ibsi': 0,
+   'n_loader_threads': 1,
+   'n_feature_calc_threads': 4,
+   'neighbor_distance': 5,
    'pixels_per_micron': 1.0}
 
 There is also the option to pass arguments to this function to only receive a subset of parameter values. The arguments should be 

--- a/src/nyx/cli_glcm_options.cpp
+++ b/src/nyx/cli_glcm_options.cpp
@@ -1,5 +1,8 @@
 #include "cli_glcm_options.h"
 #include "features/glcm.h"
+#include "helpers/system_resource.h"
+#include "dirs_and_files.h"
+#include <filesystem>
 
 using namespace Nyxus;
 
@@ -22,7 +25,7 @@ bool GLCMoptions::parse_input()
 		}
 	}
 
-	if (!rawOffs.empty())
+		if (!rawOffs.empty())
 	{
 		// string -> real
 		int x;
@@ -37,12 +40,24 @@ bool GLCMoptions::parse_input()
 		offset_ = x;
 	}
 
+		// Parse direction field path
+	if (!rawDirectionField.empty())
+	{
+		// Check if file exists
+		if (!existsOnFilesystem(rawDirectionField))
+		{
+			ermsg = "Direction field file does not exist: " + rawDirectionField;
+			return false;
+		}
+		directionFieldPath = rawDirectionField;
+	}
+
 	return true;
 }
 
 bool GLCMoptions::empty()
 {
-	return rawAngles.empty() && rawOffs.empty();
+	return rawAngles.empty() && rawOffs.empty() && rawDirectionField.empty();
 }
 
 std::string GLCMoptions::get_last_er_msg()

--- a/src/nyx/cli_glcm_options.h
+++ b/src/nyx/cli_glcm_options.h
@@ -14,11 +14,13 @@ public:
 	bool empty();
 
 	// intentionally public to be accessed by Environment
-	std::string rawOffs = "",	// matches GLCMOFFSET
-		rawAngles = "";			// matches GLCMANGLES
+	std::string rawOffs = "",		// matches GLCMOFFSET
+		rawAngles = "",			// matches GLCMANGLES
+		rawDirectionField = "";	// matches GLCM_DIRFIELD - path to direction field image
 
 	int offset_ = 1;
 	std::vector<int> glcmAngles = { 0, 45, 90, 135 };
+	std::string directionFieldPath = "";  // parsed path to direction field file
 
 private:
 	bool defined_ = false;

--- a/src/nyx/cli_option_constants.h
+++ b/src/nyx/cli_option_constants.h
@@ -61,6 +61,10 @@
 #define clo_ANISO_Y "--anisoy"
 #define clo_ANISO_Z "--anisoz"
 
+// Feature maps
+#define clo_FMAPS "--fmaps"						// Enable feature maps mode. "true" or "false"
+#define clo_FMAPS_RADIUS "--fmapsRadius"		// Kernel radius for feature maps. Integer >= 1. Example: "2" (produces 5x5 kernel)
+
 // Result options
 #define clo_NOVAL "--noval"						// -> raw_noval
 #define clo_TINYVAL "--tinyval"					// -> raw_tiny

--- a/src/nyx/cli_option_constants.h
+++ b/src/nyx/cli_option_constants.h
@@ -44,6 +44,7 @@
 // GLCM feature
 #define clo_GLCMANGLES "--glcmAngles"				// Environment :: rotAngles
 #define clo_GLCMOFFSET "--glcmOff"					// Environment :: raw_glcm_
+#define clo_GLCM_DIRFIELD "--glcmDirectionField"	// Path to direction field image (multi-channel TIFF: channel 0=dx, 1=dy, 2=dz). 
 
 // Nested ROI functionality
 #define clo_NESTEDROI_CHNL_SIGNATURE "--hsig"		// Channel signature Example: "_c" in "p0_y1_r1_c1.ome.tiff"

--- a/src/nyx/direction_field_loader.h
+++ b/src/nyx/direction_field_loader.h
@@ -1,0 +1,432 @@
+#pragma once
+
+#ifdef __APPLE__
+    #define uint64 uint64_hack_
+    #define int64 int64_hack_
+    #include <tiffio.h>
+    #undef uint64
+    #undef int64
+#else
+    #include <tiffio.h>
+#endif
+
+#include <string>
+#include <memory>
+#include <cmath>
+#include <iostream>
+#include <algorithm>
+#include "features/image_cube.h"
+#include "direction_field_loader_nifti.h"
+
+/// @brief Loader for multi-channel TIFF/NIfTI direction field images
+/// 
+/// PURPOSE: This class provides a unified interface to load direction fields from different file formats.
+/// Direction fields tell GLCM which direction to look when computing texture at each pixel.
+/// 
+/// WHAT IS A DIRECTION FIELD?
+/// - Traditional GLCM uses fixed angles (0°, 45°, 90°, 135°) everywhere
+/// - Direction field uses DIFFERENT angles at EACH pixel location
+/// - Stored as vectors: [dx, dy] for 2D or [dx, dy, dz] for 3D
+/// - Example: In a fiber image, direction field follows fiber orientation
+///
+/// FILE FORMAT REQUIREMENTS:
+/// - TIFF: Multi-channel image with 2-3 channels (dx, dy[, dz])
+/// - NIfTI: 4D image where 4th dimension holds vector components
+/// - Values: float32 or float64
+class DirectionFieldLoader
+{
+public:
+    /// @brief Main entry point - Load direction field from file
+    /// 
+    /// PURPOSE: Auto-detect file format and dispatch to appropriate loader
+    /// 
+    /// @param filePath Full path to the direction field file
+    /// 
+    /// @return SimpleCube<float> containing direction vectors
+    ///         Shape: (width, height, num_channels)
+    ///         where num_channels = 2 for 2D (dx,dy) or 3 for 3D (dx,dy,dz)
+    /// 
+    /// EXAMPLE USAGE:
+    ///   auto dirField = DirectionFieldLoader::load("myfield.tif", false);
+    ///   float dx = dirField->zyx(0, row, col);  // x-component at (row, col)
+    ///   float dy = dirField->zyx(1, row, col);  // y-component at (row, col)
+    static std::unique_ptr<SimpleCube<float>> load(const std::string& filePath)
+    {
+        // Auto-detect file format based on extension
+        std::string ext = getFileExtension(filePath);
+        std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+        
+        if (ext == ".nii" || ext == ".gz")
+        {
+            // NIfTI format - common in medical imaging
+            return DirectionFieldLoaderNifti::load(filePath);
+        }
+        else if (ext == ".tif" || ext == ".tiff")
+        {
+            // TIFF format - common in microscopy
+            return loadTiff(filePath);
+        }
+        else
+        {
+            throw std::runtime_error("DirectionFieldLoader: Unsupported file format '" + ext + "'. Expected .tif, .tiff, .nii, or .nii.gz");
+        }
+    }
+
+private:
+    
+    /// @brief Extract file extension from path
+    /// 
+    /// PURPOSE: Determine file type so we know which loader to use
+    /// 
+    /// @param filePath Full path like "/path/to/file.tif"
+    /// @return Extension including dot, like ".tif" or ".gz"
+    /// 
+    /// WHY PRIVATE? This is just a helper function - users don't need to call it directly
+    static std::string getFileExtension(const std::string& filePath)
+    {
+        size_t dotPos = filePath.find_last_of('.');
+        if (dotPos == std::string::npos)
+            return "";
+        return filePath.substr(dotPos);
+    }
+    
+    /// @brief Load direction field from a multi-channel TIFF file
+    /// 
+    /// PURPOSE: Read TIFF files that store direction vectors
+    /// 
+    /// TIFF FORMAT DETAILS:
+    /// - Must have 2-3 "samples per pixel" (channels)
+    /// - Channel 0 = dx (x-component of direction)
+    /// - Channel 1 = dy (y-component of direction)  
+    /// - Channel 2 = dz (z-component, optional, for 3D)
+    /// - Data type: float32 or float64
+    /// - Can be tiled or strip-based (we handle both)
+    /// 
+    /// @param filePath Path to TIFF file
+    /// @return SimpleCube with loaded
+    /// 
+    /// WHY PRIVATE? Implementation detail - users call load(), not this directly
+    static std::unique_ptr<SimpleCube<float>> loadTiff(const std::string& filePath)
+    {
+        // Open TIFF file using libtiff library
+        TIFF* tiff = TIFFOpen(filePath.c_str(), "r");
+        if (!tiff)
+        {
+            throw std::runtime_error("DirectionFieldLoader: Cannot open file " + filePath);
+        }
+
+        // Read TIFF metadata (image properties)
+        uint32_t width, height;              // Image dimensions
+        uint16_t samplesPerPixel;            // Number of channels (should be 2 or 3)
+        uint16_t bitsPerSample;              // Bits per value (should be 32 or 64 for float)
+        uint16_t sampleFormat;               // Data type (should be IEEE float)
+        
+        TIFFGetField(tiff, TIFFTAG_IMAGEWIDTH, &width);
+        TIFFGetField(tiff, TIFFTAG_IMAGELENGTH, &height);
+        TIFFGetField(tiff, TIFFTAG_SAMPLESPERPIXEL, &samplesPerPixel);
+        TIFFGetField(tiff, TIFFTAG_BITSPERSAMPLE, &bitsPerSample);
+        TIFFGetField(tiff, TIFFTAG_SAMPLEFORMAT, &sampleFormat);
+
+        // Validate: Must have 2 channels (dx,dy) or 3 channels (dx,dy,dz)
+        if (samplesPerPixel < 2 || samplesPerPixel > 3)
+        {
+            TIFFClose(tiff);
+            throw std::runtime_error(
+                "DirectionFieldLoader: Expected 2 or 3 channels, got " + 
+                std::to_string(samplesPerPixel) + " channels"
+            );
+        }
+
+        // Validate: Data must be floating-point (not integer)
+        if (sampleFormat != SAMPLEFORMAT_IEEEFP)
+        {
+            TIFFClose(tiff);
+            throw std::runtime_error(
+                "DirectionFieldLoader: Expected floating-point data (SAMPLEFORMAT_IEEEFP), got format " + 
+                std::to_string(sampleFormat)
+            );
+        }
+
+        // Validate: Must be 32-bit or 64-bit float
+        if (bitsPerSample != 32 && bitsPerSample != 64)
+        {
+            TIFFClose(tiff);
+            throw std::runtime_error(
+                "DirectionFieldLoader: Expected 32 or 64 bits per sample, got " + 
+                std::to_string(bitsPerSample)
+            );
+        }
+
+        // Allocate output cube to hold the direction vectors
+        auto directionField = std::make_unique<SimpleCube<float>>(width, height, samplesPerPixel);
+
+        // TIFF images can be organized two ways:
+        // 1. Tiled - image divided into rectangular tiles (faster random access)
+        // 2. Strip - image stored as horizontal strips (simpler, sequential)
+        bool isTiled = TIFFIsTiled(tiff);
+        
+        if (isTiled)
+        {
+            // Read tiled image
+            loadTiledImage(tiff, width, height, samplesPerPixel, bitsPerSample, *directionField);
+        }
+        else
+        {
+            // Read strip-based image (most common)
+            loadStripImage(tiff, width, height, samplesPerPixel, bitsPerSample, *directionField);
+        }
+
+        TIFFClose(tiff);
+
+        return directionField;
+    }
+
+    /// @brief Load a tiled TIFF image
+    /// 
+    /// PURPOSE: Handle TIFF files organized as rectangular tiles
+    /// 
+    /// WHAT ARE TILES?
+    /// - Image is divided into rectangular blocks (e.g., 256x256 pixels each)
+    /// - Allows efficient random access to image regions
+    /// - Common in large microscopy images
+    /// 
+    /// HOW IT WORKS:
+    /// 1. Read each tile from file
+    /// 2. Copy relevant pixels from tile to output cube
+    /// 3. Handle edge tiles that may be partially outside image bounds
+    /// 
+    /// @param tiff Open TIFF file handle
+    /// @param width Image width in pixels
+    /// @param height Image height in pixels
+    /// @param numChannels Number of vector components (2 or 3)
+    /// @param bitsPerSample Bits per channel value (32 or 64)
+    /// @param directionField Output cube to fill with data
+    static void loadTiledImage(
+        TIFF* tiff,
+        uint32_t width,
+        uint32_t height,
+        uint16_t numChannels,
+        uint16_t bitsPerSample,
+        SimpleCube<float>& directionField)
+    {
+        // Get tile dimensions (how big each tile is)
+        uint32_t tileWidth, tileHeight;
+        TIFFGetField(tiff, TIFFTAG_TILEWIDTH, &tileWidth);
+        TIFFGetField(tiff, TIFFTAG_TILELENGTH, &tileHeight);
+
+        // Allocate buffer to hold one tile
+        size_t tileSize = TIFFTileSize(tiff);
+        tdata_t buf = _TIFFmalloc(tileSize);
+        
+        if (!buf)
+        {
+            throw std::runtime_error("DirectionFieldLoader: Failed to allocate tile buffer");
+        }
+
+        // Iterate over all tiles, row by row
+        for (uint32_t row = 0; row < height; row += tileHeight)
+        {
+            for (uint32_t col = 0; col < width; col += tileWidth)
+            {
+                // Read one tile from file into buffer
+                if (TIFFReadTile(tiff, buf, col, row, 0, 0) < 0)
+                {
+                    _TIFFfree(buf);
+                    throw std::runtime_error("DirectionFieldLoader: Error reading tile");
+                }
+
+                // Copy data from tile buffer to output cube
+                copyTileData(
+                    buf, 
+                    bitsPerSample,
+                    directionField,
+                    row, col, 
+                    tileHeight, tileWidth,
+                    height, width,
+                    numChannels
+                );
+            }
+        }
+
+        _TIFFfree(buf);
+    }
+
+    /// @brief Load a strip-based TIFF image
+    /// 
+    /// PURPOSE: Handle TIFF files organized as horizontal strips (scanlines)
+    /// 
+    /// WHAT ARE STRIPS?
+    /// - Image stored as horizontal rows (scanlines)
+    /// - Simple, sequential storage
+    /// - Most common TIFF organization
+    /// 
+    /// HOW IT WORKS:
+    /// 1. Read one row at a time
+    /// 2. Copy pixels from row buffer to output cube
+    /// 
+    /// @param tiff Open TIFF file handle
+    /// @param width Image width in pixels
+    /// @param height Image height in pixels
+    /// @param numChannels Number of vector components (2 or 3)
+    /// @param bitsPerSample Bits per channel value (32 or 64)
+    /// @param directionField Output cube to fill with data
+    static void loadStripImage(
+        TIFF* tiff,
+        uint32_t width,
+        uint32_t height,
+        uint16_t numChannels,
+        uint16_t bitsPerSample,
+        SimpleCube<float>& directionField)
+    {
+        // Allocate buffer to hold one row of pixels
+        size_t scanlineSize = TIFFScanlineSize(tiff);
+        tdata_t buf = _TIFFmalloc(scanlineSize);
+        
+        if (!buf)
+        {
+            throw std::runtime_error("DirectionFieldLoader: Failed to allocate scanline buffer");
+        }
+
+        // Read image one row at a time
+        for (uint32_t row = 0; row < height; row++)
+        {
+            // Read one row into buffer
+            if (TIFFReadScanline(tiff, buf, row) < 0)
+            {
+                _TIFFfree(buf);
+                throw std::runtime_error("DirectionFieldLoader: Error reading scanline");
+            }
+
+            // Copy row data to output cube
+            copyScanlineData(
+                buf,
+                bitsPerSample,
+                directionField,
+                row,
+                width,
+                numChannels
+            );
+        }
+
+        _TIFFfree(buf);
+    }
+
+    /// @brief Copy one tile's data to the output cube
+    /// 
+    /// PURPOSE: Transfer pixels from tile buffer to SimpleCube storage
+    /// 
+    /// WHY NEEDED?
+    /// - Tile buffer is raw bytes in TIFF format
+    /// - SimpleCube uses specific indexing (zyx)
+    /// - Need to handle edge tiles that extend beyond image bounds
+    /// - Need to convert between float32/float64
+    /// 
+    /// MEMORY LAYOUT:
+    /// - Tile buffer: [pixel0_ch0, pixel0_ch1, ..., pixel1_ch0, pixel1_ch1, ...]
+    /// - SimpleCube: Accessed via zyx(channel, row, col)
+    /// 
+    /// @param buf Raw tile data buffer
+    /// @param bitsPerSample 32 or 64 (determines if buf is float* or double*)
+    /// @param directionField Output cube
+    /// @param startRow Starting row of this tile in the image
+    /// @param startCol Starting column of this tile in the image
+    /// @param tileHeight Height of tile
+    /// @param tileWidth Width of tile
+    /// @param imageHeight Total image height (for bounds checking)
+    /// @param imageWidth Total image width (for bounds checking)
+    /// @param numChannels Number of components per pixel
+    static void copyTileData(
+        tdata_t buf,
+        uint16_t bitsPerSample,
+        SimpleCube<float>& directionField,
+        uint32_t startRow,
+        uint32_t startCol,
+        uint32_t tileHeight,
+        uint32_t tileWidth,
+        uint32_t imageHeight,
+        uint32_t imageWidth,
+        uint16_t numChannels)
+    {
+        // Calculate actual bounds (edge tiles may extend past image)
+        uint32_t endRow = std::min(startRow + tileHeight, imageHeight);
+        uint32_t endCol = std::min(startCol + tileWidth, imageWidth);
+
+        // Iterate over pixels in this tile
+        for (uint32_t row = startRow; row < endRow; row++)
+        {
+            for (uint32_t col = startCol; col < endCol; col++)
+            {
+                // Calculate index in tile buffer
+                // Tile stores pixels sequentially: row0, row1, ...
+                size_t tileIdx = ((row - startRow) * tileWidth + (col - startCol)) * numChannels;
+                
+                // Copy each channel (dx, dy, [dz])
+                for (uint16_t ch = 0; ch < numChannels; ch++)
+                {
+                    float value;
+                    if (bitsPerSample == 32)
+                    {
+                        // Buffer contains float32 values
+                        value = static_cast<float*>(buf)[tileIdx + ch];
+                    }
+                    else // 64-bit
+                    {
+                        // Buffer contains float64 values - convert to float32
+                        value = static_cast<float>(static_cast<double*>(buf)[tileIdx + ch]);
+                    }
+                    
+                    // Store in SimpleCube
+                    // zyx indexing: z=channel, y=row, x=col
+                    directionField.zyx(ch, row, col) = value;
+                }
+            }
+        }
+    }
+
+    /// @brief Copy one scanline's data to the output cube
+    /// 
+    /// PURPOSE: Transfer pixels from scanline buffer to SimpleCube storage
+    /// 
+    /// Similar to copyTileData but simpler because we're copying a full row
+    /// 
+    /// @param buf Raw scanline data buffer
+    /// @param bitsPerSample 32 or 64
+    /// @param directionField Output cube
+    /// @param row Which row we're copying
+    /// @param width Image width
+    /// @param numChannels Number of components per pixel
+    static void copyScanlineData(
+        tdata_t buf,
+        uint16_t bitsPerSample,
+        SimpleCube<float>& directionField,
+        uint32_t row,
+        uint32_t width,
+        uint16_t numChannels)
+    {
+        // Iterate over all columns in this row
+        for (uint32_t col = 0; col < width; col++)
+        {
+            // Calculate index in scanline buffer
+            size_t idx = col * numChannels;
+            
+            // Copy each channel
+            for (uint16_t ch = 0; ch < numChannels; ch++)
+            {
+                float value;
+                if (bitsPerSample == 32)
+                {
+                    value = static_cast<float*>(buf)[idx + ch];
+                }
+                else // 64-bit
+                {
+                    value = static_cast<float>(static_cast<double*>(buf)[idx + ch]);
+                }
+                
+                // Store in SimpleCube with zyx indexing
+                directionField.zyx(ch, row, col) = value;
+            }
+        }
+    }
+
+
+};

--- a/src/nyx/direction_field_loader_nifti.h
+++ b/src/nyx/direction_field_loader_nifti.h
@@ -1,0 +1,195 @@
+#pragma once
+
+#include <string>
+#include <memory>
+#include <cmath>
+#include <iostream>
+#include "features/image_cube.h"
+#include "io/nifti/nifti2_io.h"
+
+/// @brief Loader for NIfTI direction field images
+/// 
+/// PURPOSE: Load direction fields from NIfTI medical imaging format
+/// 
+/// NIfTI FORMAT DETAILS:
+/// - NIfTI uses 4 dimensions: (nx, ny, nz, nt)
+///   - nx, ny = width, height (spatial dimensions)
+///   - nz = depth (1 for 2D images)
+///   - nt = time/volumes (we use this for vector components)
+/// - For direction fields:
+///   - nt should be 2 (dx, dy) for 2D
+///   - nt should be 3 (dx, dy, dz) for 3D
+///   - nt can be 4 if magnitude is also stored (we ignore 4th component)
+/// 
+/// MEMORY LAYOUT:
+/// - NIfTI stores data as: data[x + nx*(y + ny*(z + nz*t))]
+/// - Component 0 (t=0) = dx values for all pixels
+/// - Component 1 (t=1) = dy values for all pixels
+/// - Component 2 (t=2) = dz values for all pixels (if 3D)
+/// 
+/// Direction vectors are stored as float values 
+class DirectionFieldLoaderNifti
+{
+public:
+    /// @brief Load a direction field from a NIfTI file
+    /// 
+    /// PURPOSE: Main entry point for loading NIfTI direction fields
+    /// 
+    /// PROCESS:
+    /// 1. Open and read NIfTI file
+    /// 2. Validate dimensions (must be 2D or 3D with proper component count)
+    /// 3. Copy data from NIfTI memory layout to SimpleCube
+    /// 
+    /// @param filePath Path to the NIfTI file (.nii or .nii.gz)
+
+    /// @return SimpleCube containing the direction field with shape (width, height, num_components)
+    /// 
+    /// EXAMPLE:
+    ///   auto field = DirectionFieldLoaderNifti::load("directions.nii.gz", false);
+    ///   // field->zyx(0, y, x) = dx at position (x, y)
+    ///   // field->zyx(1, y, x) = dy at position (x, y)
+    static std::unique_ptr<SimpleCube<float>> load(const std::string& filePath)
+    {
+        // Read the NIfTI file
+        nifti_image* nii = nifti_image_read(filePath.c_str(), 1);
+        if (!nii)
+        {
+            throw std::runtime_error("DirectionFieldLoaderNifti: Cannot open file " + filePath);
+        }
+
+        // Get dimensions from NIfTI header
+        size_t width = nii->nx;          // Image width (x-dimension)
+        size_t height = nii->ny;         // Image height (y-dimension)
+        size_t depth = nii->nz;          // Image depth (z-dimension, should be 1 for 2D)
+        size_t numComponents = nii->nt;  // Number of volumes (4th dimension = vector components)
+
+        std::cout << "NIfTI dimensions: " << width << "x" << height << "x" << depth << "x" << numComponents << std::endl;
+
+        // Validate dimensions
+        // For 2D images: depth must be 1, components should be 2 (dx, dy)
+        // For 3D images: depth > 1, components should be 3 (dx, dy, dz)
+        // Currently only 2D is fully supported
+        if (depth != 1)
+        {
+            nifti_image_free(nii);
+            throw std::runtime_error(
+                "DirectionFieldLoaderNifti: Expected 2D image (depth=1), got depth=" + 
+                std::to_string(depth)
+            );
+        }
+
+        if (numComponents < 2 || numComponents > 4)
+        {
+            nifti_image_free(nii);
+            throw std::runtime_error(
+                "DirectionFieldLoaderNifti: Expected 2-4 components, got " + 
+                std::to_string(numComponents) + " components"
+            );
+        }
+
+        // Determine how many components to use
+        // - If 2D (depth=1): use 2 components (dx, dy)
+        // - If 3D (depth>1): use 3 components (dx, dy, dz)
+        // - If nt=4, the 4th component might be magnitude - we ignore it
+        size_t useComponents = std::min(size_t(3), numComponents);
+        if (depth == 1)
+            useComponents = std::min(size_t(2), numComponents);  // 2D case
+
+        // Allocate output cube
+        auto directionField = std::make_unique<SimpleCube<float>>(width, height, useComponents);
+
+        // Copy data from NIfTI buffer to SimpleCube
+        // NIfTI supports multiple data types - handle the most common ones
+        switch (nii->datatype)
+        {
+        case 16: // NIFTI_TYPE_FLOAT32
+            copyData<float>(nii, *directionField, width, height, useComponents, numComponents);
+            break;
+        case 64: // NIFTI_TYPE_FLOAT64
+            copyData<double>(nii, *directionField, width, height, useComponents, numComponents);
+            break;
+        case 8: // NIFTI_TYPE_INT32
+            copyData<int32_t>(nii, *directionField, width, height, useComponents, numComponents);
+            break;
+        case 512: // NIFTI_TYPE_UINT16
+            copyData<uint16_t>(nii, *directionField, width, height, useComponents, numComponents);
+            break;
+        default:
+            nifti_image_free(nii);
+            throw std::runtime_error(
+                "DirectionFieldLoaderNifti: Unsupported data type " + 
+                std::to_string(nii->datatype)
+            );
+        }
+
+        nifti_image_free(nii);
+
+
+        return directionField;
+    }
+
+private:
+    /// @brief Copy data from NIfTI to SimpleCube (template for different data types)
+    /// 
+    /// PURPOSE: Transfer data from NIfTI's memory layout to SimpleCube's layout
+    /// 
+    /// WHY TEMPLATE?
+    /// - NIfTI can store data as float, double, int32, uint16, etc.
+    /// - Template allows handling all types with same code
+    /// - Converts everything to float32 for SimpleCube
+    /// 
+    /// MEMORY LAYOUT CONVERSION:
+    /// - NIfTI layout: data[x + width*(y + height*(z + depth*component))]
+    ///   All dx values are stored together, then all dy values, etc.
+    /// - SimpleCube layout: directionField.zyx(component, y, x)
+    ///   Each pixel has all its components together
+    /// 
+    /// @tparam T Source data type (float, double, int32_t, etc.)
+    /// @param nii NIfTI image structure
+    /// @param directionField Output SimpleCube to fill
+    /// @param width Image width
+    /// @param height Image height
+    /// @param useComponents How many components to copy (2 or 3)
+    /// @param totalComponents Total components in NIfTI (might be more than useComponents)
+    template<typename T>
+    static void copyData(
+        nifti_image* nii,
+        SimpleCube<float>& directionField,
+        size_t width,
+        size_t height,
+        size_t useComponents,
+        size_t totalComponents)
+    {
+        // Get pointer to NIfTI data buffer (cast to appropriate type)
+        T* data = static_cast<T*>(nii->data);
+        
+        // NIfTI memory organization:
+        // - All pixels for component 0 (dx) come first
+        // - Then all pixels for component 1 (dy)
+        // - Then all pixels for component 2 (dz) if present
+        // We need to reorganize this into SimpleCube format
+        
+        for (size_t comp = 0; comp < useComponents; comp++)
+        {
+            for (size_t y = 0; y < height; y++)
+            {
+                for (size_t x = 0; x < width; x++)
+                {
+                    // Calculate NIfTI linear index
+                    // Formula: x + width * (y + height * (z + depth * component))
+                    // For 2D where z=0: x + width * (y + height * component)
+                    // This means: component 0 occupies indices [0, width*height)
+                    //             component 1 occupies indices [width*height, 2*width*height)
+                    //             etc.
+                    size_t niftiIdx = x + width * (y + height * comp);
+                    float value = static_cast<float>(data[niftiIdx]);
+                    
+                    // Store in SimpleCube with zyx indexing: z=component, y=row, x=col
+                    directionField.zyx(comp, y, x) = value;
+                }
+            }
+        }
+    }
+
+
+};

--- a/src/nyx/environment.cpp
+++ b/src/nyx/environment.cpp
@@ -13,6 +13,7 @@
 #include "helpers/system_resource.h"
 #include "helpers/timing.h"
 #include "version.h"
+#include "direction_field_loader.h"
 
 #ifdef USE_GPU
 	std::vector<std::map<std::string, std::string>> get_gpu_properties();
@@ -439,6 +440,7 @@ bool Environment::parse_cmdline(int argc, char** argv)
 			find_string_argument(i, clo_REDUCETHREADS, reduce_threads) ||
 			find_string_argument(i, clo_GLCMANGLES, glcmOptions.rawAngles) ||
 			find_string_argument(i, clo_GLCMOFFSET, glcmOptions.rawOffs) ||
+			find_string_argument(i, clo_GLCM_DIRFIELD, glcmOptions.rawDirectionField) ||
 			find_string_argument(i, clo_PXLDIST, pixel_distance) ||
 			find_string_argument(i, clo_COARSEGRAYDEPTH, raw_coarse_grayscale_depth) ||
 			find_string_argument(i, clo_VERBOSITY, rawVerbosity) ||
@@ -1022,6 +1024,39 @@ bool Environment::parse_glcm_options_raw_inputs (std::string& error_message)
 		return false;
 	}
 	return true;
+}
+
+void Environment::load_glcm_direction_field()
+{
+	if (glcmOptions.directionFieldPath.empty())
+		return;
+
+	try
+	{
+		// Load the direction field from file (normalization handled internally during binning)
+		glcm_direction_field_data = DirectionFieldLoader::load(glcmOptions.directionFieldPath);
+		
+		// Set it on the GLCMFeature class (static member)
+		GLCMFeature::direction_field = glcm_direction_field_data.get();
+		
+		VERBOSLVL2(get_verbosity_level(), 
+			std::cout << "Loaded GLCM direction field from " << glcmOptions.directionFieldPath 
+				<< " (" << glcm_direction_field_data->width() << "x" 
+				<< glcm_direction_field_data->height() << "x" 
+				<< glcm_direction_field_data->depth() << ")" << std::endl
+		);
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << "Error loading GLCM direction field: " << e.what() << std::endl;
+		throw;
+	}
+}
+
+void Environment::clear_glcm_direction_field()
+{
+	GLCMFeature::direction_field = nullptr;
+	glcm_direction_field_data.reset();
 }
 
 bool Environment::parse_fpimage_options_raw_inputs(std::string& error_message)

--- a/src/nyx/environment.cpp
+++ b/src/nyx/environment.cpp
@@ -474,6 +474,9 @@ bool Environment::parse_cmdline(int argc, char** argv)
 			|| find_string_argument(i, clo_RESULTFNAME, nyxus_result_fname)
 			|| find_string_argument(i, clo_CLI_DIM, raw_dim)
 
+			|| find_string_argument(i, clo_FMAPS, raw_fmaps)
+			|| find_string_argument(i, clo_FMAPS_RADIUS, raw_fmaps_radius)
+
 #ifdef CHECKTIMING
 			|| find_string_argument(i, clo_EXCLUSIVETIMING, rawExclusiveTiming)
 #endif
@@ -898,6 +901,27 @@ bool Environment::parse_cmdline(int argc, char** argv)
 	else
 	{
 		ibsi_compliance = false;
+	}
+
+	//==== Parse feature maps options
+	// --fmaps: enable/disable sliding-kernel feature extraction
+	if (!raw_fmaps.empty())
+	{
+		std::string tmp = raw_fmaps;
+		std::transform(tmp.begin(), tmp.end(), tmp.begin(), ::tolower);
+		fmaps_mode = (tmp == "true" || tmp == "1" || tmp == "on");
+	}
+
+	// --fmaps_radius: kernel half-width (full kernel size = 2*radius+1)
+	if (!raw_fmaps_radius.empty())
+	{
+		int r = 0;
+		if (sscanf(raw_fmaps_radius.c_str(), "%d", &r) != 1 || r < 1)
+		{
+			std::cerr << "Error: " << clo_FMAPS_RADIUS << "=" << raw_fmaps_radius << ": expecting an integer >= 1\n";
+			return false;
+		}
+		fmaps_kernel_radius = r;
 	}
 
 	// Success

--- a/src/nyx/environment.h
+++ b/src/nyx/environment.h
@@ -148,6 +148,21 @@ public:
 	ResultOptions resultOptions;
 	std::tuple<bool, std::optional<std::string>> parse_result_options_4cli ();
 
+	// Feature maps (fmaps) options — sliding-kernel feature extraction mode
+	bool fmaps_mode = false;			///< When true, features are computed per kernel position (spatial maps)
+	int fmaps_kernel_radius = 2;		///< Half-width of the kernel; full kernel side = 2*radius+1
+	std::string raw_fmaps;				///< Raw CLI string for --fmaps flag (parsed in process_input)
+	std::string raw_fmaps_radius;		///< Raw CLI string for --fmaps_radius (parsed in process_input)
+
+	/// @brief Returns the kernel side length: 2*radius+1
+	int fmaps_kernel_size() const { return 2 * fmaps_kernel_radius + 1; }
+
+	/// @brief Returns true if fmaps mode conflicts with the current save option.
+	bool fmaps_prevents_arrow() const
+	{
+		return fmaps_mode && (saveOption == Nyxus::SaveOption::saveArrowIPC || saveOption == Nyxus::SaveOption::saveParquet);
+	}
+
 	// feature settings
 	Fsettings fsett_PixelIntensity,
 		fsett_BasicMorphology,

--- a/src/nyx/environment.h
+++ b/src/nyx/environment.h
@@ -128,7 +128,10 @@ public:
 
 	// implementation of GLCM feature options
 	bool parse_glcm_options_raw_inputs (std::string& error_message);
+	void load_glcm_direction_field();
+	void clear_glcm_direction_field();
 	GLCMoptions glcmOptions;
+	std::unique_ptr<SimpleCube<float>> glcm_direction_field_data;
 
 	// implementation of nested ROI options
 	bool parse_nested_options_raw_inputs (std::string& error_message);

--- a/src/nyx/features/glcm.cpp
+++ b/src/nyx/features/glcm.cpp
@@ -7,10 +7,94 @@ using namespace Nyxus;
 
 bool GLCMFeature::symmetric_glcm = false;
 std::vector<int> GLCMFeature::angles = { 0, 45, 90, 135 };
+const SimpleCube<float>* GLCMFeature::direction_field = nullptr;
 
 GLCMFeature::GLCMFeature() : FeatureMethod("GLCMFeature")
 {
 	provide_features(GLCMFeature::featureset);
+}
+
+/// @brief Set the custom direction field for GLCM calculation
+/// 
+/// PURPOSE: Enable spatially-varying GLCM directions instead of fixed angles
+/// 
+/// WHAT THIS DOES:
+/// - When direction_field is nullptr: Uses traditional fixed angles (0°, 45°, 90°, 135°)
+/// - When direction_field is set: Uses custom per-pixel directions from the field
+/// 
+/// WHY USE CUSTOM DIRECTIONS?
+/// - Follow tissue structure (e.g., muscle fibers, neural tracts)
+/// - Adapt to image features (e.g., gradient directions)
+/// - Improve texture characterization in anisotropic structures
+/// 
+/// @param dir_field Pointer to a SimpleCube containing direction vectors
+///                  Shape: (width, height, 2) where depth dimension holds [dx, dy]
+///                  Values should be normalized unit vectors (magnitude = 1)
+///                  Pass nullptr to revert to traditional fixed-angle GLCM
+/// 
+/// EXAMPLE:
+///   auto dirField = DirectionFieldLoader::load("myfield.nii.gz");
+///   GLCMFeature::set_direction_field(dirField.get());
+///   // Now GLCM will use custom directions at each pixel
+///   
+///   GLCMFeature::set_direction_field(nullptr);
+///   // Back to traditional fixed angles
+void GLCMFeature::set_direction_field(const SimpleCube<float>* dir_field)
+{
+	direction_field = dir_field;
+}
+
+/// @brief Convert angle (in degrees) to pixel offset for GLCM calculation
+/// 
+/// PURPOSE: Translate user-friendly angle notation to pixel coordinates
+/// 
+/// WHAT IS AN OFFSET?
+/// - GLCM looks at pairs of pixels separated by a direction and distance
+/// - Direction: specified by angle (0°, 45°, 90°, 135°)
+/// - Distance: specified by offset (usually 1 pixel)
+/// - This function converts angle → (dx, dy) pixel offset
+/// 
+/// DIRECTION MAPPING:
+/// - 0°   (→): Look to the right      → dx=offset, dy=0
+/// - 45°  (↗): Look diagonal up-right → dx=offset, dy=offset
+/// - 90°  (↑): Look up                → dx=0, dy=offset
+/// - 135° (↖): Look diagonal up-left  → dx=-offset, dy=offset
+/// 
+/// EXAMPLE:
+///   int dx, dy;
+///   angle_to_offset(45, 2, dx, dy);  // dx=2, dy=2 (diagonal, 2 pixels away)
+///   angle_to_offset(0, 1, dx, dy);   // dx=1, dy=0 (horizontal, 1 pixel away)
+/// 
+/// @param angle One of {0, 45, 90, 135} degrees
+/// @param offset Distance in pixels (usually 1)
+/// @param dx Output: x-component of offset vector
+/// @param dy Output: y-component of offset vector
+/// 
+/// NOTE: Invalid angles default to dx=dy=0 and print error message
+void GLCMFeature::angle_to_offset(int angle, int offset, int& dx, int& dy) const
+{
+	switch (angle)
+	{
+	case 0:
+		dx = offset;
+		dy = 0;
+		break;
+	case 45:
+		dx = offset;
+		dy = offset;
+		break;
+	case 90:
+		dx = 0;
+		dy = offset;
+		break;
+	case 135:
+		dx = -offset;
+		dy = offset;
+		break;
+	default:
+		std::cerr << "Cannot create co-occurence matrix for angle " << angle << ": unsupported angle\n";
+		dx = dy = 0;
+	}
 }
 
 void GLCMFeature::calculate (LR& r, const Fsettings& s)
@@ -94,9 +178,16 @@ void GLCMFeature::calculate (LR& r, const Fsettings& s)
 		return;
 	}
 
-	// Calculate features for all the directions
-	for (auto a : angles)
-		Extract_Texture_Features2 (s, a, r.aux_image_matrix, offset, r.aux_min, r.aux_max);
+		// Calculate features for all the directions
+		// MODE 1: Custom direction field (per-pixel directions)
+		if (direction_field != nullptr) {
+		calculateCoocMatFromDirectionField(s, r.aux_image_matrix, offset, r.aux_min, r.aux_max);
+	}
+	// MODE 2: Traditional angle-based (existing behavior)
+	else {
+		for (auto a : angles)
+			Extract_Texture_Features2 (s, a, r.aux_image_matrix, offset, r.aux_min, r.aux_max);
+	}
 }
 
 void GLCMFeature::clear_result_buffers()
@@ -226,34 +317,16 @@ void GLCMFeature::parallel_process_1_batch (size_t start, size_t end, std::vecto
 
 void GLCMFeature::Extract_Texture_Features2 (const Fsettings& s, int angle, const ImageMatrix& grays, int offset, PixIntens min_val, PixIntens max_val)
 {
-	int nrows = grays.height;
-	int ncols = grays.width;
-
-	// Compute the gray-tone spatial dependence matrix 
+	// Convert angle to direction offset
 	int dx, dy;
-	switch (angle)
-	{
-	case 0:
-		dx = offset;
-		dy = 0;
-		break;
-	case 45:
-		dx = offset;
-		dy = offset;
-		break;
-	case 90:
-		dx = 0;
-		dy = offset;
-		break;
-	case 135:
-		dx = -offset;
-		dy = offset;
-		break;
-	default:
-		std::cerr << "Cannot create co-occurence matrix for angle " << angle << ": unsupported angle\n";
-		return;
-	}
+	angle_to_offset(angle, offset, dx, dy);
+	
+	// Call the direct version
+	Extract_Texture_Features2_Direct(s, dx, dy, grays, min_val, max_val);
+}
 
+void GLCMFeature::Extract_Texture_Features2_Direct (const Fsettings& s, int dx, int dy, const ImageMatrix& grays, PixIntens min_val, PixIntens max_val)
+{
 	calculateCoocMatAtAngle (P_matrix, s, dx, dy, grays, min_val, max_val);
 
 	// Blank cooc-matrix? -- no point to use it, assign each feature value '0' and return.
@@ -474,11 +547,293 @@ void GLCMFeature::calculateCoocMatAtAngle(
 			}
 		}
 
-	// Calculate sum of GLCM for feature calculations
+		// Calculate sum of GLCM for feature calculations
 	sum_p = 0;
 	for (int i = 0; i < GLCM.width(); ++i)
 		for (int j = 0; j < GLCM.height(); ++j)
 			sum_p += GLCM.xy(i, j);
+}
+
+/// @brief Calculate averaged direction from direction field
+/// 
+/// PURPOSE: Convert per-pixel directions into a single representative direction
+/// 
+/// APPROACH:
+/// - Average all dx values across ROI
+/// - Average all dy values across ROI
+/// - Normalize result to unit vector
+/// - Scale by offset
+/// 
+/// @param grays Image to process
+/// @param offset Pixel distance multiplier
+/// @return Pair of (dx, dy) as averaged direction
+
+/// @brief Helper to find closest canonical direction index
+/// Handles GLCM's 180° rotational symmetry by normalizing to lower hemisphere
+/// @param dx, dy Direction vector components
+/// @return Index 0-3 corresponding to angles {0°, 45°, 90°, 135°}
+static int find_closest_canonical_direction(float dx, float dy)
+{
+	// Canonical directions: 0°, 45°, 90°, 135°
+	// In image coordinates: right, down-right, down, down-left
+	const float CANONICAL_DIRS[4][2] = {
+		{1.0f, 0.0f},         // 0° = right
+		{0.707107f, 0.707107f},  // 45° = down-right  
+		{0.0f, 1.0f},         // 90° = down
+		{-0.707107f, 0.707107f}  // 135° = down-left
+	};
+	
+	// Normalize input
+	float mag = std::sqrt(dx*dx + dy*dy);
+	if (mag < 1e-6f) return 0; // degenerate: default to 0°
+	float ndx = dx / mag;
+	float ndy = dy / mag;
+	
+		// Handle GLCM's 180° symmetry: flip vectors pointing upward or left
+	// This ensures 180°→0°, 225°→45°, 270°→90°, 315°→135°
+	// Flip if pointing up (dy<0) OR pointing left on horizontal (dy==0 and dx<0)
+	if (ndy < 0 || (ndy == 0 && ndx < 0))
+	{
+		ndx = -ndx;
+		ndy = -ndy;
+	}
+	
+	// Find direction with highest dot product (most aligned)
+	int best_dir = 0;
+	float best_dot = -1e10f;
+	for (int i = 0; i < 4; i++)
+	{
+		float dot = ndx * CANONICAL_DIRS[i][0] + ndy * CANONICAL_DIRS[i][1];
+		if (dot > best_dot)
+		{
+			best_dot = dot;
+			best_dir = i;
+		}
+	}
+	return best_dir;
+}
+
+void GLCMFeature::calculateCoocMatFromDirectionField(
+	const Fsettings& s,
+	const ImageMatrix& grays,
+	int offset,
+	PixIntens grays_min_val,
+	PixIntens grays_max_val)
+{
+	int nGreys = s[(int)NyxSetting::GREYDEPTH].ival;
+	bool ibsi = s[(int)NyxSetting::IBSI].bval;
+
+	// Grey binning
+	int rows = grays.height,
+		cols = grays.width;
+
+	ImageMatrix M;
+	M.allocate(grays.width, grays.height);
+	pixData& D = M.WriteablePixels();
+	auto& imR = grays.ReadablePixels();
+
+	// Bin intensities
+	auto greyInfo = nGreys;
+	auto greyInfo_localFeature = nGreys;
+	if (greyInfo_localFeature != 0 && greyInfo != greyInfo_localFeature)
+		greyInfo = greyInfo_localFeature;
+	if (ibsi)
+		greyInfo = 0;
+	bin_intensities(D, imR, grays_min_val, grays_max_val, greyInfo);
+
+	// Allocate intensities vector
+	if (radiomics_grey_binning(greyInfo))
+	{
+		std::unordered_set<PixIntens> U(D.begin(), D.end());
+		U.erase(0);
+		I.assign(U.begin(), U.end());
+		std::sort(I.begin(), I.end());
+	}
+	else if (matlab_grey_binning(greyInfo))
+	{
+		auto n_matlab_levels = greyInfo;
+		I.resize(n_matlab_levels);
+		for (int i = 0; i < n_matlab_levels; i++)
+			I[i] = i + 1;
+	}
+	else
+	{
+		auto ibsi_levels_it = std::max_element(D.begin(), D.end());
+		auto n_ibsi_levels = *ibsi_levels_it;
+		I.resize(n_ibsi_levels);
+		for (int i = 0; i < n_ibsi_levels; i++)
+			I[i] = i + 1;
+	}
+
+	// Allocate 4 GLCM matrices, one for each canonical direction
+	SimpleMatrix<double> P_matrices[4];
+	int matrix_size = (int)I.size();
+	for (int dir = 0; dir < 4; dir++)
+	{
+		P_matrices[dir].allocate(matrix_size, matrix_size);
+		std::fill(P_matrices[dir].begin(), P_matrices[dir].end(), 0.0);
+	}
+
+	int w = M.width;
+	int h = M.height;
+
+	// Canonical direction offsets
+	const int CANONICAL_OFFSETS[4][2] = {
+		{offset, 0},      // 0°
+		{offset, offset}, // 45°
+		{0, offset},      // 90°
+		{-offset, offset} // 135°
+	};
+
+	// Track which matrices are actually used
+	bool matrix_used[4] = {false, false, false, false};
+	double matrix_sums[4] = {0.0, 0.0, 0.0, 0.0};
+
+	// Build GLCMs by binning each pixel to its nearest canonical direction
+	for (int row = 0; row < h; row++)
+	{
+		for (int col = 0; col < w; col++)
+		{
+			// Get direction at this pixel
+			float dx_raw = direction_field->zyx(0, row, col);
+			float dy_raw = direction_field->zyx(1, row, col);
+
+			// Find which canonical direction this pixel belongs to
+			int dir_bin = find_closest_canonical_direction(dx_raw, dy_raw);
+
+			// Use the canonical direction offset
+			int dx = CANONICAL_OFFSETS[dir_bin][0];
+			int dy = CANONICAL_OFFSETS[dir_bin][1];
+
+			if (row + dy >= 0 && row + dy < h && col + dx >= 0 && col + dx < w)
+			{
+				PixIntens lvl_b = D.yx(row, col);
+				PixIntens lvl_a = D.yx(row + dy, col + dx);
+
+				if (ibsi_grey_binning(greyInfo) && (lvl_a == 0 || lvl_b == 0))
+					continue;
+
+				int a = lvl_a, b = lvl_b;
+
+				if (radiomics_grey_binning(greyInfo))
+				{
+					if (a == 0 || b == 0) continue;
+					auto lower = std::lower_bound(I.begin(), I.end(), a);
+					a = int(lower - I.begin());
+					lower = std::lower_bound(I.begin(), I.end(), b);
+					b = int(lower - I.begin());
+				}
+				else
+				{
+					a = a - 1;
+					b = b - 1;
+				}
+
+				P_matrices[dir_bin].xy(a, b) += 1.0;
+				matrix_used[dir_bin] = true;
+
+				if (GLCMFeature::symmetric_glcm || radiomics_grey_binning(greyInfo) || ibsi_grey_binning(greyInfo))
+					P_matrices[dir_bin].xy(b, a) += 1.0;
+			}
+		}
+	}
+
+	// Calculate sums for each matrix
+	for (int dir = 0; dir < 4; dir++)
+	{
+		if (!matrix_used[dir]) continue;
+		for (int i = 0; i < matrix_size; ++i)
+			for (int j = 0; j < matrix_size; ++j)
+				matrix_sums[dir] += P_matrices[dir].xy(i, j);
+	}
+
+	// Compute features for each canonical direction (0, 45, 90, 135)
+	// Output exactly 4 values per feature, using NaN for unused directions
+	for (int dir = 0; dir < 4; dir++)
+	{
+		if (!matrix_used[dir] || matrix_sums[dir] == 0)
+		{
+			// Direction not used - output NaN placeholder
+			double nan_val = std::numeric_limits<double>::quiet_NaN();
+			fvals_ASM.push_back(nan_val);
+			fvals_contrast.push_back(nan_val);
+			fvals_correlation.push_back(nan_val);
+			fvals_energy.push_back(nan_val);
+			fvals_homo.push_back(nan_val);
+			fvals_variance.push_back(nan_val);
+			fvals_IDM.push_back(nan_val);
+			fvals_sum_avg.push_back(nan_val);
+			fvals_sum_entropy.push_back(nan_val);
+			fvals_entropy.push_back(nan_val);
+			fvals_diff_var.push_back(nan_val);
+			fvals_diff_entropy.push_back(nan_val);
+			fvals_diff_avg.push_back(nan_val);
+			fvals_meas_corr1.push_back(nan_val);
+			fvals_meas_corr2.push_back(nan_val);
+			fvals_acor.push_back(nan_val);
+			fvals_cluprom.push_back(nan_val);
+			fvals_clushade.push_back(nan_val);
+			fvals_clutend.push_back(nan_val);
+			fvals_sum_var.push_back(nan_val);
+			fvals_dis.push_back(nan_val);
+			fvals_hom2.push_back(nan_val);
+			fvals_idmn.push_back(nan_val);
+			fvals_id.push_back(nan_val);
+			fvals_idn.push_back(nan_val);
+			fvals_iv.push_back(nan_val);
+			fvals_jave.push_back(nan_val);
+			fvals_je.push_back(nan_val);
+			fvals_jmax.push_back(nan_val);
+			fvals_jvar.push_back(nan_val);
+			continue;
+		}
+
+		// Set current matrix and sum for feature calculations
+		P_matrix = P_matrices[dir];
+		sum_p = matrix_sums[dir];
+
+		// Calculate helper values
+		calculatePxpmy();
+		calculate_by_row_mean();
+
+		// Compute all Haralick statistics
+		fvals_ASM.push_back(f_asm(P_matrix));
+		fvals_contrast.push_back(f_contrast(P_matrix));
+		fvals_correlation.push_back(f_corr());
+		fvals_energy.push_back(f_energy(P_matrix));
+		fvals_homo.push_back(f_homogeneity());
+		fvals_variance.push_back(f_var(P_matrix));
+		fvals_IDM.push_back(f_idm());
+		fvals_sum_avg.push_back(f_savg());
+		fvals_sum_entropy.push_back(f_sentropy());
+		fvals_entropy.push_back(f_entropy(P_matrix));
+		fvals_diff_var.push_back(f_dvar(P_matrix));
+		fvals_diff_entropy.push_back(f_dentropy(P_matrix));
+		fvals_diff_avg.push_back(f_difference_avg());
+		fvals_meas_corr1.push_back(f_info_meas_corr1(P_matrix));
+		fvals_meas_corr2.push_back(f_info_meas_corr2(P_matrix));
+		fvals_acor.push_back(f_GLCM_ACOR(P_matrix));
+		fvals_cluprom.push_back(f_GLCM_CLUPROM());
+		fvals_clushade.push_back(f_GLCM_CLUSHADE());
+
+		double clutend = f_GLCM_CLUTEND();
+		fvals_clutend.push_back(clutend);
+		fvals_sum_var.push_back(clutend);
+
+		fvals_dis.push_back(f_GLCM_DIS(P_matrix));
+		fvals_hom2.push_back(f_GLCM_HOM2(P_matrix));
+		fvals_idmn.push_back(f_GLCM_IDMN());
+		fvals_id.push_back(f_GLCM_ID());
+		fvals_idn.push_back(f_GLCM_IDN());
+		fvals_iv.push_back(f_GLCM_IV());
+
+		double jave = f_GLCM_JAVE();
+		fvals_jave.push_back(jave);
+
+		fvals_je.push_back(f_GLCM_JE(P_matrix));
+		fvals_jmax.push_back(f_GLCM_JMAX(P_matrix));
+		fvals_jvar.push_back(f_GLCM_JVAR(P_matrix, jave));
+	}
 }
 
 void GLCMFeature::calculatePxpmy()
@@ -495,7 +850,6 @@ void GLCMFeature::calculatePxpmy()
 	std::fill(kValuesSum.begin(), kValuesSum.end(), 0);
 
 	kValuesDiff.resize (Ng, 0);
-	std::fill (kValuesDiff.begin(), kValuesDiff.end(), 0);
 
 	for (int x = 0; x < Ng; x++)
 		for (int y = 0; y < Ng; y++)

--- a/src/nyx/features/glcm.h
+++ b/src/nyx/features/glcm.h
@@ -4,6 +4,7 @@
 #include "../dataset.h"
 #include "../roi_cache.h"
 #include "image_matrix.h"
+#include "image_cube.h"
 #include "../feature_method.h"
 #include "../feature_settings.h"
 #include "texture_feature.h"
@@ -127,13 +128,23 @@ public:
 	static std::vector<int> angles;	// default value: {0,45,90,135} (the supreset)
 	double sum_p = 0; // sum of P matrix for normalization
 
+	// Custom direction field support (static so it's shared across all instances)
+	// SimpleCube with depth=2 for 2D (dx, dy) or depth=3 for 3D (dx, dy, dz)
+	// Access: direction_field->zyx(0, row, col) = dx, direction_field->zyx(1, row, col) = dy
+	static const SimpleCube<float>* direction_field;
+
 	static bool required(const FeatureSet& fs)
 	{
 		return fs.anyEnabled(GLCMFeature::featureset);
 	}
 
-	GLCMFeature();
+		GLCMFeature();
 	void calculate (LR& roi, const Fsettings& settings);
+	
+	// Set custom direction field for per-pixel GLCM directions
+	// For 2D: pass SimpleCube with depth=2 (dx, dy)
+	// For 3D: pass SimpleCube with depth=3 (dx, dy, dz)
+	void set_direction_field(const SimpleCube<float>* dir_field);
 	void osized_add_online_pixel(size_t x, size_t y, uint32_t intensity);
 	void osized_calculate (LR& roi, const Fsettings& settings, ImageLoader& imloader);
 	void save_value(std::vector<std::vector<double>>& feature_vals);
@@ -156,6 +167,25 @@ private:
 		bool ibsi);
 
 	void Extract_Texture_Features2 (const Fsettings& settings, int angle, const ImageMatrix& grays, int offset, PixIntens min_val, PixIntens max_val);
+	
+	// Refactored version that accepts dx/dy directly
+	void Extract_Texture_Features2_Direct (
+		const Fsettings& settings, 
+		int dx, int dy,
+		const ImageMatrix& grays, 
+		PixIntens min_val, 
+		PixIntens max_val);
+	
+	// Build GLCM from custom direction field
+	void calculateCoocMatFromDirectionField(
+		const Fsettings& settings,
+		const ImageMatrix& grays,
+		int offset,
+		PixIntens min_val,
+		PixIntens max_val);
+	
+	// Helper to convert angle to offset
+	void angle_to_offset(int angle, int offset, int& dx, int& dy) const;
 
 	void calculateCoocMatAtAngle(
 		// out

--- a/src/nyx/globals.h
+++ b/src/nyx/globals.h
@@ -49,6 +49,24 @@ namespace Nyxus
 		const SaveOption saveOption,
 		const std::string& outputPath);
 
+	// feature maps 2D workflow
+	int processDataset_2D_fmaps(
+		Environment& env,
+		const std::vector<std::string>& intensFiles,
+		const std::vector<std::string>& labelFiles,
+		int numReduceThreads,
+		const SaveOption saveOption,
+		const std::string& outputPath);
+
+	// feature maps 3D workflow
+	int processDataset_3D_fmaps(
+		Environment& env,
+		const std::vector <Imgfile3D_layoutA>& intensFiles,
+		const std::vector <Imgfile3D_layoutA>& labelFiles,
+		int numReduceThreads,
+		const SaveOption saveOption,
+		const std::string& outputPath);
+
 	// single-segment 2D workflow
 	int processDataset_2D_wholeslide(
 		Environment & env,
@@ -74,6 +92,10 @@ namespace Nyxus
 		const SaveOption saveOption,
 		const std::string& outputPath);
 
+	// Reset CSV header state between workflow invocations (fixes static flag persistence).
+	// Must be called before any worker threads begin processing (not thread-safe).
+	void reset_csv_header_state();
+
 	std::string getPureFname(const std::string& fpath);
 	bool gatherRoisMetrics(int slide_idx, const std::string& intens_fpath, const std::string& label_fpath, Environment & env, ImageLoader & L);
 	bool gather_wholeslide_metrics(const std::string& intens_fpath, ImageLoader& L, LR& roi);
@@ -89,7 +111,10 @@ namespace Nyxus
 	bool scan_trivial_wholevolume (LR& vroi, const std::string& intens_fpath, ImageLoader& ldr);	
 	bool scan_trivial_wholevolume_anisotropic (LR& vroi, const std::string& intens_fpath, ImageLoader& ldr, double aniso_x, double aniso_y, double aniso_z);
 
+	bool scanTrivialRois (const std::vector<int>& batch_labels, const std::string& intens_fpath, const std::string& label_fpath, Environment & env, ImageLoader & ldr);
+	bool scanTrivialRois_anisotropic (const std::vector<int>& batch_labels, const std::string& intens_fpath, const std::string& label_fpath, Environment & env, ImageLoader & ldr, double sf_x, double sf_y);
 	bool scanTrivialRois_3D (Environment& env, const std::vector<int>& batch_labels, const std::string& intens_fpath, const std::string& label_fpath, size_t t_index);
+	bool scanTrivialRois_3D_anisotropic (Environment& env, const std::vector<int>& batch_labels, const std::string& intens_fpath, const std::string& label_fpath, size_t t_index, double aniso_x, double aniso_y, double aniso_z);
 	void dump_roi_metrics (const int dim, const std::string& output_dir, const size_t ram_limit, const std::string& seg_fpath, const Uniqueids& uniqueLabels, const Roidata& roiData);
 	void dump_roi_pixels (const int dim, const std::string& output_dir, const std::vector<int>& batch_labels, const std::string& seg_fpath, const Uniqueids& uniqueLabels, const Roidata& roiData);
 	void dump_2d_image_with_halfcontour(
@@ -134,7 +159,92 @@ namespace Nyxus
 	extern const std::vector<std::string> mandatory_output_columns;
 	bool save_features_2_csv (Environment & env, const std::string & intFpath, const std::string & segFpath, const std::string & outputDir, size_t t_index, bool need_aggregation);
 	bool save_features_2_csv_wholeslide (Environment & env, const LR & r, const std::string & ifpath, const std::string & mfpath, const std::string & outdir, size_t t_index);
+
+	// Shared helpers for feature column names and value collection (eliminates duplication across output paths)
+	std::vector<std::string> get_feature_column_names (Environment & env, const std::vector<std::tuple<std::string, int>> & F);
+	std::vector<double> collect_feature_values (const LR & r, const std::vector<std::tuple<std::string, int>> & F);
+
+	/// @brief RAII guard that temporarily replaces env's ROI data with child data and restores on destruction.
+	/// Ensures env is restored even if an exception is thrown during child ROI processing.
+	struct EnvRoiSwapGuard
+	{
+		Environment & env;
+		Uniqueids savedUniqueLabels;
+		Roidata savedRoiData;
+
+		EnvRoiSwapGuard (Environment & e, std::unordered_set<int> childLabels, std::unordered_map<int, LR> childRoiData)
+			: env(e)
+		{
+			savedUniqueLabels = std::move(env.uniqueLabels);
+			savedRoiData = std::move(env.roiData);
+			env.uniqueLabels = std::move(childLabels);
+			env.roiData = std::move(childRoiData);
+		}
+
+		~EnvRoiSwapGuard ()
+		{
+			env.uniqueLabels = std::move(savedUniqueLabels);
+			env.roiData = std::move(savedRoiData);
+		}
+
+		EnvRoiSwapGuard (const EnvRoiSwapGuard &) = delete;
+		EnvRoiSwapGuard & operator= (const EnvRoiSwapGuard &) = delete;
+	};
+
+	// Feature maps — per-child metadata linking a child ROI back to its parent
+	/// @brief Tracks which parent ROI a child belongs to and the global image
+	/// coordinates of the kernel center that produced it.
+	struct FmapChildInfo
+	{
+		int parent_label;	///< Label of the parent ROI this child was generated from
+		int center_x;		///< Global x-coordinate of the kernel center
+		int center_y;		///< Global y-coordinate of the kernel center
+		int center_z = 0;	///< Global z-coordinate of the kernel center (unused in 2D)
+	};
+
+	/// @brief Shared helper: swaps child ROI data into env, reduces features, and outputs fmap arrays.
+	/// Used by both 2D and 3D fmaps workflows.
+	void reduceAndOutputChildRois_fmaps (
+		Environment & env,
+		std::unordered_set<int> childLabels,
+		std::unordered_map<int, LR> childRoiData,
+		const std::unordered_map<int, FmapChildInfo> & childToParentMap,
+		const std::string & intens_fpath,
+		const std::string & label_fpath,
+		int parentLab,
+		int parentXmin, int parentYmin, int parentZmin,
+		int parentW, int parentH, int parentD);
+
+	/// @brief Generates 2D child ROIs by sliding a kernel across a parent ROI.
+	int generateChildRois (
+		const LR & parent,
+		int kernel_size,
+		std::unordered_set<int> & childLabels,
+		std::unordered_map<int, LR> & childRoiData,
+		std::unordered_map<int, FmapChildInfo> & childToParentMap,
+		int64_t startLabel);
+	/// @brief Generates 3D child ROIs by sliding a cubic kernel across a parent ROI.
+	int generateChildRois_3D (
+		const LR & parent,
+		int kernel_size,
+		std::unordered_set<int> & childLabels,
+		std::unordered_map<int, LR> & childRoiData,
+		std::unordered_map<int, FmapChildInfo> & childToParentMap,
+		int64_t startLabel);
 	bool save_features_2_buffer (ResultsCache &results_cache, Environment &env, size_t t_index);
+	/// @brief Writes fmaps child ROI features into flat arrays for the Python buffer output path.
+	void save_features_2_fmap_arrays (
+		ResultsCache & rescache,
+		Environment & env,
+		const std::string & intens_name,
+		const std::string & seg_name,
+		int parent_label,
+		int parent_xmin, int parent_ymin, int parent_zmin,
+		int parent_w, int parent_h, int parent_d,
+		int kernel_size,
+		const std::unordered_set<int> & childLabels,
+		const std::unordered_map<int, LR> & childRoiData,
+		const std::unordered_map<int, FmapChildInfo> & childToParentMap);
 	bool save_features_2_buffer_wholeslide(
 		ResultsCache& rescache,
 		Environment& env, 

--- a/src/nyx/helpers/helpers.h
+++ b/src/nyx/helpers/helpers.h
@@ -336,9 +336,9 @@ namespace Nyxus
 	/// @return Squeezed intensity within range [0,255]
 	inline unsigned int to_grayscale (unsigned int i, unsigned int min_i, unsigned int i_range, unsigned int n_levels, bool disable_binning=false)
 	{
-		if (disable_binning) 
+		if (disable_binning)
 			return i;
-		
+
 		double pi = ((double(i-min_i) / double(i_range) * double(n_levels)));
 		unsigned int new_pi = (unsigned int)pi;
 		return new_pi;

--- a/src/nyx/main_nyxus.cpp
+++ b/src/nyx/main_nyxus.cpp
@@ -80,6 +80,13 @@ int main (int argc, char** argv)
 
 		// Process the image data
 		int errorCode = 0;
+		// Feature maps mode outputs spatial arrays and is only supported via the Python API
+		if (env.fmaps_mode)
+		{
+			std::cerr << "Error: feature maps (fmaps) mode is only supported via the Python API.\n";
+			return 1;
+		}
+
 		if (env.singleROI)
 		{
 			errorCode = processDataset_2D_wholeslide(
@@ -180,7 +187,15 @@ int main (int argc, char** argv)
 					return 1;
 				}
 
-				int errorCode = processDataset_3D_segmented(
+				int errorCode = 0;
+				// Feature maps mode outputs spatial arrays and is only supported via the Python API
+				if (env.fmaps_mode)
+				{
+					std::cerr << "Error: feature maps (fmaps) mode is only supported via the Python API.\n";
+					return 1;
+				}
+
+				errorCode = processDataset_3D_segmented(
 					env,
 					intensFiles,
 					labelFiles,

--- a/src/nyx/main_nyxus.cpp
+++ b/src/nyx/main_nyxus.cpp
@@ -54,6 +54,13 @@ int main (int argc, char** argv)
 
 	// prepare feature settings
 	env.compile_feature_settings();
+
+	// Load GLCM direction field if specified via command line
+	if (!env.glcmOptions.directionFieldPath.empty())
+	{
+		VERBOSLVL1(env.get_verbosity_level(), std::cout << "Loading GLCM direction field from command line...\n");
+		env.load_glcm_direction_field();
+	}
 		
 	if (env.dim() == 2)
 	{

--- a/src/nyx/output_2_buffer.cpp
+++ b/src/nyx/output_2_buffer.cpp
@@ -153,14 +153,17 @@ namespace Nyxus
 		const std::unordered_map<int, LR> & childRoiData,
 		const std::unordered_map<int, FmapChildInfo> & childToParentMap)
 	{
+
 		int half = kernel_size / 2;
-		// Map dimensions = valid convolution output size
+		// 2D/3D aware map size calculation
+		bool is3d = (parent_d > 1);
 		int map_w = parent_w - kernel_size + 1;
 		int map_h = parent_h - kernel_size + 1;
-		int map_d = parent_d - kernel_size + 1;
+		int map_d = is3d ? (parent_d - kernel_size + 1) : 1;
 
-		if (map_w <= 0 || map_h <= 0 || map_d <= 0)
+		if (map_w <= 0 || map_h <= 0 || (is3d && map_d <= 0)) {
 			return;
+		}
 
 		std::vector<std::tuple<std::string, int>> F = env.theFeatureSet.getEnabledFeatures();
 		std::vector<std::string> feature_names = get_feature_column_names(env, F);
@@ -171,34 +174,40 @@ namespace Nyxus
 		std::vector<double> feature_data(n_features * map_size, std::numeric_limits<double>::quiet_NaN());
 
 		// Fill in values from child ROIs
+				
+
 		for (auto l : childLabels)
 		{
 			auto it_roi = childRoiData.find(l);
-			if (it_roi == childRoiData.end())
+			if (it_roi == childRoiData.end()) {
 				continue;
+			}
 			const LR& r = it_roi->second;
-			if (r.blacklisted)
+			if (r.blacklisted) {
 				continue;
+			}
 
 			auto it_map = childToParentMap.find(l);
-			if (it_map == childToParentMap.end())
+			if (it_map == childToParentMap.end()) {
 				continue;
+			}
 
 			const FmapChildInfo& info = it_map->second;
 
 			// Convert global center coords to map indices
 			int map_col = info.center_x - parent_xmin - half;
 			int map_row = info.center_y - parent_ymin - half;
-			int map_z   = info.center_z - parent_zmin - half;
+			int map_z   = is3d ? (info.center_z - parent_zmin - half) : 0;
 
 			if (map_col < 0 || map_col >= map_w ||
 				map_row < 0 || map_row >= map_h ||
-				map_z < 0 || map_z >= map_d)
+				(is3d && (map_z < 0 || map_z >= map_d))) {
 				continue;
+			}
 
 			size_t voxel_idx = (size_t)map_z * map_h * map_w + (size_t)map_row * map_w + map_col;
 
-			// Collect feature values for this child
+						// Collect feature values for this child
 			auto vals = collect_feature_values(r, F);
 			for (size_t fi = 0; fi < n_features && fi < vals.size(); fi++)
 				feature_data[fi * map_size + voxel_idx] = force_finite_number(vals[fi], env.resultOptions.noval());
@@ -217,7 +226,10 @@ namespace Nyxus
 		result.origin_z = parent_zmin + half;
 		result.feature_names = std::move(feature_names);
 		result.feature_data = std::move(feature_data);
-		rescache.get_fmapArrayResults().push_back(std::move(result));
+        rescache.get_fmapArrayResults().push_back(std::move(result));
 	}
+// end of save_features_2_fmap_arrays
 
-}
+} // namespace Nyxus
+
+

--- a/src/nyx/output_2_buffer.cpp
+++ b/src/nyx/output_2_buffer.cpp
@@ -23,6 +23,31 @@ namespace Nyxus
 {
 	static std::mutex mx1;
 
+	/// @brief Writes feature header columns for all enabled features to a ResultsCache.
+	/// Uses get_feature_column_names() as the single source of truth.
+	void write_feature_header_buffer (
+		ResultsCache & rescache,
+		Environment & env,
+		const std::vector<std::tuple<std::string, int>> & F)
+	{
+		auto cols = get_feature_column_names(env, F);
+		for (const auto& c : cols)
+			rescache.add_to_header(c);
+	}
+
+	/// @brief Writes all feature values for a single ROI to a ResultsCache.
+	/// Uses collect_feature_values() as the single source of truth.
+	void write_feature_values_buffer (
+		ResultsCache & rescache,
+		const LR & r,
+		const std::vector<std::tuple<std::string, int>> & F,
+		Environment & env)
+	{
+		auto vals = collect_feature_values(r, F);
+		for (auto v : vals)
+			rescache.add_numeric(Nyxus::force_finite_number(v, env.resultOptions.noval()));
+	}
+
 	bool save_features_2_buffer_wholeslide (
 		// out
 		ResultsCache & rescache, 
@@ -45,119 +70,7 @@ namespace Nyxus
 		if (fill_header)
 		{
 			rescache.add_to_header({ Nyxus::colname_intensity_image, Nyxus::colname_mask_image, Nyxus::colname_roi_label, Nyxus::colname_t_index });
-
-			for (auto& enabdF : F)
-			{
-				auto fn = std::get<0>(enabdF);	// feature name
-				auto fc = std::get<1>(enabdF);	// feature code
-
-				// Handle missing feature name (which is a significant issue!) in order to at least be able to trace back to the feature code
-				if (fn.empty())
-					fn = "feature" + std::to_string(fc);
-
-				// Parameterized feature
-				// --GLCM family
-				bool glcmFeature = std::find(GLCMFeature::featureset.begin(), GLCMFeature::featureset.end(), (Feature2D)fc) != GLCMFeature::featureset.end();
-				bool nonAngledGlcmFeature = std::find(GLCMFeature::nonAngledFeatures.begin(), GLCMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLCMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-				if (glcmFeature && nonAngledGlcmFeature == false)
-				{
-					// Populate with angles
-					for (auto ang : env.glcmOptions.glcmAngles)
-					{
-						std::string col = fn + "_" + std::to_string(ang);
-						rescache.add_to_header(col);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				// --GLRLM family
-				bool glrlmFeature = std::find(GLRLMFeature::featureset.begin(), GLRLMFeature::featureset.end(), (Feature2D)fc) != GLRLMFeature::featureset.end();
-				bool nonAngledGlrlmFeature = std::find(GLRLMFeature::nonAngledFeatures.begin(), GLRLMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLRLMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-				if (glrlmFeature && nonAngledGlrlmFeature == false)
-				{
-					// Populate with angles
-					for (auto ang : GLRLMFeature::rotAngles)
-					{
-						std::string col = fn + "_" + std::to_string(ang);
-						rescache.add_to_header(col);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				// --Gabor
-				if (fc == (int)Feature2D::GABOR)
-				{
-					// Generate the feature value list
-					for (auto i = 0; i < GaborFeature::f0_theta_pairs.size(); i++)
-					{
-						std::string col = fn + "_" + std::to_string(i);
-						rescache.add_to_header(col);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				if (fc == (int)Feature2D::FRAC_AT_D)
-				{
-					// Generate the feature value list
-					for (auto i = 0; i < RadialDistributionFeature::num_features_FracAtD; i++)
-					{
-						std::string col = fn + "_" + std::to_string(i);
-						rescache.add_to_header(col);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				if (fc == (int)Feature2D::MEAN_FRAC)
-				{
-					// Generate the feature value list
-					for (auto i = 0; i < RadialDistributionFeature::num_features_MeanFrac; i++)
-					{
-						std::string col = fn + "_" + std::to_string(i);
-						rescache.add_to_header(col);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				if (fc == (int)Feature2D::RADIAL_CV)
-				{
-					// Generate the feature value list
-					for (auto i = 0; i < RadialDistributionFeature::num_features_RadialCV; i++)
-					{
-						std::string col = fn + "_" + std::to_string(i);
-						rescache.add_to_header(col);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				// --Zernike family
-				if (fc == (int)Feature2D::ZERNIKE2D)
-				{
-					// Populate with indices
-					for (int i = 0; i < ZernikeFeature::NUM_FEATURE_VALS; i++)
-					{
-						std::string col = fn + "_Z" + std::to_string(i);
-						rescache.add_to_header(col);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				// Regular feature
-				rescache.add_to_header(fn);
-			}
+			write_feature_header_buffer(rescache, env, F);
 		}
 
 		// -- Values
@@ -171,103 +84,7 @@ namespace Nyxus
 		rescache.add_numeric (DEFAULT_T_INDEX);
 
 		// - features
-		for (auto& enabdF : F)
-		{
-			auto fc = std::get<1>(enabdF);
-			auto fn = std::get<0>(enabdF);	// debug
-
-			auto vv = r.get_fvals(fc);
-
-			// Parameterized feature
-			// --GLCM family
-			bool glcmFeature = std::find(GLCMFeature::featureset.begin(), GLCMFeature::featureset.end(), (Feature2D)fc) != GLCMFeature::featureset.end();
-			bool nonAngledGlcmFeature = std::find(GLCMFeature::nonAngledFeatures.begin(), GLCMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLCMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-			if (glcmFeature && nonAngledGlcmFeature == false)
-			{
-				// Mock angled values if they haven't been calculated for some error reason
-				if (vv.size() < GLCMFeature::angles.size())
-					vv.resize(GLCMFeature::angles.size(), 0.0);
-
-				// Populate with angles
-				int nAng = GLCMFeature::angles.size();
-				for (int i = 0; i < nAng; i++)
-				{
-					rescache.add_numeric(Nyxus::force_finite_number(vv[i], env.resultOptions.noval()));
-				}
-
-				// Proceed with other features
-				continue;
-			}
-
-			// --GLRLM family
-			bool glrlmFeature = std::find(GLRLMFeature::featureset.begin(), GLRLMFeature::featureset.end(), (Feature2D)fc) != GLRLMFeature::featureset.end();
-			bool nonAngledGlrlmFeature = std::find(GLRLMFeature::nonAngledFeatures.begin(), GLRLMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLRLMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-			if (glrlmFeature && nonAngledGlrlmFeature == false)
-			{
-				// Populate with angles
-				int nAng = 4; // check GLRLMFeature::rotAngles
-				for (int i = 0; i < nAng; i++)
-				{
-					rescache.add_numeric(Nyxus::force_finite_number(vv[i], env.resultOptions.noval()));
-				}
-				// Proceed with other features
-				continue;
-			}
-
-			// --Gabor
-			if (fc == (int)Feature2D::GABOR)
-			{
-				for (auto i = 0; i < GaborFeature::f0_theta_pairs.size(); i++)
-				{
-					rescache.add_numeric(Nyxus::force_finite_number(vv[i], env.resultOptions.noval()));
-				}
-				// Proceed with other features
-				continue;
-			}
-
-			// --Zernike family
-			if (fc == (int)Feature2D::ZERNIKE2D)
-			{
-				for (int i = 0; i < ZernikeFeature::NUM_FEATURE_VALS; i++)
-				{
-					rescache.add_numeric(Nyxus::force_finite_number(vv[i], env.resultOptions.noval()));
-				}
-				// Proceed with other features
-				continue;
-			}
-
-			// --Radial distribution features
-			if (fc == (int)Feature2D::FRAC_AT_D)
-			{
-				for (auto i = 0; i < RadialDistributionFeature::num_features_FracAtD; i++)
-				{
-					rescache.add_numeric(Nyxus::force_finite_number(vv[i], env.resultOptions.noval()));
-				}
-				// Proceed with other features
-				continue;
-			}
-			if (fc == (int)Feature2D::MEAN_FRAC)
-			{
-				for (auto i = 0; i < RadialDistributionFeature::num_features_MeanFrac; i++)
-				{
-					rescache.add_numeric(Nyxus::force_finite_number(vv[i], env.resultOptions.noval()));
-				}
-				// Proceed with other features
-				continue;
-			}
-			if (fc == (int)Feature2D::RADIAL_CV)
-			{
-				for (auto i = 0; i < RadialDistributionFeature::num_features_RadialCV; i++)
-				{
-					rescache.add_numeric(Nyxus::force_finite_number(vv[i], env.resultOptions.noval()));
-				}
-				// Proceed with other features
-				continue;
-			}
-
-			// Regular feature
-			rescache.add_numeric(Nyxus::force_finite_number(vv[0], env.resultOptions.noval()));
-		}
+		write_feature_values_buffer(rescache, r, F, env);
 
 		return true;
 	}
@@ -287,119 +104,7 @@ namespace Nyxus
 		if (fill_header)
 		{
 			rescache.add_to_header({ Nyxus::colname_intensity_image, Nyxus::colname_mask_image, Nyxus::colname_roi_label, Nyxus::colname_t_index });
-
-			for (auto& enabdF : F)
-			{
-				auto fn = std::get<0>(enabdF);	// feature name
-				auto fc = std::get<1>(enabdF);	// feature code
-
-				// Handle missing feature name (which is a significant issue!) in order to at least be able to trace back to the feature code
-				if (fn.empty())
-					fn = "feature" + std::to_string(fc);
-
-				// Parameterized feature
-				// --GLCM family
-				bool glcmFeature = std::find(GLCMFeature::featureset.begin(), GLCMFeature::featureset.end(), (Feature2D)fc) != GLCMFeature::featureset.end();
-				bool nonAngledGlcmFeature = std::find(GLCMFeature::nonAngledFeatures.begin(), GLCMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLCMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-				if (glcmFeature && nonAngledGlcmFeature == false)
-				{
-					// Populate with angles
-					for (auto ang : env.glcmOptions.glcmAngles)
-					{
-						std::string col = fn + "_" + std::to_string(ang);
-						rescache.add_to_header(col);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				// --GLRLM family
-				bool glrlmFeature = std::find(GLRLMFeature::featureset.begin(), GLRLMFeature::featureset.end(), (Feature2D)fc) != GLRLMFeature::featureset.end();
-				bool nonAngledGlrlmFeature = std::find(GLRLMFeature::nonAngledFeatures.begin(), GLRLMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLRLMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-				if (glrlmFeature && nonAngledGlrlmFeature == false)
-				{
-					// Populate with angles
-					for (auto ang : GLRLMFeature::rotAngles)
-					{
-						std::string col = fn + "_" + std::to_string(ang);
-						rescache.add_to_header(col);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				// --Gabor
-				if (fc == (int) Feature2D::GABOR)
-				{
-					// Generate the feature value list
-					for (auto i = 0; i < GaborFeature::f0_theta_pairs.size(); i++)
-					{
-						std::string col = fn + "_" + std::to_string(i);
-						rescache.add_to_header(col);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				if (fc == (int) Feature2D::FRAC_AT_D)
-				{
-					// Generate the feature value list
-					for (auto i = 0; i < RadialDistributionFeature::num_features_FracAtD; i++)
-					{
-						std::string col = fn + "_" + std::to_string(i);
-						rescache.add_to_header(col);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				if (fc == (int) Feature2D::MEAN_FRAC)
-				{
-					// Generate the feature value list
-					for (auto i = 0; i < RadialDistributionFeature::num_features_MeanFrac; i++)
-					{
-						std::string col = fn + "_" + std::to_string(i);
-						rescache.add_to_header(col);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				if (fc == (int) Feature2D::RADIAL_CV)
-				{
-					// Generate the feature value list
-					for (auto i = 0; i < RadialDistributionFeature::num_features_RadialCV; i++)
-					{
-						std::string col = fn + "_" + std::to_string(i);
-						rescache.add_to_header(col);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				// --Zernike family
-				if (fc == (int) Feature2D::ZERNIKE2D)
-				{
-					// Populate with indices
-					for (int i = 0; i < ZernikeFeature::NUM_FEATURE_VALS; i++)
-					{
-						std::string col = fn + "_Z" + std::to_string(i);
-						rescache.add_to_header(col);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				// Regular feature
-				rescache.add_to_header(fn);
-			}
+			write_feature_header_buffer(rescache, env, F);
 		}
 
 		// -- Values
@@ -415,7 +120,7 @@ namespace Nyxus
 
 			// Tear off pure file names from segment and intensity file paths
 			const SlideProps & slide = env.dataset.dataset_props[r.slide_idx];
-			fs::path pseg(slide.fname_seg), 
+			fs::path pseg(slide.fname_seg),
 				pint(slide.fname_int);
 			std::string segfname = pseg.filename().string(),
 				intfname = pint.filename().string();
@@ -425,106 +130,94 @@ namespace Nyxus
 			rescache.add_numeric (l);
 			rescache.add_numeric (t_index);
 
-			for (auto& enabdF : F)
-			{
-				auto fc = std::get<1>(enabdF);
-				auto fn = std::get<0>(enabdF);	// debug
-
-				auto vv = r.get_fvals(fc);
-
-				// Parameterized feature
-				// --GLCM family
-				bool glcmFeature = std::find(GLCMFeature::featureset.begin(), GLCMFeature::featureset.end(), (Feature2D)fc) != GLCMFeature::featureset.end();
-				bool nonAngledGlcmFeature = std::find(GLCMFeature::nonAngledFeatures.begin(), GLCMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLCMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-				if (glcmFeature && nonAngledGlcmFeature == false)
-				{
-					// Mock angled values if they haven't been calculated for some error reason
-					if (vv.size() < GLCMFeature::angles.size())
-						vv.resize(GLCMFeature::angles.size(), 0.0);
-
-					// Populate with angles
-					int nAng = GLCMFeature::angles.size();
-					for (int i = 0; i < nAng; i++)
-					{
-						rescache.add_numeric (Nyxus::force_finite_number(vv[i], env.resultOptions.noval()));
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				// --GLRLM family
-				bool glrlmFeature = std::find(GLRLMFeature::featureset.begin(), GLRLMFeature::featureset.end(), (Feature2D)fc) != GLRLMFeature::featureset.end();
-				bool nonAngledGlrlmFeature = std::find(GLRLMFeature::nonAngledFeatures.begin(), GLRLMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLRLMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-				if (glrlmFeature && nonAngledGlrlmFeature == false)
-				{
-					// Populate with angles
-					int nAng = 4; // check GLRLMFeature::rotAngles
-					for (int i = 0; i < nAng; i++)
-					{
-						rescache.add_numeric (Nyxus::force_finite_number(vv[i], env.resultOptions.noval()));
-					}
-					// Proceed with other features
-					continue;
-				}
-
-				// --Gabor
-				if (fc == (int) Feature2D::GABOR)
-				{
-					for (auto i = 0; i < GaborFeature::f0_theta_pairs.size(); i++)
-					{
-						rescache.add_numeric (Nyxus::force_finite_number(vv[i], env.resultOptions.noval()));
-					}
-					// Proceed with other features
-					continue;
-				}
-
-				// --Zernike family
-				if (fc == (int) Feature2D::ZERNIKE2D)
-				{
-					for (int i = 0; i < ZernikeFeature::NUM_FEATURE_VALS; i++)
-					{
-						rescache.add_numeric (Nyxus::force_finite_number(vv[i], env.resultOptions.noval()));
-					}
-					// Proceed with other features
-					continue;
-				}
-
-				// --Radial distribution features
-				if (fc == (int) Feature2D::FRAC_AT_D)
-				{
-					for (auto i = 0; i < RadialDistributionFeature::num_features_FracAtD; i++)
-					{
-						rescache.add_numeric (Nyxus::force_finite_number(vv[i], env.resultOptions.noval()));
-					}
-					// Proceed with other features
-					continue;
-				}
-				if (fc == (int) Feature2D::MEAN_FRAC)
-				{
-					for (auto i = 0; i < RadialDistributionFeature::num_features_MeanFrac; i++)
-					{
-						rescache.add_numeric (Nyxus::force_finite_number(vv[i], env.resultOptions.noval()));
-					}
-					// Proceed with other features
-					continue;
-				}
-				if (fc == (int) Feature2D::RADIAL_CV)
-				{
-					for (auto i = 0; i < RadialDistributionFeature::num_features_RadialCV; i++)
-					{
-						rescache.add_numeric (Nyxus::force_finite_number(vv[i], env.resultOptions.noval()));
-					}
-					// Proceed with other features
-					continue;
-				}
-
-				// Regular feature
-				rescache.add_numeric (Nyxus::force_finite_number(vv[0], env.resultOptions.noval()));
-			}
+			write_feature_values_buffer(rescache, r, F, env);
 		}
 
 		return true;
+	}
+
+	/// @brief Assembles child ROI features into spatial arrays for one parent ROI.
+	/// Produces one FmapArrayResult with n_features arrays of shape (map_d, map_h, map_w).
+	/// Map dimensions are parent_dim - kernel_size + 1 (the valid convolution output size).
+	/// Positions with no valid child ROI remain NaN.
+	void save_features_2_fmap_arrays (
+		ResultsCache & rescache,
+		Environment & env,
+		const std::string & intens_name,
+		const std::string & seg_name,
+		int parent_label,
+		int parent_xmin, int parent_ymin, int parent_zmin,
+		int parent_w, int parent_h, int parent_d,
+		int kernel_size,
+		const std::unordered_set<int> & childLabels,
+		const std::unordered_map<int, LR> & childRoiData,
+		const std::unordered_map<int, FmapChildInfo> & childToParentMap)
+	{
+		int half = kernel_size / 2;
+		// Map dimensions = valid convolution output size
+		int map_w = parent_w - kernel_size + 1;
+		int map_h = parent_h - kernel_size + 1;
+		int map_d = parent_d - kernel_size + 1;
+
+		if (map_w <= 0 || map_h <= 0 || map_d <= 0)
+			return;
+
+		std::vector<std::tuple<std::string, int>> F = env.theFeatureSet.getEnabledFeatures();
+		std::vector<std::string> feature_names = get_feature_column_names(env, F);
+		size_t n_features = feature_names.size();
+		size_t map_size = (size_t)map_d * map_h * map_w;
+
+		// Initialize with NaN
+		std::vector<double> feature_data(n_features * map_size, std::numeric_limits<double>::quiet_NaN());
+
+		// Fill in values from child ROIs
+		for (auto l : childLabels)
+		{
+			auto it_roi = childRoiData.find(l);
+			if (it_roi == childRoiData.end())
+				continue;
+			const LR& r = it_roi->second;
+			if (r.blacklisted)
+				continue;
+
+			auto it_map = childToParentMap.find(l);
+			if (it_map == childToParentMap.end())
+				continue;
+
+			const FmapChildInfo& info = it_map->second;
+
+			// Convert global center coords to map indices
+			int map_col = info.center_x - parent_xmin - half;
+			int map_row = info.center_y - parent_ymin - half;
+			int map_z   = info.center_z - parent_zmin - half;
+
+			if (map_col < 0 || map_col >= map_w ||
+				map_row < 0 || map_row >= map_h ||
+				map_z < 0 || map_z >= map_d)
+				continue;
+
+			size_t voxel_idx = (size_t)map_z * map_h * map_w + (size_t)map_row * map_w + map_col;
+
+			// Collect feature values for this child
+			auto vals = collect_feature_values(r, F);
+			for (size_t fi = 0; fi < n_features && fi < vals.size(); fi++)
+				feature_data[fi * map_size + voxel_idx] = force_finite_number(vals[fi], env.resultOptions.noval());
+		}
+
+		// Store result
+		FmapArrayResult result;
+		result.parent_label = parent_label;
+		result.intens_name = intens_name;
+		result.seg_name = seg_name;
+		result.map_w = map_w;
+		result.map_h = map_h;
+		result.map_d = map_d;
+		result.origin_x = parent_xmin + half;
+		result.origin_y = parent_ymin + half;
+		result.origin_z = parent_zmin + half;
+		result.feature_names = std::move(feature_names);
+		result.feature_data = std::move(feature_data);
+		rescache.get_fmapArrayResults().push_back(std::move(result));
 	}
 
 }

--- a/src/nyx/output_2_csv.cpp
+++ b/src/nyx/output_2_csv.cpp
@@ -1,6 +1,7 @@
+#include <atomic>
 #include <memory>
 #include <unordered_map>
-#include <unordered_set> 
+#include <unordered_set>
 #include <algorithm>
 #include <iostream>
 #include <sstream>
@@ -25,6 +26,211 @@ namespace Nyxus
 #ifndef _WIN32
 #define fopen_s(pFile,filename,mode) ((*(pFile))=fopen((filename),(mode)))==NULL
 #endif
+
+	/// @brief Returns feature column names for all enabled features.
+	/// Single source of truth for header generation across CSV, buffer, and Arrow output paths.
+	std::vector<std::string> get_feature_column_names (
+		Environment & env,
+		const std::vector<std::tuple<std::string, int>> & F)
+	{
+		std::vector<std::string> cols;
+
+		for (const auto& enabdF : F)
+		{
+			auto fn = std::get<0>(enabdF);
+			auto fc = std::get<1>(enabdF);
+
+			if (fn.empty())
+				fn = "feature" + std::to_string(fc);
+
+			// GLCM family
+			bool glcmFeature = std::find(GLCMFeature::featureset.begin(), GLCMFeature::featureset.end(), (Feature2D)fc) != GLCMFeature::featureset.end();
+			bool nonAngledGlcmFeature = std::find(GLCMFeature::nonAngledFeatures.begin(), GLCMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLCMFeature::nonAngledFeatures.end();
+			if (glcmFeature && nonAngledGlcmFeature == false)
+			{
+				for (auto ang : env.glcmOptions.glcmAngles)
+					cols.push_back(fn + "_" + std::to_string(ang));
+				continue;
+			}
+
+			// GLRLM family
+			bool glrlmFeature = std::find(GLRLMFeature::featureset.begin(), GLRLMFeature::featureset.end(), (Feature2D)fc) != GLRLMFeature::featureset.end();
+			bool nonAngledGlrlmFeature = std::find(GLRLMFeature::nonAngledFeatures.begin(), GLRLMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLRLMFeature::nonAngledFeatures.end();
+			if (glrlmFeature && nonAngledGlrlmFeature == false)
+			{
+				for (auto ang : GLRLMFeature::rotAngles)
+					cols.push_back(fn + "_" + std::to_string(ang));
+				continue;
+			}
+
+			// Gabor
+			if (fc == (int)Feature2D::GABOR)
+			{
+				for (auto i = 0; i < GaborFeature::f0_theta_pairs.size(); i++)
+					cols.push_back(fn + "_" + std::to_string(i));
+				continue;
+			}
+
+			if (fc == (int)Feature2D::FRAC_AT_D)
+			{
+				for (auto i = 0; i < RadialDistributionFeature::num_features_FracAtD; i++)
+					cols.push_back(fn + "_" + std::to_string(i));
+				continue;
+			}
+
+			if (fc == (int)Feature2D::MEAN_FRAC)
+			{
+				for (auto i = 0; i < RadialDistributionFeature::num_features_MeanFrac; i++)
+					cols.push_back(fn + "_" + std::to_string(i));
+				continue;
+			}
+
+			if (fc == (int)Feature2D::RADIAL_CV)
+			{
+				for (auto i = 0; i < RadialDistributionFeature::num_features_RadialCV; i++)
+					cols.push_back(fn + "_" + std::to_string(i));
+				continue;
+			}
+
+			// Zernike
+			if (fc == (int)Feature2D::ZERNIKE2D)
+			{
+				for (int i = 0; i < ZernikeFeature::NUM_FEATURE_VALS; i++)
+					cols.push_back(fn + "_Z" + std::to_string(i));
+				continue;
+			}
+
+			// Regular feature
+			cols.push_back(fn);
+		}
+
+		return cols;
+	}
+
+	/// @brief Collects raw feature values for a single ROI into a flat vector.
+	/// Single source of truth for value collection across CSV, buffer, and Python output paths.
+	/// Callers apply force_finite_number or other formatting as needed.
+	std::vector<double> collect_feature_values (
+		const LR & r,
+		const std::vector<std::tuple<std::string, int>> & F)
+	{
+		std::vector<double> vals;
+
+		for (const auto& enabdF : F)
+		{
+			auto fc = std::get<1>(enabdF);
+			auto vv = r.get_fvals(fc);
+
+			// GLCM family
+			bool glcmFeature = std::find(GLCMFeature::featureset.begin(), GLCMFeature::featureset.end(), (Feature2D)fc) != GLCMFeature::featureset.end();
+			bool nonAngledGlcmFeature = std::find(GLCMFeature::nonAngledFeatures.begin(), GLCMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLCMFeature::nonAngledFeatures.end();
+			if (glcmFeature && nonAngledGlcmFeature == false)
+			{
+				if (vv.size() < GLCMFeature::angles.size())
+					vv.resize(GLCMFeature::angles.size(), 0.0);
+				int nAng = (int)GLCMFeature::angles.size();
+				for (int i = 0; i < nAng; i++)
+					vals.push_back(vv[i]);
+				continue;
+			}
+
+			// GLRLM family
+			bool glrlmFeature = std::find(GLRLMFeature::featureset.begin(), GLRLMFeature::featureset.end(), (Feature2D)fc) != GLRLMFeature::featureset.end();
+			bool nonAngledGlrlmFeature = std::find(GLRLMFeature::nonAngledFeatures.begin(), GLRLMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLRLMFeature::nonAngledFeatures.end();
+			if (glrlmFeature && nonAngledGlrlmFeature == false)
+			{
+				int nAng = (int)std::size(GLRLMFeature::rotAngles);
+				if ((int)vv.size() < nAng)
+					vv.resize(nAng, 0.0);
+				for (int i = 0; i < nAng; i++)
+					vals.push_back(vv[i]);
+				continue;
+			}
+
+			// Gabor
+			if (fc == (int)Feature2D::GABOR)
+			{
+				auto nGabor = GaborFeature::f0_theta_pairs.size();
+				if (vv.size() < nGabor)
+					vv.resize(nGabor, 0.0);
+				for (size_t i = 0; i < nGabor; i++)
+					vals.push_back(vv[i]);
+				continue;
+			}
+
+			// Zernike
+			if (fc == (int)Feature2D::ZERNIKE2D)
+			{
+				if ((int)vv.size() < ZernikeFeature::NUM_FEATURE_VALS)
+					vv.resize(ZernikeFeature::NUM_FEATURE_VALS, 0.0);
+				for (int i = 0; i < ZernikeFeature::NUM_FEATURE_VALS; i++)
+					vals.push_back(vv[i]);
+				continue;
+			}
+
+			// Radial distribution
+			if (fc == (int)Feature2D::FRAC_AT_D)
+			{
+				if ((int)vv.size() < RadialDistributionFeature::num_features_FracAtD)
+					vv.resize(RadialDistributionFeature::num_features_FracAtD, 0.0);
+				for (auto i = 0; i < RadialDistributionFeature::num_features_FracAtD; i++)
+					vals.push_back(vv[i]);
+				continue;
+			}
+			if (fc == (int)Feature2D::MEAN_FRAC)
+			{
+				if ((int)vv.size() < RadialDistributionFeature::num_features_MeanFrac)
+					vv.resize(RadialDistributionFeature::num_features_MeanFrac, 0.0);
+				for (auto i = 0; i < RadialDistributionFeature::num_features_MeanFrac; i++)
+					vals.push_back(vv[i]);
+				continue;
+			}
+			if (fc == (int)Feature2D::RADIAL_CV)
+			{
+				if ((int)vv.size() < RadialDistributionFeature::num_features_RadialCV)
+					vv.resize(RadialDistributionFeature::num_features_RadialCV, 0.0);
+				for (auto i = 0; i < RadialDistributionFeature::num_features_RadialCV; i++)
+					vals.push_back(vv[i]);
+				continue;
+			}
+
+			// Regular feature
+			vals.push_back(vv.empty() ? 0.0 : vv[0]);
+		}
+
+		return vals;
+	}
+
+	/// @brief Writes all feature values for a single ROI to a stringstream in CSV format.
+	/// Uses collect_feature_values() as the single source of truth for value dispatch.
+	void write_feature_values_csv (
+		std::stringstream & ssVals,
+		const LR & r,
+		const std::vector<std::tuple<std::string, int>> & F,
+		Environment & env,
+		char* rvbuf,
+		int rvbuf_len,
+		const char* rvfmt)
+	{
+		auto vals = collect_feature_values(r, F);
+
+#ifdef DIAGNOSE_NYXUS_OUTPUT
+		auto names = get_feature_column_names(env, F);
+		for (size_t i = 0; i < vals.size(); i++)
+		{
+			double fv = Nyxus::force_finite_number(vals[i], env.resultOptions.noval());
+			snprintf(rvbuf, rvbuf_len, rvfmt, fv);
+			ssVals << "," << names[i] << "-" << rvbuf;
+		}
+#else
+		for (auto v : vals)
+		{
+			double fv = Nyxus::force_finite_number(v, env.resultOptions.noval());
+			snprintf(rvbuf, rvbuf_len, rvfmt, fv);
+			ssVals << "," << rvbuf;
+		}
+#endif
+	}
 
 	double auto_precision (Environment & env, std::stringstream& ss, double x)
 	{
@@ -80,107 +286,10 @@ namespace Nyxus
 		// time
 		head.push_back (Nyxus::colname_t_index);
 
-		// Optional columns
-		for (auto& enabdF : F)
-		{
-			auto fn = std::get<0>(enabdF);	// feature name
-			auto fc = std::get<1>(enabdF);	// feature code
-
-			// Handle missing feature name (which is a significant issue!) in order to at least be able to trace back to the feature code
-			if (fn.empty())
-			{
-				std::stringstream temp;
-				temp << "feature" << fc;
-				fn = temp.str();
-			}
-
-			// Parameterized feature
-			// --GLCM family
-			bool glcmFeature = std::find(GLCMFeature::featureset.begin(), GLCMFeature::featureset.end(), (Feature2D)fc) != GLCMFeature::featureset.end();
-			bool nonAngledGlcmFeature = std::find(GLCMFeature::nonAngledFeatures.begin(), GLCMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLCMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-			if (glcmFeature && nonAngledGlcmFeature == false)
-			{
-				// Populate with angles
-				for (auto ang : env.glcmOptions.glcmAngles)
-				{
-					// CSV separator
-					//if (ang != env.rotAngles[0])
-					//	ssHead << ",";
-					head.emplace_back(fn + "_" + std::to_string(ang));
-				}
-				// Proceed with other features
-				continue;
-			}
-
-			// --GLRLM family
-			bool glrlmFeature = std::find(GLRLMFeature::featureset.begin(), GLRLMFeature::featureset.end(), (Feature2D)fc) != GLRLMFeature::featureset.end();
-			bool nonAngledGlrlmFeature = std::find(GLRLMFeature::nonAngledFeatures.begin(), GLRLMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLRLMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-			if (glrlmFeature && nonAngledGlrlmFeature == false)
-			{
-				// Populate with angles
-				for (auto ang : GLRLMFeature::rotAngles)
-				{
-					head.emplace_back(fn + "_" + std::to_string(ang));
-				}
-				// Proceed with other features
-				continue;
-			}
-
-			// --Gabor
-			if (fc == (int) Feature2D::GABOR)
-			{
-				// Generate the feature value list
-				for (auto i = 0; i < GaborFeature::f0_theta_pairs.size(); i++)
-					head.emplace_back(fn + "_" + std::to_string(i));
-
-				// Proceed with other features
-				continue;
-			}
-
-			if (fc == (int) Feature2D::FRAC_AT_D)
-			{
-				// Generate the feature value list
-				for (auto i = 0; i < RadialDistributionFeature::num_features_FracAtD; i++)
-					head.emplace_back(fn + "_" + std::to_string(i));
-
-				// Proceed with other features
-				continue;
-			}
-
-			if (fc == (int) Feature2D::MEAN_FRAC)
-			{
-				// Generate the feature value list
-				for (auto i = 0; i < RadialDistributionFeature::num_features_MeanFrac; i++)
-					head.emplace_back(fn + "_" + std::to_string(i));
-
-				// Proceed with other features
-				continue;
-			}
-
-			if (fc == (int) Feature2D::RADIAL_CV)
-			{
-				// Generate the feature value list
-				for (auto i = 0; i < RadialDistributionFeature::num_features_RadialCV; i++)
-					head.emplace_back(fn + "_" + std::to_string(i));
-
-				// Proceed with other features
-				continue;
-			}
-
-			// --Zernike features header 
-			if (fc == (int) Feature2D::ZERNIKE2D)
-			{
-				// Populate with indices
-				for (int i = 0; i < ZernikeFeature::NUM_FEATURE_VALS; i++)	// i < ZernikeFeature::num_feature_values_calculated
-					head.emplace_back(fn + "_Z" + std::to_string(i));
-
-				// Proceed with other features
-				continue;
-			}
-
-			// Regular feature
-			head.emplace_back(fn);
-		}
+		// Feature columns (single source of truth)
+		auto feature_cols = get_feature_column_names(env, F);
+		for (const auto& c : feature_cols)
+			head.push_back(c);
 
 		return head;
 	}
@@ -197,6 +306,20 @@ namespace Nyxus
 
 	static std::mutex mutex1;
 
+	// Moved from function-local statics to namespace scope so they can be
+	// reset between workflow invocations (e.g. when processing multiple
+	// datasets in one Python session). Function-local statics persisted
+	// across calls, causing headers to be missing on subsequent runs.
+	// std::atomic ensures safe reset-before-use even without mutex protection.
+	static std::atomic<bool> mustRenderHeader_wholeslide{true};
+	static std::atomic<bool> mustRenderHeader_segmented{true};
+
+	void reset_csv_header_state()
+	{
+		mustRenderHeader_wholeslide.store(true);
+		mustRenderHeader_segmented.store(true);
+	}
+
 	bool save_features_2_csv_wholeslide (
 		Environment & env,
 		const LR & r, 
@@ -212,8 +335,6 @@ namespace Nyxus
 		char rvbuf[VAL_BUF_LEN]; // real value buffer large enough to fit a float64 value in range (2.2250738585072014E-308 to 1.79769313486231570e+308)
 		const char rvfmt[] = "%g"; // instead of "%20.12f" which produces a too massive output
 
-		static bool mustRenderHeader = true;	// In 'singlecsv' scenario this flag flips from 'T' to 'F' when necessary (after the header is rendered)
-
 		// Make the file name and write mode
 		std::string fullPath = get_feature_output_fname (env, ifpath, mfpath);
 		VERBOSLVL2 (env.get_verbosity_level(), std::cout << "\t--> " << fullPath << "\n");
@@ -221,7 +342,7 @@ namespace Nyxus
 		// Single CSV: create or continue?
 		const char* mode = "w";
 		if (!env.separateCsv)
-			mode = mustRenderHeader ? "w" : "a";
+			mode = mustRenderHeader_wholeslide ? "w" : "a";
 
 		// Open it
 		FILE* fp = nullptr;
@@ -235,7 +356,7 @@ namespace Nyxus
 		}
 
 		// configure buffered write
-		if (std::setvbuf(fp, nullptr, _IOFBF, 32768) != 0) 
+		if (std::setvbuf(fp, nullptr, _IOFBF, 32768) != 0)
 			std::cerr << "setvbuf failed \n";
 
 		// Learn what features need to be displayed
@@ -243,7 +364,7 @@ namespace Nyxus
 
 		// ********** Header
 
-		if (mustRenderHeader)
+		if (mustRenderHeader_wholeslide)
 		{
 			std::stringstream ssHead;
 
@@ -263,7 +384,7 @@ namespace Nyxus
 
 			// Prevent rendering the header again for another image's portion of labels
 			if (env.separateCsv == false)
-				mustRenderHeader = false;
+				mustRenderHeader_wholeslide = false;
 		}
 
 		// ********** Values
@@ -282,117 +403,7 @@ namespace Nyxus
 			ssVals << "," << r.label << "," << t_index;
 
 			// features
-			for (auto& enabdF : F)
-			{
-				auto fc = std::get<1>(enabdF);
-				auto fn = std::get<0>(enabdF);	// feature name, for debugging
-				auto vv = r.get_fvals(fc);
-
-				// Parameterized feature
-				// --GLCM family
-				bool glcmFeature = std::find(GLCMFeature::featureset.begin(), GLCMFeature::featureset.end(), (Feature2D)fc) != GLCMFeature::featureset.end();
-				bool nonAngledGlcmFeature = std::find(GLCMFeature::nonAngledFeatures.begin(), GLCMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLCMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-				if (glcmFeature && nonAngledGlcmFeature == false)
-				{
-					// Mock angled values if they haven't been calculated for some error reason
-					if (vv.size() < GLCMFeature::angles.size())
-						vv.resize(GLCMFeature::angles.size(), 0.0);
-					// Output the sub-values
-					int nAng = (int)GLCMFeature::angles.size();
-					for (int i = 0; i < nAng; i++)
-					{
-						double fv = Nyxus::force_finite_number(vv[i], env.resultOptions.noval());	// safe feature value (no NAN, no inf)
-						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
-						ssVals << "," << rvbuf;
-					}
-					// Proceed with other features
-					continue;
-				}
-
-				// --GLRLM family
-				bool glrlmFeature = std::find(GLRLMFeature::featureset.begin(), GLRLMFeature::featureset.end(), (Feature2D)fc) != GLRLMFeature::featureset.end();
-				bool nonAngledGlrlmFeature = std::find(GLRLMFeature::nonAngledFeatures.begin(), GLRLMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLRLMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-				if (glrlmFeature && nonAngledGlrlmFeature == false)
-				{
-					// Populate with angles
-					int nAng = 4;
-					for (int i = 0; i < nAng; i++)
-					{
-						double fv = Nyxus::force_finite_number(vv[i], env.resultOptions.noval());	// safe feature value (no NAN, no inf)
-						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
-						ssVals << "," << rvbuf;
-					}
-					// Proceed with other features
-					continue;
-				}
-
-				// --Gabor
-				if (fc == (int)Feature2D::GABOR)
-				{
-					for (auto i = 0; i < GaborFeature::f0_theta_pairs.size(); i++)
-					{
-						double fv = Nyxus::force_finite_number(vv[i], env.resultOptions.noval());	// safe feature value (no NAN, no inf)
-						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
-						ssVals << "," << rvbuf;
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				// --Zernike feature values
-				if (fc == (int)Feature2D::ZERNIKE2D)
-				{
-					for (int i = 0; i < ZernikeFeature::NUM_FEATURE_VALS; i++)
-					{
-						double fv = Nyxus::force_finite_number(vv[i], env.resultOptions.noval());	// safe feature value (no NAN, no inf)
-						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
-						ssVals << "," << rvbuf;
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				// --Radial distribution features
-				if (fc == (int)Feature2D::FRAC_AT_D)
-				{
-					for (auto i = 0; i < RadialDistributionFeature::num_features_FracAtD; i++)
-					{
-						double fv = Nyxus::force_finite_number(vv[i], env.resultOptions.noval());	// safe feature value (no NAN, no inf)
-						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
-						ssVals << "," << rvbuf;
-					}
-					// Proceed with other features
-					continue;
-				}
-				if (fc == (int)Feature2D::MEAN_FRAC)
-				{
-					for (auto i = 0; i < RadialDistributionFeature::num_features_MeanFrac; i++)
-					{
-						double fv = Nyxus::force_finite_number(vv[i], env.resultOptions.noval());	// safe feature value (no NAN, no inf)
-						snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
-						ssVals << "," << rvbuf;
-					}
-					// Proceed with other features
-					continue;
-				}
-				if (fc == (int)Feature2D::RADIAL_CV)
-				{
-					for (auto i = 0; i < RadialDistributionFeature::num_features_RadialCV; i++)
-					{
-						double fv = Nyxus::force_finite_number(vv[i], env.resultOptions.noval());	// safe feature value (no NAN, no inf)
-						snprintf (rvbuf, VAL_BUF_LEN, rvfmt, fv);
-						ssVals << "," << rvbuf;
-					}
-					// Proceed with other features
-					continue;
-				}
-
-				// Regular feature
-				snprintf (rvbuf, VAL_BUF_LEN, rvfmt, Nyxus::force_finite_number(vv[0], env.resultOptions.noval()));
-				ssVals << "," << rvbuf; // Alternatively: auto_precision(ssVals, vv[0]);
-			}
+			write_feature_values_csv(ssVals, r, F, env, rvbuf, VAL_BUF_LEN, rvfmt);
 
 			fprintf(fp, "%s\n", ssVals.str().c_str());
 		}
@@ -421,8 +432,6 @@ namespace Nyxus
 		std::vector<int> L{ env.uniqueLabels.begin(), env.uniqueLabels.end() };
 		std::sort(L.begin(), L.end());
 
-		static bool mustRenderHeader = true;	// In 'singlecsv' scenario this flag flips from 'T' to 'F' when necessary (after the header is rendered)
-
 		// Make the file name and write mode
 		std::string fullPath = get_feature_output_fname (env, intFpath, segFpath);
 		VERBOSLVL2 (env.get_verbosity_level(), std::cout << "\t--> " << fullPath << "\n");
@@ -430,7 +439,7 @@ namespace Nyxus
 		// Single CSV: create or continue?
 		const char* mode = "w";
 		if (!env.separateCsv)
-			mode = mustRenderHeader ? "w" : "a";
+			mode = mustRenderHeader_segmented ? "w" : "a";
 
 		// Open it
 		FILE* fp = nullptr;
@@ -453,7 +462,7 @@ namespace Nyxus
 		std::vector<std::tuple<std::string, int>> F = env.theFeatureSet.getEnabledFeatures();
 
 		// -- Header
-		if (mustRenderHeader)
+		if (mustRenderHeader_segmented)
 		{
 			std::stringstream ssHead;
 
@@ -473,7 +482,7 @@ namespace Nyxus
 
 			// Prevent rendering the header again for another image's portion of labels
 			if (env.separateCsv == false)
-				mustRenderHeader = false;
+				mustRenderHeader_segmented = false;
 		}
 
 		if (need_aggregation)
@@ -560,157 +569,7 @@ namespace Nyxus
 				// ROI label and time
 				ssVals << "," << l << "," << t_index;
 
-				for (auto& enabdF : F)
-				{
-					auto fc = std::get<1>(enabdF);
-					auto fn = std::get<0>(enabdF);	// debug
-					auto vv = r.get_fvals(fc);
-
-					// Parameterized feature
-					// --GLCM family
-					bool glcmFeature = std::find(GLCMFeature::featureset.begin(), GLCMFeature::featureset.end(), (Feature2D)fc) != GLCMFeature::featureset.end();
-					bool nonAngledGlcmFeature = std::find(GLCMFeature::nonAngledFeatures.begin(), GLCMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLCMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-					if (glcmFeature && nonAngledGlcmFeature == false)
-					{
-						// Mock angled values if they haven't been calculated for some error reason
-						if (vv.size() < GLCMFeature::angles.size())
-							vv.resize(GLCMFeature::angles.size(), 0.0);
-						// Output the sub-values
-						int nAng = (int) GLCMFeature::angles.size();
-						for (int i = 0; i < nAng; i++)
-						{
-							double fv = Nyxus::force_finite_number(vv[i], env.resultOptions.noval());	// safe feature value (no NAN, no inf)
-							snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
-	#ifndef DIAGNOSE_NYXUS_OUTPUT
-							ssVals << "," << rvbuf;
-	#else
-							//--diagnoze misalignment-- 
-							ssVals << "," << fn << "-" << rvbuf;
-	#endif
-						}
-						// Proceed with other features
-						continue;
-					}
-
-					// --GLRLM family
-					bool glrlmFeature = std::find(GLRLMFeature::featureset.begin(), GLRLMFeature::featureset.end(), (Feature2D)fc) != GLRLMFeature::featureset.end();
-					bool nonAngledGlrlmFeature = std::find(GLRLMFeature::nonAngledFeatures.begin(), GLRLMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLRLMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-					if (glrlmFeature && nonAngledGlrlmFeature == false)
-					{
-						// Populate with angles
-						int nAng = 4;
-						for (int i = 0; i < nAng; i++)
-						{
-							double fv = Nyxus::force_finite_number(vv[i], env.resultOptions.noval());	// safe feature value (no NAN, no inf)
-							snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
-	#ifndef DIAGNOSE_NYXUS_OUTPUT
-							ssVals << "," << rvbuf;
-	#else
-							//--diagnoze misalignment-- 
-							ssVals << "," << fn << "-" << rvbuf;
-	#endif
-						}
-						// Proceed with other features
-						continue;
-					}
-
-					// --Gabor
-					if (fc == (int) Feature2D::GABOR)
-					{
-						for (auto i = 0; i < GaborFeature::f0_theta_pairs.size(); i++)
-						{
-							double fv = Nyxus::force_finite_number(vv[i], env.resultOptions.noval());	// safe feature value (no NAN, no inf)
-							snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
-	#ifndef DIAGNOSE_NYXUS_OUTPUT
-							ssVals << "," << rvbuf;
-	#else	
-							//--diagnoze misalignment-- 
-							ssVals << "," << fn << "-" << rvbuf;
-	#endif			
-						}
-
-						// Proceed with other features
-						continue;
-					}
-
-					// --Zernike feature values
-					if (fc == (int) Feature2D::ZERNIKE2D)
-					{
-						for (int i = 0; i < ZernikeFeature::NUM_FEATURE_VALS; i++)
-						{
-							double fv = Nyxus::force_finite_number(vv[i], env.resultOptions.noval());	// safe feature value (no NAN, no inf)
-							snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
-	#ifndef DIAGNOSE_NYXUS_OUTPUT
-							ssVals << "," << rvbuf;
-	#else
-							//--diagnoze misalignment-- 
-							ssVals << "," << fn << "-" << rvbuf;
-	#endif
-						}
-
-						// Proceed with other features
-						continue;
-					}
-
-					// --Radial distribution features
-					if (fc == (int) Feature2D::FRAC_AT_D)
-					{
-						for (auto i = 0; i < RadialDistributionFeature::num_features_FracAtD; i++)
-						{
-							double fv = Nyxus::force_finite_number(vv[i], env.resultOptions.noval());	// safe feature value (no NAN, no inf)
-							snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
-	#ifndef DIAGNOSE_NYXUS_OUTPUT
-							ssVals << "," << rvbuf;
-	#else
-							//--diagnoze misalignment-- 
-							ssVals << "," << fn << "-" << rvbuf;
-	#endif
-						}
-						// Proceed with other features
-						continue;
-					}
-					if (fc == (int) Feature2D::MEAN_FRAC)
-					{
-						for (auto i = 0; i < RadialDistributionFeature::num_features_MeanFrac; i++)
-						{
-							double fv = Nyxus::force_finite_number(vv[i], env.resultOptions.noval());	// safe feature value (no NAN, no inf)
-							snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
-	#ifndef DIAGNOSE_NYXUS_OUTPUT
-							ssVals << "," << rvbuf;
-	#else
-							//--diagnoze misalignment-- 
-							ssVals << "," << fn << "-" << rvbuf;
-	#endif
-						}
-						// Proceed with other features
-						continue;
-					}
-					if (fc == (int) Feature2D::RADIAL_CV)
-					{
-						for (auto i = 0; i < RadialDistributionFeature::num_features_RadialCV; i++)
-						{
-							double fv = Nyxus::force_finite_number(vv[i], env.resultOptions.noval());	// safe feature value (no NAN, no inf)
-							snprintf(rvbuf, VAL_BUF_LEN, rvfmt, fv);
-	#ifndef DIAGNOSE_NYXUS_OUTPUT
-							ssVals << "," << rvbuf;
-	#else
-							//--diagnoze misalignment-- 
-							ssVals << "," << fn << "-" << rvbuf;
-	#endif
-						}
-						// Proceed with other features
-						continue;
-					}
-
-					// Regular feature
-					snprintf(rvbuf, VAL_BUF_LEN, rvfmt, Nyxus::force_finite_number(vv[0], env.resultOptions.noval()));
-	#ifndef DIAGNOSE_NYXUS_OUTPUT
-					ssVals << "," << rvbuf; // Alternatively: auto_precision(ssVals, vv[0]);
-	#else
-					//--diagnoze misalignment-- 
-					ssVals << "," << fn << "-" << rvbuf;
-	#endif
-				}
+				write_feature_values_csv(ssVals, r, F, env, rvbuf, VAL_BUF_LEN, rvfmt);
 
 				fprintf(fp, "%s\n", ssVals.str().c_str());
 			}
@@ -730,112 +589,13 @@ namespace Nyxus
 	{
 		std::vector<FTABLE_RECORD> features;
 
-		// user's feature selection
 		std::vector<std::tuple<std::string, int>> F = fset.getEnabledFeatures();
+		auto fvals = collect_feature_values(r, F);
 
-		// numeric columns
-		std::vector<double> fvals;
-
-		for (auto& enabdF : F)
-		{
-			auto fc = std::get<1>(enabdF);
-			auto vv = r.get_fvals(std::get<1>(enabdF));
-
-			// Parameterized feature
-			// --GLCM family
-			bool glcmFeature = std::find(GLCMFeature::featureset.begin(), GLCMFeature::featureset.end(), (Feature2D)fc) != GLCMFeature::featureset.end();
-			bool nonAngledGlcmFeature = std::find(GLCMFeature::nonAngledFeatures.begin(), GLCMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLCMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-			if (glcmFeature && nonAngledGlcmFeature == false)
-			{
-				// Mock angled values if they haven't been calculated for some error reason
-				if (vv.size() < GLCMFeature::angles.size())
-					vv.resize(GLCMFeature::angles.size(), 0.0);
-				// Output the sub-values
-				int nAng = (int)GLCMFeature::angles.size();
-				for (int i = 0; i < nAng; i++)
-				{
-					fvals.push_back(vv[i]);
-				}
-				// Proceed with other features
-				continue;
-			}
-
-			// --GLRLM family
-			bool glrlmFeature = std::find(GLRLMFeature::featureset.begin(), GLRLMFeature::featureset.end(), (Feature2D)fc) != GLRLMFeature::featureset.end();
-			bool nonAngledGlrlmFeature = std::find(GLRLMFeature::nonAngledFeatures.begin(), GLRLMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLRLMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-			if (glrlmFeature && nonAngledGlrlmFeature == false)
-			{
-				// Polulate with angles
-				int nAng = 4;
-				for (int i = 0; i < nAng; i++)
-				{
-					fvals.push_back(vv[i]);
-				}
-				// Proceed with other features
-				continue;
-			}
-
-			// --Gabor
-			if (fc == (int)Feature2D::GABOR)
-			{
-				for (auto i = 0; i < GaborFeature::f0_theta_pairs.size(); i++)
-				{
-					fvals.push_back(vv[i]);
-				}
-
-				// Proceed with other features
-				continue;
-			}
-
-			// --Zernike feature values
-			if (fc == (int)Feature2D::ZERNIKE2D)
-			{
-				for (int i = 0; i < ZernikeFeature::NUM_FEATURE_VALS; i++)
-				{
-					fvals.push_back(vv[i]);
-				}
-
-				// Proceed with other features
-				continue;
-			}
-
-			// --Radial distribution features
-			if (fc == (int)Feature2D::FRAC_AT_D)
-			{
-				for (auto i = 0; i < RadialDistributionFeature::num_features_FracAtD; i++)
-				{
-					fvals.push_back(vv[i]);
-				}
-				// Proceed with other features
-				continue;
-			}
-			if (fc == (int)Feature2D::MEAN_FRAC)
-			{
-				for (auto i = 0; i < RadialDistributionFeature::num_features_MeanFrac; i++)
-				{
-					fvals.push_back(vv[i]);
-				}
-				// Proceed with other features
-				continue;
-			}
-			if (fc == (int)Feature2D::RADIAL_CV)
-			{
-				for (auto i = 0; i < RadialDistributionFeature::num_features_RadialCV; i++)
-				{
-					fvals.push_back(vv[i]);
-				}
-				// Proceed with other features
-				continue;
-			}
-
-			fvals.push_back(vv[0]);
-		}
-
-		// other columns
 		std::vector<std::string> textcols;
 		textcols.push_back ((fs::path(ifpath)).filename().string());
 		textcols.push_back ("");
-		int roilabl = r.label; // whole-slide roi #
+		int roilabl = r.label;
 
 		features.push_back (std::make_tuple(textcols, roilabl, -999.88, fvals));
 
@@ -862,114 +622,19 @@ namespace Nyxus
 		{
 			const LR& r = roiData.at (l);
 
-			std::vector<double> feature_values;
-
 			// Skip blacklisted ROI
 			if (r.blacklisted)
 				continue;
 
 			// Tear off pure file names from segment and intensity file paths
 			const SlideProps& sli = dataset.dataset_props [r.slide_idx];
-			fs::path pseg (sli.fname_seg), 
+			fs::path pseg (sli.fname_seg),
 				pint (sli.fname_int);
 			std::vector<std::string> filenames;
 			filenames.push_back(pint.filename().string());
 			filenames.push_back(pseg.filename().string());
 
-			for (auto& enabdF : F)
-			{
-				auto fc = std::get<1>(enabdF);
-				auto vv = r.get_fvals(std::get<1>(enabdF));
-
-				// Parameterized feature
-				// --GLCM family
-				bool glcmFeature = std::find(GLCMFeature::featureset.begin(), GLCMFeature::featureset.end(), (Feature2D)fc) != GLCMFeature::featureset.end();
-				bool nonAngledGlcmFeature = std::find(GLCMFeature::nonAngledFeatures.begin(), GLCMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLCMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-				if (glcmFeature && nonAngledGlcmFeature == false)
-				{
-					// Mock angled values if they haven't been calculated for some error reason
-					if (vv.size() < GLCMFeature::angles.size())
-						vv.resize(GLCMFeature::angles.size(), 0.0);
-					// Output the sub-values
-					int nAng = (int) GLCMFeature::angles.size();
-					for (int i = 0; i < nAng; i++)
-					{
-						feature_values.push_back(vv[i]);
-					}
-					// Proceed with other features
-					continue;
-				}
-
-				// --GLRLM family
-				bool glrlmFeature = std::find(GLRLMFeature::featureset.begin(), GLRLMFeature::featureset.end(), (Feature2D)fc) != GLRLMFeature::featureset.end();
-				bool nonAngledGlrlmFeature = std::find(GLRLMFeature::nonAngledFeatures.begin(), GLRLMFeature::nonAngledFeatures.end(), (Feature2D)fc) != GLRLMFeature::nonAngledFeatures.end(); // prevent output of a non-angled feature in an angled way
-				if (glrlmFeature && nonAngledGlrlmFeature == false)
-				{
-					// Polulate with angles
-					int nAng = 4;
-					for (int i = 0; i < nAng; i++)
-					{
-						feature_values.push_back(vv[i]);
-					}
-					// Proceed with other features
-					continue;
-				}
-
-				// --Gabor
-				if (fc == (int) Feature2D::GABOR)
-				{
-					for (auto i = 0; i < GaborFeature::f0_theta_pairs.size(); i++)
-					{
-						feature_values.push_back(vv[i]);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				// --Zernike feature values
-				if (fc == (int) Feature2D::ZERNIKE2D)
-				{
-					for (int i = 0; i < ZernikeFeature::NUM_FEATURE_VALS; i++)
-					{
-						feature_values.push_back(vv[i]);
-					}
-
-					// Proceed with other features
-					continue;
-				}
-
-				// --Radial distribution features
-				if (fc == (int) Feature2D::FRAC_AT_D)
-				{
-					for (auto i = 0; i < RadialDistributionFeature::num_features_FracAtD; i++)
-					{
-						feature_values.push_back(vv[i]);
-					}
-					// Proceed with other features
-					continue;
-				}
-				if (fc == (int) Feature2D::MEAN_FRAC)
-				{
-					for (auto i = 0; i < RadialDistributionFeature::num_features_MeanFrac; i++)
-					{
-						feature_values.push_back(vv[i]);
-					}
-					// Proceed with other features
-					continue;
-				}
-				if (fc == (int) Feature2D::RADIAL_CV)
-				{
-					for (auto i = 0; i < RadialDistributionFeature::num_features_RadialCV; i++)
-					{
-						feature_values.push_back(vv[i]);
-					}
-					// Proceed with other features
-					continue;
-				}
-
-				feature_values.push_back(vv[0]);
-			}
+			auto feature_values = collect_feature_values(r, F);
 
 			features.push_back (std::make_tuple(filenames, l, DEFAULT_T_INDEX, feature_values));
 		}

--- a/src/nyx/parallel.h
+++ b/src/nyx/parallel.h
@@ -39,6 +39,14 @@ namespace Nyxus
 				idxE = datasetSize; // include the tail
 			T.push_back(std::async(std::launch::async, f, idxS, idxE, ptrLabels, ptrLabelData, std::cref(f_settings), std::cref(dataset)));
 		}
+		// Wait for all threads to complete before returning. This is
+		// necessary for correctness in all callers, not just fmaps mode:
+		// without explicit .get(), futures are only awaited by their
+		// destructors, which can race with the caller's scope exit and
+		// cause use-after-free when referenced data (labels, LR map,
+		// settings) is destroyed while threads are still running.
+		for (auto& fut : T)
+			fut.get();
 	}
 
 	void parallelReduceConvHull (size_t start, size_t end, std::vector<int>* ptrLabels, std::unordered_map <int, LR>* ptrLabelData, const Fsettings & fst, const Dataset & ds);

--- a/src/nyx/python/new_bindings_py.cpp
+++ b/src/nyx/python/new_bindings_py.cpp
@@ -13,6 +13,7 @@
 #include "../globals.h"
 #include "../nested_feature_aggregation.h"
 #include "../features/gabor.h"
+#include "../features/glcm.h"
 #include "../output_writers.h" 
 #include "../arrow_output_stream.h"
 #include "../strpat.h"
@@ -128,7 +129,8 @@ void initialize_environment(
     float aniso_y,
     float aniso_z,
     bool fmaps = false,
-    int fmaps_radius = 2)
+    int fmaps_radius = 2,
+    const std::string& glcm_direction_field = "")
 {
     Environment & theEnvironment = Nyxus::findenv (instid);
 
@@ -146,6 +148,18 @@ void initialize_environment(
     theEnvironment.fmaps_mode = fmaps;
     if (fmaps_radius >= 1)
         theEnvironment.fmaps_kernel_radius = fmaps_radius;
+
+    // GLCM direction field
+    if (!glcm_direction_field.empty())
+    {
+        theEnvironment.glcmOptions.rawDirectionField = glcm_direction_field;
+        std::string ermsg;
+        if (!theEnvironment.parse_glcm_options_raw_inputs(ermsg))
+            throw std::invalid_argument("Invalid GLCM direction field: " + ermsg);
+        
+        // Load the direction field immediately after parsing
+        theEnvironment.load_glcm_direction_field();
+    }
 
     // Throws exception if invalid feature is passed
     theEnvironment.expand_featuregroups();
@@ -811,13 +825,22 @@ py::tuple featurize_fname_lists_imp (uint64_t instid, const py::list& int_fnames
         }
 
         // we're good to extract features
-        errorCode = processDataset_2D_segmented(
-            theEnvironment,
-            intensFiles,
-            labelFiles,
-            theEnvironment.n_reduce_threads,
-            theEnvironment.saveOption,
-            output_path);
+        if (theEnvironment.fmaps_mode)
+            errorCode = processDataset_2D_fmaps(
+                theEnvironment,
+                intensFiles,
+                labelFiles,
+                theEnvironment.n_reduce_threads,
+                theEnvironment.saveOption,
+                output_path);
+        else
+            errorCode = processDataset_2D_segmented(
+                theEnvironment,
+                intensFiles,
+                labelFiles,
+                theEnvironment.n_reduce_threads,
+                theEnvironment.saveOption,
+                output_path);
     }
 
     if (errorCode)
@@ -1093,6 +1116,67 @@ void customize_gabor_feature_imp(
         throw std::invalid_argument("Invalid GABOR parameter value: " + ermsg);
 }
 
+void set_glcm_direction_field_imp(
+    uint64_t instid,
+    const std::string& direction_field_path)
+{
+    Environment & env = Nyxus::findenv (instid);
+
+    // Set the raw direction field path
+    env.glcmOptions.rawDirectionField = direction_field_path;
+
+    // Validate and parse
+    std::string ermsg;
+    if (!env.parse_glcm_options_raw_inputs(ermsg))
+        throw std::invalid_argument("Invalid GLCM direction field path: " + ermsg);
+    
+    // Load the direction field immediately
+    env.load_glcm_direction_field();
+}
+
+void set_glcm_direction_field_array_imp(
+    uint64_t instid,
+    py::array_t<float> direction_array)
+{
+    Environment & env = Nyxus::findenv (instid);
+    
+    auto buf = direction_array.request();
+    
+    // Validate dimensions: should be (height, width, 2) or (height, width, 3)
+    if (buf.ndim != 3)
+        throw std::invalid_argument("Direction field array must be 3-dimensional (height, width, channels)");
+    
+    int height = buf.shape[0];
+    int width = buf.shape[1];
+    int channels = buf.shape[2];
+    
+    if (channels < 2 || channels > 3)
+        throw std::invalid_argument("Direction field must have 2 or 3 channels (dx, dy[, dz])");
+    
+    // Create SimpleCube and copy data
+    env.glcm_direction_field_data = std::make_unique<SimpleCube<float>>(width, height, channels);
+    
+    float* src = static_cast<float*>(buf.ptr);
+    for (int ch = 0; ch < channels; ch++)
+    {
+        for (int row = 0; row < height; row++)
+        {
+            for (int col = 0; col < width; col++)
+            {
+                // numpy array is (row, col, channel), SimpleCube uses zyx(channel, row, col)
+                size_t src_idx = row * width * channels + col * channels + ch;
+                env.glcm_direction_field_data->zyx(ch, row, col) = src[src_idx];
+            }
+        }
+    }
+    
+    // Note: Normalization is not needed here because find_closest_canonical_direction()
+    // in glcm.cpp normalizes vectors internally before computing dot products
+    
+    // Set it on the GLCMFeature class
+    GLCMFeature::direction_field = env.glcm_direction_field_data.get();
+}
+
 std::map<std::string, ParameterTypes> get_params_imp (uint64_t instid, const std::vector<std::string>& vars )
 {
     Environment & theEnvironment = Nyxus::findenv (instid);
@@ -1233,6 +1317,8 @@ PYBIND11_MODULE(backend, m)
     m.def("clear_roi_blacklist_imp",    &clear_roi_blacklist_imp,   "Clear the ROI black list");
     m.def("roi_blacklist_get_summary_imp",  &roi_blacklist_get_summary_imp, "Returns a summary of the ROI blacklist");
     m.def("customize_gabor_feature_imp",    &customize_gabor_feature_imp,   "Sets custom GABOR feature's parameters");
+    m.def("set_glcm_direction_field_imp",   &set_glcm_direction_field_imp,  "Sets GLCM custom direction field path");
+    m.def("set_glcm_direction_field_array_imp", &set_glcm_direction_field_array_imp, "Sets GLCM custom direction field from numpy array");
     m.def("set_if_ibsi_imp",            &set_if_ibsi_imp,           "Set if the features will be ibsi compliant");
     m.def("set_fmaps_imp",              &set_fmaps_imp,             "Enable/disable feature maps mode and set kernel radius");
     m.def("set_environment_params_imp", &set_environment_params_imp,    "Set the environment variables of Nyxus");

--- a/src/nyx/python/new_bindings_py.cpp
+++ b/src/nyx/python/new_bindings_py.cpp
@@ -52,13 +52,60 @@ bool mine_segment_relations (
 template <typename Sequence>
 inline py::array_t<typename Sequence::value_type> as_pyarray(Sequence &&seq)
 {
-    auto size = seq.size();
-    auto data = seq.data();
-    std::unique_ptr<Sequence> seq_ptr = std::make_unique<Sequence>(std::move(seq));
-    auto capsule = py::capsule(seq_ptr.get(), [](void *p)
-                               { std::unique_ptr<Sequence>(reinterpret_cast<Sequence *>(p)); });
-    seq_ptr.release();
-    return py::array(size, data, capsule);
+    // Copy data into a numpy-owned array rather than wrapping the C++ memory
+    // with a pybind11 capsule. A capsule's destructor is compiled code inside
+    // this .so — if Python's GC frees the array after the .so is unloaded
+    // (e.g. during interpreter shutdown), the destructor call jumps to
+    // unmapped memory and segfaults. Copying avoids that by letting numpy
+    // manage the memory entirely with no reference back to this module.
+    using T = typename Sequence::value_type;
+    py::array_t<T> arr(seq.size());
+    std::copy(seq.begin(), seq.end(), arr.mutable_data());
+    return arr;
+}
+
+/// @brief Converts accumulated FmapArrayResult entries into a Python list of dicts.
+/// Each dict contains: parent_roi_label, intensity_image, mask_image, origin_x, origin_y,
+/// and a 'features' dict mapping feature names to numpy arrays.
+/// For 2D: arrays are (map_h, map_w). For 3D: arrays are (map_d, map_h, map_w).
+py::list fmap_results_to_python(ResultsCache & rescache)
+{
+    py::list result;
+    for (auto & fr : rescache.get_fmapArrayResults())
+    {
+        py::dict d;
+        d["parent_roi_label"] = fr.parent_label;
+        d["intensity_image"] = fr.intens_name;
+        d["mask_image"] = fr.seg_name;
+        d["origin_x"] = fr.origin_x;
+        d["origin_y"] = fr.origin_y;
+
+        bool is_3d = fr.map_d > 1;
+        if (is_3d)
+            d["origin_z"] = fr.origin_z;
+
+        size_t map_size = (size_t)fr.map_d * fr.map_h * fr.map_w;
+        size_t n_features = fr.feature_names.size();
+
+        py::dict features;
+        for (size_t fi = 0; fi < n_features; fi++)
+        {
+            py::array_t<double> arr;
+            if (is_3d)
+                arr = py::array_t<double>({fr.map_d, fr.map_h, fr.map_w});
+            else
+                arr = py::array_t<double>({fr.map_h, fr.map_w});
+            auto ptr = arr.mutable_data();
+            std::copy(
+                fr.feature_data.begin() + fi * map_size,
+                fr.feature_data.begin() + (fi + 1) * map_size,
+                ptr);
+            features[py::str(fr.feature_names[fi])] = arr;
+        }
+        d["features"] = features;
+        result.append(d);
+    }
+    return result;
 }
 
 void initialize_environment(
@@ -79,7 +126,9 @@ void initialize_environment(
     int verb_lvl,
     float aniso_x,
     float aniso_y,
-    float aniso_z)
+    float aniso_z,
+    bool fmaps = false,
+    int fmaps_radius = 2)
 {
     Environment & theEnvironment = Nyxus::findenv (instid);
 
@@ -92,6 +141,11 @@ void initialize_environment(
     theEnvironment.set_coarse_gray_depth(coarse_gray_depth);
     theEnvironment.n_reduce_threads = n_reduce_threads;
     theEnvironment.ibsi_compliance = ibsi;
+
+    // feature maps
+    theEnvironment.fmaps_mode = fmaps;
+    if (fmaps_radius >= 1)
+        theEnvironment.fmaps_kernel_radius = fmaps_radius;
 
     // Throws exception if invalid feature is passed
     theEnvironment.expand_featuregroups();
@@ -140,6 +194,23 @@ void set_if_ibsi_imp (uint64_t instid, bool ibsi)
 {
     Environment & env = Nyxus::findenv (instid);
     env.set_ibsi_compliance (ibsi);
+}
+
+void set_fmaps_imp (uint64_t instid, int set_mode, int radius)
+{
+    Environment & env = Nyxus::findenv (instid);
+    // Always validate radius when explicitly provided (not sentinel -1),
+    // even if fmaps_mode is false, to prevent stale invalid values
+    if (radius != -1)
+    {
+        if (radius >= 1)
+            env.fmaps_kernel_radius = radius;
+        else
+            throw std::invalid_argument("fmaps_radius must be an integer >= 1");
+    }
+    // set_mode: 0=disable, 1=enable, -1=leave unchanged (radius-only update)
+    if (set_mode >= 0)
+        env.fmaps_mode = (set_mode != 0);
 }
 
 void set_environment_params_imp (
@@ -267,7 +338,18 @@ py::tuple featurize_directory_imp(
 
     // run the workflow
     int ercode = 0;
-    if (env.singleROI)
+    if (env.fmaps_prevents_arrow())
+        throw std::runtime_error("Arrow/Parquet output is not supported in feature maps (fmaps) mode.");
+
+    if (env.fmaps_mode)
+        ercode = processDataset_2D_fmaps(
+            env,
+            intensFiles,
+            labelFiles,
+            env.n_reduce_threads,
+            env.saveOption,
+            output_path);
+    else if (env.singleROI)
         ercode = processDataset_2D_wholeslide(
             env,
             intensFiles,
@@ -286,10 +368,15 @@ py::tuple featurize_directory_imp(
     if (ercode)
         throw std::runtime_error("Error: " + std::to_string(ercode));
 
-    // shut down the output structures
+    // Fmaps mode returns spatial arrays, not a DataFrame
+    if (env.fmaps_mode && env.saveOption == Nyxus::SaveOption::saveBuffer)
+    {
+        auto fmaps = fmap_results_to_python(env.theResultsCache);
+        return py::make_tuple(fmaps);
+    }
 
     // shape the resulting data frame
-    
+
     if (env.saveOption == Nyxus::SaveOption::saveBuffer)
     {
         // has the backend produced any result ?
@@ -510,19 +597,39 @@ py::tuple featurize_directory_3D_imp(
         if (mayBerror.has_value())
             throw std::runtime_error ("Error traversing dataset: " + *mayBerror);
 
-        int errorCode = processDataset_3D_segmented(
-            theEnvironment,
-            intensFiles,
-            labelFiles,
-            theEnvironment.n_reduce_threads,
-            theEnvironment.saveOption,
-            output_path);
+        int errorCode = 0;
+        if (theEnvironment.fmaps_mode)
+        {
+            errorCode = processDataset_3D_fmaps(
+                theEnvironment,
+                intensFiles,
+                labelFiles,
+                theEnvironment.n_reduce_threads,
+                theEnvironment.saveOption,
+                output_path);
+        }
+        else
+        {
+            errorCode = processDataset_3D_segmented(
+                theEnvironment,
+                intensFiles,
+                labelFiles,
+                theEnvironment.n_reduce_threads,
+                theEnvironment.saveOption,
+                output_path);
+        }
 
         if (errorCode)
             throw std::runtime_error ("Error " + std::to_string(errorCode) + " occurred during dataset processing");
     }
 
     // Output the result
+    if (theEnvironment.fmaps_mode && theEnvironment.saveOption == Nyxus::SaveOption::saveBuffer)
+    {
+        py::list fmaps = fmap_results_to_python(theEnvironment.theResultsCache);
+        return py::make_tuple(fmaps);
+    }
+
     if (theEnvironment.saveOption == Nyxus::SaveOption::saveBuffer)
     {
         auto pyHeader = py::array(py::cast(theEnvironment.theResultsCache.get_headerBuf()));
@@ -607,6 +714,12 @@ py::tuple featurize_montage_imp (
     if (mayBerror.has_value())
         throw std::runtime_error ("Error occurred during dataset processing: " + *mayBerror);
 
+    if (theEnvironment.fmaps_mode)
+    {
+        auto fmaps = fmap_results_to_python(theEnvironment.theResultsCache);
+        return py::make_tuple(fmaps, error_message);
+    }
+
     if (theEnvironment.saveOption == Nyxus::SaveOption::saveBuffer) {
 
         auto pyHeader = py::array(py::cast(theEnvironment.theResultsCache.get_headerBuf()));
@@ -618,7 +731,7 @@ py::tuple featurize_montage_imp (
         pyNumData = pyNumData.reshape({ nRows, pyNumData.size() / nRows });
 
         return py::make_tuple(pyHeader, pyStrData, pyNumData, error_message);
-    } 
+    }
 
     return py::make_tuple(error_message);
 }
@@ -709,6 +822,12 @@ py::tuple featurize_fname_lists_imp (uint64_t instid, const py::list& int_fnames
 
     if (errorCode)
         throw std::runtime_error("Error occurred during dataset processing.");
+
+    if (theEnvironment.fmaps_mode && theEnvironment.saveOption == Nyxus::SaveOption::saveBuffer)
+    {
+        auto fmaps = fmap_results_to_python(theEnvironment.theResultsCache);
+        return py::make_tuple(fmaps);
+    }
 
     if (theEnvironment.saveOption == Nyxus::SaveOption::saveBuffer) {
 
@@ -802,18 +921,37 @@ py::tuple featurize_fname_lists_3D_imp (
             }
     }();
 
-    errorCode = processDataset_3D_segmented(
-        theEnvironment,
-        ifiles,
-        mfiles,
-        theEnvironment.n_reduce_threads,
-        theEnvironment.saveOption,
-        output_path);
+    if (theEnvironment.fmaps_mode)
+    {
+        errorCode = processDataset_3D_fmaps(
+            theEnvironment,
+            ifiles,
+            mfiles,
+            theEnvironment.n_reduce_threads,
+            theEnvironment.saveOption,
+            output_path);
+    }
+    else
+    {
+        errorCode = processDataset_3D_segmented(
+            theEnvironment,
+            ifiles,
+            mfiles,
+            theEnvironment.n_reduce_threads,
+            theEnvironment.saveOption,
+            output_path);
+    }
 
     if (errorCode)
         throw std::runtime_error("Error occurred during dataset processing");
 
     // save the result
+    if (theEnvironment.fmaps_mode && theEnvironment.saveOption == Nyxus::SaveOption::saveBuffer)
+    {
+        py::list fmaps = fmap_results_to_python(theEnvironment.theResultsCache);
+        return py::make_tuple(fmaps);
+    }
+
     if (theEnvironment.saveOption == Nyxus::SaveOption::saveBuffer)
     {
         auto pyHeader = py::array(py::cast(theEnvironment.theResultsCache.get_headerBuf()));
@@ -988,7 +1126,10 @@ std::map<std::string, ParameterTypes> get_params_imp (uint64_t instid, const std
     params["max_intensity"] = theEnvironment.fpimageOptions.max_intensity();
     params["ram_limit"] = (int)(theEnvironment.get_ram_limit()/1048576); // convert from bytes to megabytes
 
-    if (vars.size() == 0) 
+    params["fmaps"] = theEnvironment.fmaps_mode;
+    params["fmaps_radius"] = theEnvironment.fmaps_kernel_radius;
+
+    if (vars.size() == 0)
         return params;
 
     std::map<std::string, ParameterTypes> params_subset;
@@ -1066,6 +1207,18 @@ py::tuple get_metaparam_imp (uint64_t instid, const std::string p_name)
 PYBIND11_MODULE(backend, m)
 {
     m.doc() = "Nyxus";
+
+    // Register an atexit handler to destroy all Environment objects while
+    // the Python interpreter is still alive.  Without this, the global
+    // pynyxus_cache is destroyed during C++ static destruction — after
+    // Python has already torn down modules — causing segfaults from
+    // stale references in LR/ImageMatrix/ResultsCache destructors.
+    auto atexit = py::module_::import("atexit");
+    atexit.attr("register")(py::cpp_function([]() {
+        Nyxus::pynyxus_cache.clear();
+        Nyxus::unique_pynyxus_ids.clear();
+    }));
+
     m.def("initialize_environment",     &initialize_environment,    "Environment initialization");
     m.def("featurize_directory_imp",    &featurize_directory_imp,   "Calculate features of images defined by intensity and mask image collection directories");
     m.def("featurize_directory_3D_imp", &featurize_directory_3D_imp,    "Calculate 3D features of images defined by intensity and mask image collection directories");
@@ -1081,6 +1234,7 @@ PYBIND11_MODULE(backend, m)
     m.def("roi_blacklist_get_summary_imp",  &roi_blacklist_get_summary_imp, "Returns a summary of the ROI blacklist");
     m.def("customize_gabor_feature_imp",    &customize_gabor_feature_imp,   "Sets custom GABOR feature's parameters");
     m.def("set_if_ibsi_imp",            &set_if_ibsi_imp,           "Set if the features will be ibsi compliant");
+    m.def("set_fmaps_imp",              &set_fmaps_imp,             "Enable/disable feature maps mode and set kernel radius");
     m.def("set_environment_params_imp", &set_environment_params_imp,    "Set the environment variables of Nyxus");
     m.def("get_params_imp",             &get_params_imp,            "Get parameters of Nyxus");
     m.def("arrow_is_enabled_imp",       &arrow_is_enabled_imp,      "Check if arrow is enabled.");

--- a/src/nyx/python/nyxus/__init__.py
+++ b/src/nyx/python/nyxus/__init__.py
@@ -3,6 +3,7 @@ from .nyxus import Nyxus3D
 from .nyxus import Nested
 from .nyxus import ImageQuality
 from .functions import gpu_is_available, get_gpu_properties
+from .fmap_io import save_fmaps_to_tiff, save_fmaps_to_nifti
 
 from . import _version
 __version__ = _version.get_versions()['version']

--- a/src/nyx/python/nyxus/fmap_io.py
+++ b/src/nyx/python/nyxus/fmap_io.py
@@ -1,0 +1,174 @@
+"""Utilities for saving feature-map (fmaps) results to image formats.
+
+Feature-map results from Nyxus/Nyxus3D are returned as a list of dicts,
+one per parent ROI, each containing numpy arrays of spatial feature maps.
+These utilities write those arrays to TIFF stacks or NIfTI volumes so
+they can be consumed by downstream imaging and ML pipelines.
+"""
+
+import os
+import numpy as np
+from typing import List, Dict, Optional
+
+
+def save_fmaps_to_tiff(
+    fmaps: List[Dict],
+    output_dir: str,
+    prefix: str = "fmap",
+    features: Optional[List[str]] = None,
+):
+    """Save 2D feature maps to multi-page TIFF files.
+
+    For each parent ROI, creates one TIFF per feature. If the feature map
+    is 3D (D, H, W), each z-slice becomes a page in the TIFF stack.
+
+    Requires ``tifffile`` (``pip install tifffile``).
+
+    Parameters
+    ----------
+    fmaps : list[dict]
+        Feature-map results from ``Nyxus.featurize_directory()`` or similar,
+        obtained with ``fmaps=True``.
+    output_dir : str
+        Directory to write TIFF files into. Created if it does not exist.
+    prefix : str, optional
+        Filename prefix. Default ``"fmap"``.
+    features : list[str], optional
+        Subset of feature names to save. Default saves all features.
+
+    Returns
+    -------
+    list[str]
+        Paths of all TIFF files written.
+    """
+    try:
+        import tifffile
+    except ImportError:
+        raise ImportError(
+            "tifffile is required for TIFF export. Install it with: pip install tifffile"
+        )
+
+    os.makedirs(output_dir, exist_ok=True)
+    written = []
+
+    for roi_result in fmaps:
+        roi_label = roi_result["parent_roi_label"]
+        feat_dict = roi_result["features"]
+
+        names = features if features else list(feat_dict.keys())
+
+        for feat_name in names:
+            if feat_name not in feat_dict:
+                continue
+            arr = feat_dict[feat_name]
+
+            # Ensure float32 for compatibility
+            arr = np.asarray(arr, dtype=np.float32)
+
+            fname = f"{prefix}_roi{roi_label}_{feat_name}.tif"
+            fpath = os.path.join(output_dir, fname)
+
+            if arr.ndim == 2:
+                tifffile.imwrite(fpath, arr)
+            elif arr.ndim == 3:
+                # (D, H, W) -> multi-page TIFF
+                tifffile.imwrite(fpath, arr)
+            else:
+                raise ValueError(
+                    f"Unexpected array dimensions {arr.ndim} for feature '{feat_name}'"
+                )
+
+            written.append(fpath)
+
+    return written
+
+
+def save_fmaps_to_nifti(
+    fmaps: List[Dict],
+    output_dir: str,
+    prefix: str = "fmap",
+    features: Optional[List[str]] = None,
+    voxel_size: tuple = (1.0, 1.0, 1.0),
+):
+    """Save 3D feature maps to NIfTI-1 (.nii.gz) volumes.
+
+    For each parent ROI, creates one NIfTI file per feature.
+    The affine is set so the origin matches the ROI's global coordinates.
+
+    Requires ``nibabel`` (``pip install nibabel``).
+
+    Parameters
+    ----------
+    fmaps : list[dict]
+        Feature-map results from ``Nyxus3D.featurize_directory()`` or similar,
+        obtained with ``fmaps=True``.
+    output_dir : str
+        Directory to write NIfTI files into. Created if it does not exist.
+    prefix : str, optional
+        Filename prefix. Default ``"fmap"``.
+    features : list[str], optional
+        Subset of feature names to save. Default saves all features.
+    voxel_size : tuple of float, optional
+        Voxel dimensions (x, y, z) in physical units. Default ``(1.0, 1.0, 1.0)``.
+
+    Returns
+    -------
+    list[str]
+        Paths of all NIfTI files written.
+    """
+    try:
+        import nibabel as nib
+    except ImportError:
+        raise ImportError(
+            "nibabel is required for NIfTI export. Install it with: pip install nibabel"
+        )
+
+    os.makedirs(output_dir, exist_ok=True)
+    written = []
+
+    for roi_result in fmaps:
+        roi_label = roi_result["parent_roi_label"]
+        feat_dict = roi_result["features"]
+        origin_x = roi_result.get("origin_x", 0)
+        origin_y = roi_result.get("origin_y", 0)
+        origin_z = roi_result.get("origin_z", 0)
+
+        names = features if features else list(feat_dict.keys())
+
+        for feat_name in names:
+            if feat_name not in feat_dict:
+                continue
+            arr = feat_dict[feat_name]
+            arr = np.asarray(arr, dtype=np.float32)
+
+            # For 2D maps, add a singleton z-dimension
+            if arr.ndim == 2:
+                arr = arr[np.newaxis, :, :]
+
+            if arr.ndim != 3:
+                raise ValueError(
+                    f"Unexpected array dimensions {arr.ndim} for feature '{feat_name}'"
+                )
+
+            # NIfTI expects (x, y, z) axis order; our arrays are (D, H, W)
+            # Transpose to (W, H, D) = (x, y, z) for NIfTI convention
+            arr_nifti = np.transpose(arr, (2, 1, 0))
+
+            # Build affine: diagonal scaling + translation to ROI origin
+            affine = np.eye(4)
+            affine[0, 0] = voxel_size[0]
+            affine[1, 1] = voxel_size[1]
+            affine[2, 2] = voxel_size[2]
+            affine[0, 3] = origin_x * voxel_size[0]
+            affine[1, 3] = origin_y * voxel_size[1]
+            affine[2, 3] = origin_z * voxel_size[2]
+
+            img = nib.Nifti1Image(arr_nifti, affine)
+
+            fname = f"{prefix}_roi{roi_label}_{feat_name}.nii.gz"
+            fpath = os.path.join(output_dir, fname)
+            nib.save(img, fpath)
+
+            written.append(fpath)
+
+    return written

--- a/src/nyx/python/nyxus/nyxus.py
+++ b/src/nyx/python/nyxus/nyxus.py
@@ -13,10 +13,11 @@ from .backend import (
     roi_blacklist_get_summary_imp,
     customize_gabor_feature_imp,
     set_if_ibsi_imp,
+    set_fmaps_imp,
     set_environment_params_imp,
     get_params_imp,
     arrow_is_enabled_imp,
-    get_arrow_file_imp, 
+    get_arrow_file_imp,
     get_parquet_file_imp,
     set_metaparam_imp,
     get_metaparam_imp)
@@ -120,6 +121,16 @@ class Nyxus:
         X-dimension scale factor
     anisotropy_y: float (optional, default 1.0)
         Y-dimension scale factor
+    fmaps: bool (optional, default False)
+        Enable feature maps mode. Instead of computing a single feature vector per ROI,
+        a sliding kernel is moved across each ROI and features are computed at every
+        position, producing spatial feature maps as numpy arrays.
+        When enabled, featurize methods return a list of dicts (one per parent ROI)
+        instead of a DataFrame. Each dict contains numpy arrays shaped (map_h, map_w).
+    fmaps_radius: int (optional, default 2)
+        Radius of the sliding kernel used in feature maps mode.
+        The kernel size is (2 * fmaps_radius + 1). For example, fmaps_radius=2
+        produces a 5x5 kernel. Must be >= 1.
     """
 
     def __init__(
@@ -131,10 +142,11 @@ class Nyxus:
             'neighbor_distance', 'pixels_per_micron', 'coarse_gray_depth',
             'n_feature_calc_threads', 'use_gpu_device', 'ibsi',
             'gabor_kersize', 'gabor_gamma', 'gabor_sig2lam', 'gabor_f0',
-            'gabor_thold', 'gabor_thetas', 'gabor_freqs', 'channel_signature', 
+            'gabor_thold', 'gabor_thetas', 'gabor_freqs', 'channel_signature',
             'parent_channel', 'child_channel', 'aggregate', 'dynamic_range', 'min_intensity',
             'max_intensity', 'ram_limit', 'verbose',
-            'anisotropy_x', 'anisotropy_y'
+            'anisotropy_x', 'anisotropy_y',
+            'fmaps', 'fmaps_radius',
         }
 
         # Check for unexpected keyword arguments
@@ -164,7 +176,9 @@ class Nyxus:
         verb_lvl = kwargs.get('verbose', 0)
         aniso_x = kwargs.get('anisotropy_x', 1.0)
         aniso_y = kwargs.get('anisotropy_y', 1.0)
-        
+        fmaps = kwargs.get('fmaps', False)
+        fmaps_radius = kwargs.get('fmaps_radius', 2)
+
         if neighbor_distance <= 0:
             raise ValueError("Neighbor distance must be greater than zero.")
 
@@ -189,6 +203,11 @@ class Nyxus:
         if aniso_y <= 0:
             raise ValueError ("anisotropy_y must be positive")
 
+        if fmaps and fmaps_radius < 1:
+            raise ValueError("fmaps_radius must be an integer >= 1")
+
+        self._fmaps = fmaps
+
         aniso_z = 1.0   # not used in 2D
 
         initialize_environment(
@@ -197,7 +216,7 @@ class Nyxus:
             features,
             neighbor_distance,
             pixels_per_micron,
-            coarse_gray_depth, 
+            coarse_gray_depth,
             n_feature_calc_threads,
             use_gpu_device,
             ibsi,
@@ -209,7 +228,9 @@ class Nyxus:
             verb_lvl,
             aniso_x,
             aniso_y,
-            aniso_z) 
+            aniso_z,
+            fmaps,
+            fmaps_radius)
 
         self.set_gabor_feature_params(
             kersize = gabor_kersize,
@@ -320,9 +341,13 @@ class Nyxus:
 
         if (output_type not in self._valid_output_types):
             raise  ValueError(f'Invalid output type {output_type}. Valid output types are {self._valid_output_types}.')
-            
+
+        if self._fmaps and output_type == 'pandas':
+            result = featurize_directory_imp(id(self), intensity_dir, label_dir, file_pattern, output_type, "")
+            return result[0]  # list of dicts with numpy array feature maps
+
         if (output_type == 'pandas'):
-            
+
             header, string_data, numeric_data = featurize_directory_imp (id(self), intensity_dir, label_dir, file_pattern, output_type, "")
 
             df = pd.concat(
@@ -338,11 +363,11 @@ class Nyxus:
                 df.ROI_label = df.ROI_label.astype(np.uint32)
 
             return df
-        
+
         else:
-            
+
             featurize_directory_imp (id(self), intensity_dir, label_dir, file_pattern, output_type, output_path)
-            
+
             return get_arrow_file_imp (id(self)) # return path to file
 
 
@@ -453,6 +478,13 @@ class Nyxus:
         M = label_images.astype (np.uint32)
 
         # featurize
+        if self._fmaps and output_type == 'pandas':
+            fmaps_list, error_message = featurize_montage_imp(id(self), I, M, intensity_names, label_names, output_type, "")
+            self.error_message = error_message
+            if error_message != '':
+                print(error_message)
+            return fmaps_list  # list of dicts with numpy array feature maps
+
         if (output_type == 'pandas'):
             header, string_data, numeric_data, error_message = featurize_montage_imp (id(self), I, M, intensity_names, label_names, output_type, "")
             self.error_message = error_message
@@ -472,13 +504,13 @@ class Nyxus:
                 df.ROI_label = df.ROI_label.astype(np.uint32)
 
             return df
-            
+
         else:
             ret = featurize_montage_imp (id(self), I, M, intensity_names, label_names, output_type, output_path)
             self.error_message = ret[0]
             if(self.error_message != ''):
                 raise RuntimeError('Error calculating features: ' + error_message[0])
-            
+
             return get_arrow_file_imp (id(self)) # return path to file
                 
     
@@ -531,8 +563,12 @@ class Nyxus:
         if (output_type not in self._valid_output_types):
             raise  ValueError(f'Invalid output type {output_type}. Valid output types are {self._valid_output_types}')
 
+        if self._fmaps and output_type == 'pandas':
+            result = featurize_fname_lists_imp(id(self), intensity_files, mask_files, single_roi, output_type, "")
+            return result[0]  # list of dicts with numpy array feature maps
+
         if (output_type == 'pandas'):
-            
+
             header, string_data, numeric_data = featurize_fname_lists_imp (id(self), intensity_files, mask_files, single_roi, output_type, "")
 
             df = pd.concat(
@@ -548,9 +584,9 @@ class Nyxus:
                 df.ROI_label = df.ROI_label.astype(np.uint32)
 
             return df
-        
+
         else:
-            
+
             featurize_fname_lists_imp (id(self), intensity_files, mask_files, single_roi, output_type, output_path)
             return get_arrow_file_imp (id(self))
 
@@ -698,11 +734,11 @@ class Nyxus:
             'max_intensity',
             'ram_limit',
         ]
-        
+
         for key in params:
             if key not in valid_params:
                 raise ValueError(f'Invalid environment parameter {key}. Value parameters are {params}')
-        
+
         features = params.get('features', [])
         neighbor_distance = params.get ('neighbor_distance', -1)
         pixels_per_micron = params.get ('pixels_per_micron', -1)
@@ -714,10 +750,10 @@ class Nyxus:
         min_intensity = params.get('min_intensity', -1)
         max_intensity = params.get('max_intensity', -1)
         ram_limit = params.get('ram_limit', -1)
-        
+
         set_environment_params_imp (id(self),
-                                   features, 
-                                   neighbor_distance, 
+                                   features,
+                                   neighbor_distance,
                                    pixels_per_micron,
                                    coarse_gray_depth,
                                    n_reduce_threads,
@@ -775,19 +811,31 @@ class Nyxus:
         for key, value in params.items():
             if key.startswith("gabor_"):
                 gabor_params[key[len("gabor_"):]] = value
-            
+
             elif (key == "ibsi"):
                 set_if_ibsi_imp (id(self), value)
-            
+
+            elif key in ("fmaps", "fmaps_radius"):
+                pass  # handled after loop to avoid double-processing
+
             else:
                 if (key not in available_environment_params):
                     raise ValueError ("Invalid parameter: ", key)
                 else:
                     environment_params[key] = value
-                
+
+        # Update fmaps settings if either param was provided.
+        # -1 sentinel means "leave unchanged" for that param.
+        if "fmaps" in params or "fmaps_radius" in params:
+            mode = int(bool(params["fmaps"])) if "fmaps" in params else -1
+            radius = params.get("fmaps_radius", -1)
+            set_fmaps_imp(id(self), mode, radius)
+            if "fmaps" in params:
+                self._fmaps = bool(params["fmaps"])
+
         if (len(gabor_params) > 0):
             self.set_gabor_feature_params(**gabor_params)
-        
+
         if (len(environment_params) > 0):
             self.set_environment_params(**environment_params)
 
@@ -944,6 +992,16 @@ class Nyxus3D:
         Y-dimension scale factor
     anisotropy_z: float (optional, default 1.0)
         Z-dimension scale factor
+    fmaps: bool (optional, default False)
+        Enable feature maps mode. Instead of computing a single feature vector per ROI,
+        a sliding kernel is moved across each ROI and features are computed at every
+        voxel position, producing spatial feature maps as numpy arrays.
+        When enabled, featurize methods return a list of dicts (one per parent ROI)
+        instead of a DataFrame. Each dict contains numpy arrays shaped (map_d, map_h, map_w).
+    fmaps_radius: int (optional, default 2)
+        Radius of the sliding kernel used in feature maps mode.
+        The kernel size is (2 * fmaps_radius + 1). For example, fmaps_radius=2
+        produces a 5x5x5 kernel. Must be >= 1.
     """
 
     def __init__(
@@ -953,20 +1011,21 @@ class Nyxus3D:
         ):
         valid_keys = {
             'neighbor_distance', 'pixels_per_micron', 'coarse_gray_depth',
-            'n_feature_calc_threads', 'use_gpu_device', 'ibsi', 'channel_signature', 
-            'parent_channel', 'child_channel', 'aggregate', 
+            'n_feature_calc_threads', 'use_gpu_device', 'ibsi', 'channel_signature',
+            'parent_channel', 'child_channel', 'aggregate',
             'dynamic_range', 'min_intensity', 'max_intensity', 'ram_limit',
             'verbose',
-            'anisotropy_x', 
+            'anisotropy_x',
             'anisotropy_y',
-            'anisotropy_z'
+            'anisotropy_z',
+            'fmaps', 'fmaps_radius',
         }
 
         # Check for unexpected keyword arguments
         invalid_keys = set(kwargs.keys()) - valid_keys
         if invalid_keys:
             print(f"Warning: unexpected keyword argument(s): {', '.join(invalid_keys)}")
-        
+
         # parse kwargs
         features = features
         neighbor_distance = kwargs.get('neighbor_distance', 5)
@@ -982,7 +1041,9 @@ class Nyxus3D:
         aniso_x = kwargs.get('anisotropy_x', 1.0)
         aniso_y = kwargs.get('anisotropy_y', 1.0)
         aniso_z = kwargs.get('anisotropy_z', 1.0)
-        
+        fmaps = kwargs.get('fmaps', False)
+        fmaps_radius = kwargs.get('fmaps_radius', 2)
+
         if neighbor_distance <= 0:
             raise ValueError("Neighbor distance must be greater than zero.")
 
@@ -994,7 +1055,7 @@ class Nyxus3D:
 
         if n_feature_calc_threads < 1:
             raise ValueError("There must be at least one feature calculation thread.")
-        
+
         if(use_gpu_device > -1 and n_feature_calc_threads != 1):
             print("Gpu features only support a single thread. Defaulting to one thread.")
             n_feature_calc_threads = 1
@@ -1017,13 +1078,18 @@ class Nyxus3D:
         if aniso_z <= 0:
             raise ValueError ("anisotropy_z must be positive")
 
+        if fmaps and fmaps_radius < 1:
+            raise ValueError("fmaps_radius must be an integer >= 1")
+
+        self._fmaps = fmaps
+
         initialize_environment(
             id(self),
             3, # 3D
             features,
             neighbor_distance,
             pixels_per_micron,
-            coarse_gray_depth, 
+            coarse_gray_depth,
             n_feature_calc_threads,
             use_gpu_device,
             ibsi,
@@ -1035,8 +1101,10 @@ class Nyxus3D:
             verb_lvl,
             aniso_x,
             aniso_y,
-            aniso_z)
-        
+            aniso_z,
+            fmaps,
+            fmaps_radius)
+
         # list of valid outputs that are used throughout featurize functions
         self._valid_output_types = ['pandas', 'arrowipc', 'parquet']
 
@@ -1135,7 +1203,11 @@ class Nyxus3D:
 
         if (output_type not in self._valid_output_types):
             raise  ValueError(f'Invalid output type {output_type}. Valid output types are {self._valid_output_types}.')
-            
+
+        if self._fmaps and output_type == 'pandas':
+            result = featurize_directory_3D_imp(id(self), intensity_dir, label_dir, file_pattern, output_type, "")
+            return result[0]  # list of dicts with numpy array feature maps
+
         if (output_type == 'pandas'):
             header, string_data, numeric_data = featurize_directory_3D_imp (id(self), intensity_dir, label_dir, file_pattern, output_type, "")
             df = pd.concat(
@@ -1200,8 +1272,12 @@ class Nyxus3D:
         if (output_type not in self._valid_output_types):
             raise  ValueError(f'Invalid output type {output_type}. Valid output types are {self._valid_output_types}')
 
+        if self._fmaps and output_type == 'pandas':
+            result = featurize_fname_lists_3D_imp(id(self), intensity_files, mask_files, single_roi, output_type, "")
+            return result[0]  # list of dicts with numpy array feature maps
+
         if (output_type == 'pandas'):
-            
+
             header, string_data, numeric_data = featurize_fname_lists_3D_imp (id(self), intensity_files, mask_files, single_roi, output_type, "")
 
             df = pd.concat(
@@ -1217,9 +1293,9 @@ class Nyxus3D:
                 df.ROI_label = df.ROI_label.astype(np.uint32)
 
             return df
-        
+
         else:
-            
+
             featurize_fname_lists_3D_imp (id(self), intensity_files, mask_files, single_roi, output_type, output_path)
             return get_arrow_file_imp (id(self))
 
@@ -1257,13 +1333,13 @@ class Nyxus3D:
             'verbose',
             'dynamic_range',
             'min_intensity',
-            'max_intensity'
+            'max_intensity',
         ]
-        
+
         for key in params:
             if key not in valid_params:
                 raise ValueError(f'Invalid environment parameter {key}. Value parameters are {params}')
-        
+
         features = params.get('features', [])
         neighbor_distance = params.get ('neighbor_distance', -1)
         pixels_per_micron = params.get ('pixels_per_micron', -1)
@@ -1275,10 +1351,10 @@ class Nyxus3D:
         min_intensity = params.get('min_intensity', -1)
         max_intensity = params.get('max_intensity', -1)
         ram_limit = -1 # no limit
-        
+
         set_environment_params_imp (id(self),
-                                   features, 
-                                   neighbor_distance, 
+                                   features,
+                                   neighbor_distance,
                                    pixels_per_micron,
                                    coarse_gray_depth,
                                    n_reduce_threads,
@@ -1288,12 +1364,12 @@ class Nyxus3D:
                                    max_intensity,
                                    ram_limit,
                                    verb_lvl)
-        
+
     def set_params(self, **params):
         """Sets parameters of the Nyxus class
 
         Keyword args:
-        
+
         * features: List[str],
         * neighbor_distance
         * pixels_per_micron
@@ -1326,17 +1402,16 @@ class Nyxus3D:
         
         
         for key, value in params.items():
-           
+
             if (key == "ibsi"):
                 set_if_ibsi_imp (id(self), value)
-            
+
             else:
                 if (key not in available_environment_params):
                     raise ValueError(f"Invalid parameter {key}.")
                 else:
                     environment_params[key] = value
-                
-                        
+
         if (len(environment_params) > 0):
             self.set_environment_params(**environment_params)
     
@@ -1550,7 +1625,7 @@ class ImageQuality:
             features,
             neighbor_distance,
             pixels_per_micron,
-            coarse_gray_depth, 
+            coarse_gray_depth,
             n_feature_calc_threads,
             using_gpu,
             ibsi,
@@ -1562,8 +1637,10 @@ class ImageQuality:
             verb_lvl,
             aniso_x,
             aniso_y,
-            aniso_z)
-        
+            aniso_z,
+            False,
+            2)
+
         # list of valid outputs that are used throughout featurize functions
         self._valid_output_types = ['pandas', 'arrowipc', 'parquet']
 
@@ -1991,13 +2068,13 @@ class ImageQuality:
             'verbose',
             'dynamic_range',
             'min_intensity',
-            'max_intensity'
+            'max_intensity',
         ]
-        
+
         for key in params:
             if key not in valid_params:
                 raise ValueError(f'Invalid environment parameter {key}. Value parameters are {params}')
-        
+
         features = params.get('features', [])
         neighbor_distance = params.get ('neighbor_distance', -1)
         pixels_per_micron = params.get ('pixels_per_micron', -1)
@@ -2009,10 +2086,10 @@ class ImageQuality:
         min_intensity = params.get('min_intensity', -1)
         max_intensity = params.get('max_intensity', -1)
         ram_limit = -1 # no limit
-        
+
         set_environment_params_imp (id(self),
                                    features,
-                                   neighbor_distance, 
+                                   neighbor_distance,
                                    pixels_per_micron,
                                    coarse_gray_depth,
                                    n_reduce_threads,
@@ -2022,7 +2099,7 @@ class ImageQuality:
                                    max_intensity,
                                    ram_limit,
                                    verb_lvl)
-        
+
     def set_params(self, **params):
         """Sets parameters of the Nyxus class
 

--- a/src/nyx/python/nyxus/nyxus.py
+++ b/src/nyx/python/nyxus/nyxus.py
@@ -12,6 +12,8 @@ from .backend import (
     clear_roi_blacklist_imp,
     roi_blacklist_get_summary_imp,
     customize_gabor_feature_imp,
+    set_glcm_direction_field_imp,
+    set_glcm_direction_field_array_imp,
     set_if_ibsi_imp,
     set_fmaps_imp,
     set_environment_params_imp,
@@ -223,14 +225,16 @@ class Nyxus:
             dynamic_range,
             min_intensity,
             max_intensity,
-            False,
+            False,  # is_imq
             ram_limit,
             verb_lvl,
             aniso_x,
             aniso_y,
             aniso_z,
             fmaps,
-            fmaps_radius)
+            fmaps_radius,
+            ""  # glcm_direction_field
+        )
 
         self.set_gabor_feature_params(
             kersize = gabor_kersize,
@@ -697,6 +701,32 @@ class Nyxus:
 
         customize_gabor_feature_imp (id(self), kersize, gamma, sig2lam, f0, thetas, thold, freqs)
 
+    def set_glcm_direction_field(self, direction_field_path: str):
+        """Set the path to a NIfTI or TIFF file containing custom GLCM direction field.
+        
+        The direction field should be a multi-channel file with 2 channels for 2D (dx, dy)
+        or 3 channels for 3D (dx, dy, dz).
+        
+        Parameters
+        ----------
+        direction_field_path : str
+            Path to the TIFF or NIfTI file containing the direction field
+        """
+        set_glcm_direction_field_imp(id(self), direction_field_path)
+    
+    def set_glcm_direction_field_array(self, direction_array):
+        """Set custom GLCM direction field from a numpy array.
+        
+        The direction array should have shape (height, width, 2) for 2D
+        or (depth, height, width, 3) for 3D, where the last dimension
+        contains the direction components (dx, dy[, dz]).
+        
+        Parameters
+        ----------
+        direction_array : np.ndarray
+            Array containing direction vectors
+        """
+        set_glcm_direction_field_array_imp(id(self), direction_array)
     
     def set_environment_params (self, **params):
         """Sets parameters of the environment for Nyxus
@@ -1096,14 +1126,16 @@ class Nyxus3D:
             dynamic_range,
             min_intensity,
             max_intensity,
-            False,
+            False,  # is_imq
             ram_limit,
             verb_lvl,
             aniso_x,
             aniso_y,
             aniso_z,
             fmaps,
-            fmaps_radius)
+            fmaps_radius,
+            ""  # glcm_direction_field
+        )
 
         # list of valid outputs that are used throughout featurize functions
         self._valid_output_types = ['pandas', 'arrowipc', 'parquet']
@@ -1632,14 +1664,16 @@ class ImageQuality:
             dynamic_range,
             min_intensity,
             max_intensity,
-            True,
+            True,  # is_imq
             ram_limit,
             verb_lvl,
             aniso_x,
             aniso_y,
             aniso_z,
-            False,
-            2)
+            False,  # fmaps
+            2,      # fmaps_radius
+            ""      # glcm_direction_field
+        )
 
         # list of valid outputs that are used throughout featurize functions
         self._valid_output_types = ['pandas', 'arrowipc', 'parquet']
@@ -2034,8 +2068,6 @@ class ImageQuality:
 
         customize_gabor_feature_imp (id(self), kersize, gamma, sig2lam, f0, thetas, thold, freqs)
 
-    
-    def set_environment_params (self, **params):
         """Sets parameters of the environment for Nyxus
         
         Keyword args:

--- a/src/nyx/raw_nifti.h
+++ b/src/nyx/raw_nifti.h
@@ -113,13 +113,13 @@ public:
         return (double)x;
     }
 
-    uint32_t get_uint32_pixel (size_t idx) const
+    uint32_t get_uint32_pixel (size_t idx) const override
     {
         uint32_t rv = get_uint32_pixel_typeresolved (nii_->data, idx);
         return rv;
     }
 
-    double get_dpequiv_pixel (size_t idx) const
+    double get_dpequiv_pixel (size_t idx) const override
     {
         double rv = get_dpequiv_pixel_typeresolved (nii_->data, idx);
         return rv;

--- a/src/nyx/raw_omezarr.h
+++ b/src/nyx/raw_omezarr.h
@@ -116,13 +116,13 @@ public:
     {
     }
 
-    uint32_t get_uint32_pixel (size_t idx) const
+    uint32_t get_uint32_pixel (size_t idx) const override
     {
         uint32_t rv = dest[idx];
         return rv;
     }
 
-    double get_dpequiv_pixel (size_t idx) const
+    double get_dpequiv_pixel (size_t idx) const override
     {
         double rv = (double) dest[idx];
         return rv;    

--- a/src/nyx/raw_tiff.h
+++ b/src/nyx/raw_tiff.h
@@ -200,24 +200,24 @@ public:
         tiffTile = nullptr;
     }
 
-    uint32_t get_uint32_pixel (size_t idx) const
+    uint32_t get_uint32_pixel (size_t idx) const override
     {
         uint32_t rv = get_uint32_pixel_typeresolved (tiffTile, idx);
         return rv;
     }
 
-    double get_dpequiv_pixel (size_t idx) const
+    double get_dpequiv_pixel (size_t idx) const override
     {
         double rv = get_dpequiv_pixel_typeresolved (tiffTile, idx);
         return rv;
     }
 
-    [[nodiscard]] size_t fullHeight([[maybe_unused]] size_t level) const { return fullHeight_; }
-    [[nodiscard]] size_t fullWidth([[maybe_unused]] size_t level) const { return fullWidth_; }
-    [[nodiscard]] size_t tileWidth([[maybe_unused]] size_t level) const { return tileWidth_; }
-    [[nodiscard]] size_t tileHeight([[maybe_unused]] size_t level) const { return tileHeight_; }
-    [[nodiscard]] short bitsPerSample() const { return bitsPerSample_; }
-    [[nodiscard]] size_t numberPyramidLevels() const { return 1; }
+    [[nodiscard]] size_t fullHeight([[maybe_unused]] size_t level) const override { return fullHeight_; }
+    [[nodiscard]] size_t fullWidth([[maybe_unused]] size_t level) const override { return fullWidth_; }
+    [[nodiscard]] size_t tileWidth([[maybe_unused]] size_t level) const override { return tileWidth_; }
+    [[nodiscard]] size_t tileHeight([[maybe_unused]] size_t level) const override { return tileHeight_; }
+    [[nodiscard]] short bitsPerSample() const override { return bitsPerSample_; }
+    [[nodiscard]] size_t numberPyramidLevels() const override { return 1; }
 
 private:
 
@@ -457,7 +457,7 @@ public:
             throw (std::runtime_error(erm));
         }
 
-        uint8* fub = (uint8*)buf;
+        uint8_t* fub = (uint8_t*)buf;
         for (size_t r = 0; r < tileHeight_; r++)
         {
             size_t offs = r * scanline_szb;
@@ -485,13 +485,13 @@ public:
         _TIFFfree(buf);
     }
 
-    uint32_t get_uint32_pixel(size_t idx) const
+    uint32_t get_uint32_pixel(size_t idx) const override
     {
         uint32_t rv = get_uint32_pixel_typeresolved (buf, idx);
         return rv;
     }
 
-    double get_dpequiv_pixel(size_t idx) const
+    double get_dpequiv_pixel(size_t idx) const override
     {
         double rv = get_dpequiv_pixel_typeresolved (buf, idx);
         return rv;

--- a/src/nyx/results_cache.h
+++ b/src/nyx/results_cache.h
@@ -1,6 +1,25 @@
 #pragma once
+#include <cmath>
+#include <limits>
 #include <string>
 #include <vector>
+
+/// @brief Holds a spatial feature map for one parent ROI: one 2D/3D array per feature.
+struct FmapArrayResult
+{
+	int parent_label;
+	std::string intens_name;
+	std::string seg_name;
+	int map_w, map_h;        // dimensions of the feature map arrays
+	int map_d = 1;           // depth dimension (1 for 2D feature maps)
+	int origin_x, origin_y;  // global image coords of the map's top-left pixel
+	int origin_z = 0;        // global z-coord of the map's first slice (unused in 2D)
+	std::vector<std::string> feature_names;
+	// Flat storage: n_features contiguous blocks of (map_d * map_h * map_w) doubles each.
+	// 2D access: feature_data[f * map_h * map_w + row * map_w + col]
+	// 3D access: feature_data[f * map_d * map_h * map_w + z * map_h * map_w + row * map_w + col]
+	std::vector<double> feature_data;
+};
 
 class ResultsCache
 {
@@ -14,6 +33,7 @@ public:
 		stringColBuf_.clear();
 		calcResultBuf_.clear();
 		totalNumLabels_ = 0;
+		fmapArrayResults_.clear();
 	}
 
 	std::vector<std::string>& get_headerBuf() { return headerBuf_; }
@@ -25,7 +45,8 @@ public:
 		for (auto c : cols)
 			add_to_header(c);
 	}
-	void add_to_header(std::string& col)
+	// const ref: callers may pass temporaries or string expressions
+	void add_to_header(const std::string& col)
 	{
 		headerBuf_.push_back(col);
 	}
@@ -35,9 +56,12 @@ public:
 	void inc_num_rows() { totalNumLabels_++; }
 	size_t get_num_rows() { return totalNumLabels_; }
 
+	std::vector<FmapArrayResult>& get_fmapArrayResults() { return fmapArrayResults_; }
+
 private:
 
 	std::vector<double> calcResultBuf_;
 	size_t totalNumLabels_ = 0;
 	std::vector<std::string> stringColBuf_, headerBuf_;
+	std::vector<FmapArrayResult> fmapArrayResults_;
 };

--- a/src/nyx/workflow_2d_fmaps.cpp
+++ b/src/nyx/workflow_2d_fmaps.cpp
@@ -1,0 +1,415 @@
+/// @file workflow_2d_fmaps.cpp
+/// @brief 2D feature maps (fmaps) workflow: slides a kernel across each parent ROI to
+///        produce spatially-resolved feature maps.  For every valid kernel position a
+///        "child" ROI is created, its features are computed, and the results are stored
+///        either as flat arrays (Python buffer mode) or as a CSV with per-pixel rows.
+
+#include "helpers/fsystem.h"
+#include <fstream>
+#include <string>
+#include <iomanip>
+#include <vector>
+#include <map>
+#include <array>
+#include <regex>
+#include <string>
+#include <limits>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+
+#ifdef WITH_PYTHON_H
+	#include <pybind11/pybind11.h>
+	#include <pybind11/stl.h>
+	#include <pybind11/numpy.h>
+	namespace py = pybind11;
+#endif
+
+#include "constants.h"
+#include "dirs_and_files.h"
+#include "environment.h"
+#include "globals.h"
+#include "helpers/helpers.h"
+#include "helpers/system_resource.h"
+#include "helpers/timing.h"
+#include "raw_image_loader.h"
+
+namespace Nyxus
+{
+
+	/// @brief Generates kernel-sized child ROIs by sliding a kernel across a parent ROI's image matrix.
+	/// Only creates child ROIs where the kernel center pixel is within the mask (non-zero intensity in the image matrix).
+	/// @param parent The parent ROI (must have aux_image_matrix populated)
+	/// @param kernel_size The kernel size (odd integer >= 3)
+	/// @param childLabels [out] Set of child ROI labels
+	/// @param childRoiData [out] Map of child label -> child LR
+	/// @param childToParentMap [out] Map of child label -> (parent_label, center_x, center_y)
+	/// @param startLabel Starting label for child ROIs to avoid collisions across parents
+	/// @return Number of child ROIs generated
+	//
+	// Disable optimizations for this function: at -O3 the loop vectorizer
+	// miscompiles inlined code (LR ctor, push_back, init_aabb, etc.) within
+	// the sliding-kernel loops, causing heap corruption.  The function is
+	// dominated by memory allocation (LR construction, hash-map insertion)
+	// so vectorization provides no benefit here.
+#pragma clang optimize off
+	int generateChildRois (
+		const LR & parent,
+		int kernel_size,
+		// out:
+		std::unordered_set<int> & childLabels,
+		std::unordered_map<int, LR> & childRoiData,
+		std::unordered_map<int, FmapChildInfo> & childToParentMap,
+		int64_t startLabel)
+	{
+		int half = kernel_size / 2;
+		int childCount = 0;
+
+		int parentW = parent.aabb.get_width();
+		int parentH = parent.aabb.get_height();
+		int parentXmin = parent.aabb.get_xmin();
+		int parentYmin = parent.aabb.get_ymin();
+
+		const auto& pixelMatrix = parent.aux_image_matrix.ReadablePixels();
+		const auto* pixelData = pixelMatrix.data();
+		int matW = parentW;  // image matrix stride (width)
+
+		// Slide kernel across the parent ROI's bounding box
+		for (int cy = half; cy < parentH - half; cy++)
+		{
+			for (int cx = half; cx < parentW - half; cx++)
+			{
+				// Check if the kernel center pixel is within the mask
+				auto centerVal = pixelData[matW * cy + cx];
+				if (centerVal == 0)
+					continue;
+
+				int64_t childLabel64 = startLabel + childCount;
+				if (childLabel64 > std::numeric_limits<int>::max())
+					throw std::overflow_error("Child ROI label overflow — too many child ROIs generated across all parents");
+				int childLabel = (int)childLabel64;
+
+				// Create child LR
+				LR child(childLabel);
+
+				// Set up child's AABB in image coordinates
+				int childXmin = parentXmin + cx - half;
+				int childYmin = parentYmin + cy - half;
+				int childXmax = parentXmin + cx + half;
+				int childYmax = parentYmin + cy + half;
+
+				child.init_aabb(childXmin, childYmin);
+				child.update_aabb(childXmax, childYmax);
+				child.make_nonanisotropic_aabb();
+
+				// Extract pixels from the parent's image matrix
+				double cmin = std::numeric_limits<double>::max();
+				double cmax = std::numeric_limits<double>::lowest();
+				for (int ky = 0; ky < kernel_size; ky++)
+				{
+					for (int kx = 0; kx < kernel_size; kx++)
+					{
+						int localY = cy - half + ky;
+						int localX = cx - half + kx;
+						auto val = pixelData[matW * localY + localX];
+						if (val != 0)
+						{
+							int imgX = parentXmin + localX;
+							int imgY = parentYmin + localY;
+							child.raw_pixels.push_back(Pixel2(imgX, imgY, val));
+							child.aux_area++;
+							if (val < cmin) cmin = val;
+							if (val > cmax) cmax = val;
+						}
+					}
+				}
+				if (child.aux_area > 0)
+				{
+					// Use parent ROI's min/max so all kernel patches share
+					// the same binning range (consistent with pyradiomics
+					// fixed-width global binning).  Local cmin/cmax would
+					// cause each tiny patch to get its own adaptive range,
+					// collapsing most pixels to the same bin.
+					child.aux_min = parent.aux_min;
+					child.aux_max = parent.aux_max;
+				}
+
+				// Allocate and populate image matrix
+				child.aux_image_matrix.allocate(kernel_size, kernel_size);
+				child.aux_image_matrix.calculate_from_pixelcloud(child.raw_pixels, child.aabb);
+
+				// Initialize feature value buffers
+				child.initialize_fvals();
+
+				// Store
+				childLabels.insert(childLabel);
+				childRoiData[childLabel] = std::move(child);
+				childToParentMap[childLabel] = { parent.label, parentXmin + cx, parentYmin + cy };
+
+				childCount++;
+			}
+		}
+
+		return childCount;
+	}
+#pragma clang optimize on
+
+	/// @brief Reduces child ROIs to feature values and outputs results as spatial arrays.
+	/// Temporarily swaps child ROI data into the environment (via RAII guard),
+	/// computes features for all children, and writes results to fmap arrays.
+	void reduceAndOutputChildRois_fmaps (
+		Environment & env,
+		std::unordered_set<int> childLabels,
+		std::unordered_map<int, LR> childRoiData,
+		const std::unordered_map<int, FmapChildInfo> & childToParentMap,
+		const std::string & intens_fpath,
+		const std::string & label_fpath,
+		int parentLab,
+		int parentXmin, int parentYmin, int parentZmin,
+		int parentW, int parentH, int parentD)
+	{
+		// RAII guard swaps env's ROI data with child data and restores on scope exit
+		EnvRoiSwapGuard guard (env, std::move(childLabels), std::move(childRoiData));
+
+		std::vector<int> childLabelVec(env.uniqueLabels.begin(), env.uniqueLabels.end());
+		std::sort(childLabelVec.begin(), childLabelVec.end());
+
+		reduce_trivial_rois_manual (childLabelVec, env);
+
+		// Output child ROI features as spatial arrays
+		save_features_2_fmap_arrays (
+			env.theResultsCache,
+			env,
+			intens_fpath,
+			label_fpath,
+			parentLab,
+			parentXmin, parentYmin, parentZmin,
+			parentW, parentH, parentD,
+			env.fmaps_kernel_size(),
+			env.uniqueLabels,
+			env.roiData,
+			childToParentMap);
+	}
+
+	/// @brief Processes a single intensity-segmentation image pair in feature maps mode.
+	/// Loads parent ROIs, generates child ROIs per kernel, computes features, outputs results.
+	/// @param globalChildLabel [in/out] Running child label counter, persists across file pairs to avoid label collisions.
+	static bool processIntSegImagePair_fmaps (
+		Environment & env,
+		const std::string & intens_fpath,
+		const std::string & label_fpath,
+		int filepair_index,
+		int tot_num_filepairs,
+		int64_t & globalChildLabel)
+	{
+		// Display progress
+		if (tot_num_filepairs > 0)
+		{
+			int digits = (tot_num_filepairs >= 100) ? (int)std::log10(tot_num_filepairs/100.) + 1 : 1,
+				k = (int)std::pow(10.f, digits);
+			float perCent = float(filepair_index + 1) * 100.f / float(tot_num_filepairs);
+			perCent = std::round(perCent * k) / k;
+			VERBOSLVL1 (env.get_verbosity_level(), std::cout << "[ " << filepair_index+1 << " = " << std::setw(digits + 2) << perCent << "% ]\t" << intens_fpath << "\n")
+		}
+
+		// Phase 1: gather ROI metrics (unchanged)
+		VERBOSLVL2 (env.get_verbosity_level(), std::cout << "Gathering ROI metrics\n");
+		bool okGather = gatherRoisMetrics (filepair_index, intens_fpath, label_fpath, env, env.theImLoader);
+		if (!okGather)
+		{
+			std::string msg = "Error gathering ROI metrics from " + intens_fpath + " / " + label_fpath + "\n";
+			std::cerr << msg;
+			throw (std::runtime_error(msg));
+		}
+
+		if (env.uniqueLabels.size() == 0)
+			return true;
+
+		// Collect parent ROI labels (all trivial for fmaps — kernel-sized children are always small)
+		std::vector<int> parentLabels;
+		for (auto lab : env.uniqueLabels)
+		{
+			LR& r = env.roiData[lab];
+			if (env.roi_is_blacklisted("", lab))
+			{
+				r.blacklisted = true;
+				continue;
+			}
+			parentLabels.push_back(lab);
+		}
+
+		// Phase 2 (fmaps): Process each parent ROI
+		for (auto parentLab : parentLabels)
+		{
+			LR& parentROI = env.roiData[parentLab];
+
+			// Check that the parent ROI is large enough for the kernel
+			int parentW = parentROI.aabb.get_width();
+			int parentH = parentROI.aabb.get_height();
+			if (parentW < env.fmaps_kernel_size() || parentH < env.fmaps_kernel_size())
+			{
+				VERBOSLVL2 (env.get_verbosity_level(),
+					std::cout << "Skipping ROI " << parentLab
+						<< " (too small for kernel: " << parentW << "x" << parentH
+						<< " < " << env.fmaps_kernel_size() << ")\n");
+				continue;
+			}
+
+			// Step a: Load parent ROI pixels
+			std::vector<int> singleParent = { parentLab };
+
+			if (env.anisoOptions.customized() == false)
+				scanTrivialRois (singleParent, intens_fpath, label_fpath, env, env.theImLoader);
+			else
+			{
+				double ax = env.anisoOptions.get_aniso_x(),
+					ay = env.anisoOptions.get_aniso_y();
+				scanTrivialRois_anisotropic (singleParent, intens_fpath, label_fpath, env, env.theImLoader, ax, ay);
+			}
+
+			// Step b: Allocate image matrix for the parent
+			allocateTrivialRoisBuffers (singleParent, env.roiData, env.hostCache);
+
+			// Step c: Generate child ROIs
+			std::unordered_set<int> childLabels;
+			std::unordered_map<int, LR> childRoiData;
+			std::unordered_map<int, FmapChildInfo> childToParentMap;
+
+			int nChildren = generateChildRois (
+				parentROI,
+				env.fmaps_kernel_size(),
+				childLabels,
+				childRoiData,
+				childToParentMap,
+				globalChildLabel);
+
+			VERBOSLVL2 (env.get_verbosity_level(),
+				std::cout << "ROI " << parentLab << ": generated " << nChildren << " child ROIs\n");
+
+			globalChildLabel += nChildren;
+
+			if (nChildren > 0)
+			{
+				// Capture parent geometry before the swap invalidates the reference
+				int parentXmin = parentROI.aabb.get_xmin();
+				int parentYmin = parentROI.aabb.get_ymin();
+
+				// Step d: Compute features on child ROIs and output results
+				reduceAndOutputChildRois_fmaps (
+					env,
+					std::move(childLabels), std::move(childRoiData), childToParentMap,
+					intens_fpath, label_fpath,
+					parentLab,
+					parentXmin, parentYmin, /*parentZmin=*/ 0,
+					parentW, parentH, /*parentD=*/ 1);
+			}
+
+			// Free parent ROI buffers
+			freeTrivialRoisBuffers (singleParent, env.roiData);
+
+#ifdef WITH_PYTHON_H
+			if (PyErr_CheckSignals() != 0)
+			{
+				sureprint("\nAborting per user input\n");
+				throw pybind11::error_already_set();
+			}
+#endif
+		}
+
+		return true;
+	}
+
+	/// @brief Entry point for the 2D feature maps workflow.
+	/// Prescans all image pairs, then processes each pair by generating child ROIs
+	/// per parent and computing features at each kernel position.
+	/// @return 0 on success, nonzero on error.
+	int processDataset_2D_fmaps (
+		Environment & env,
+		const std::vector<std::string> & intensFiles,
+		const std::vector<std::string> & labelFiles,
+		int numReduceThreads,
+		const SaveOption saveOption,
+		const std::string & outputPath)
+	{
+		reset_csv_header_state();
+
+#ifdef CHECKTIMING
+		if (Stopwatch::inclusive())
+			Stopwatch::reset();
+#endif
+
+		//********************** prescan (unchanged from segmented workflow) ***********************
+
+		size_t nf = intensFiles.size();
+
+		{ STOPWATCH("prescan/p0/P/#ccbbaa", "\t=");
+		VERBOSLVL1 (env.get_verbosity_level(), std::cout << "phase 0 (prescanning)\n");
+
+		env.dataset.reset_dataset_props();
+
+		for (size_t i = 0; i < nf; i++)
+		{
+			SlideProps& p = env.dataset.dataset_props.emplace_back (intensFiles[i], labelFiles[i]);
+
+			VERBOSLVL1 (env.get_verbosity_level(), std::cout << "prescanning " << p.fname_int);
+			if (! scan_slide_props(p, 2, env.anisoOptions, env.resultOptions.need_annotation()))
+			{
+				VERBOSLVL1 (env.get_verbosity_level(), std::cout << "error prescanning pair " << p.fname_int << " and " << p.fname_seg << std::endl);
+				return 1;
+			}
+			VERBOSLVL1 (env.get_verbosity_level(), std::cout << "\t " << p.slide_w << " W x " << p.slide_h << " H\tmax ROI " << p.max_roi_w << " x " << p.max_roi_h << "\tmin-max I " << Nyxus::virguler_real(p.min_preroi_inten) << "-" << Nyxus::virguler_real(p.max_preroi_inten) << "\t" << p.lolvl_slide_descr << "\n");
+		}
+
+		env.dataset.update_dataset_props_extrema();
+		VERBOSLVL1 (env.get_verbosity_level(), std::cout << "\t finished prescanning \n");
+		} // prescan timing
+
+		// One-time initialization
+		init_slide_rois (env.uniqueLabels, env.roiData);
+
+		bool ok = true;
+		int64_t globalChildLabel = 1;	// Persists across file pairs to avoid label collisions
+
+		// Iterate intensity-segmentation pairs
+		for (int i = 0; i < nf; i++)
+		{
+#ifdef CHECKTIMING
+			if (Stopwatch::exclusive())
+				Stopwatch::reset();
+#endif
+
+			clear_slide_rois (env.uniqueLabels, env.roiData);
+
+			auto& ifp = intensFiles[i],
+				& lfp = labelFiles[i];
+
+			SlideProps& p = env.dataset.dataset_props[i];
+			ok = env.theImLoader.open (p, env.fpimageOptions);
+			if (ok == false)
+			{
+				std::cerr << "Terminating\n";
+				return 1;
+			}
+
+			// Feature maps processing
+			if (! processIntSegImagePair_fmaps(env, ifp, lfp, i, nf, globalChildLabel))
+			{
+				std::cerr << "Error in feature maps processing for " << ifp << " @ " << __FILE__ << ":" << __LINE__ << "\n";
+				return 1;
+			}
+
+			env.theImLoader.close();
+
+#ifdef WITH_PYTHON_H
+			if (PyErr_CheckSignals() != 0)
+			{
+				sureprint("\nAborting per user input\n");
+				throw pybind11::error_already_set();
+			}
+#endif
+		}
+
+		return 0; // success
+	}
+
+} // namespace Nyxus

--- a/src/nyx/workflow_2d_segmented.cpp
+++ b/src/nyx/workflow_2d_segmented.cpp
@@ -166,11 +166,12 @@ namespace Nyxus
 		const SaveOption saveOption,
 		const std::string& outputPath)
 	{
+		reset_csv_header_state();
 
 #ifdef CHECKTIMING
 		if (Stopwatch::inclusive())
 			Stopwatch::reset();
-#endif		
+#endif
 
 		//********************** prescan ***********************
 

--- a/src/nyx/workflow_2d_whole.cpp
+++ b/src/nyx/workflow_2d_whole.cpp
@@ -209,6 +209,7 @@ namespace Nyxus
 		// create a vector of blank mask file names. Blank mask counterparts 
 		// of intensity files will serve as the condition of the whole-slide scenario in the prescan phase
 		std::vector<std::string> labelFiles (intensFiles.size());
+		reset_csv_header_state();
 
 		//**** prescan all slides
 

--- a/src/nyx/workflow_3d_fmaps.cpp
+++ b/src/nyx/workflow_3d_fmaps.cpp
@@ -1,0 +1,362 @@
+/// @file workflow_3d_fmaps.cpp
+/// @brief 3D feature maps (fmaps) workflow: slides a cubic kernel across each parent ROI
+///        to produce volumetric feature maps.  Analogous to workflow_2d_fmaps.cpp but
+///        operates on 3D image cubes and supports time-frame iteration.
+
+#include "helpers/fsystem.h"
+#include <fstream>
+#include <string>
+#include <iomanip>
+#include <vector>
+#include <map>
+#include <array>
+#include <regex>
+#include <string>
+#include <limits>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+
+#ifdef WITH_PYTHON_H
+	#include <pybind11/pybind11.h>
+	#include <pybind11/stl.h>
+	#include <pybind11/numpy.h>
+	namespace py = pybind11;
+#endif
+
+#include "constants.h"
+#include "dirs_and_files.h"
+#include "environment.h"
+#include "globals.h"
+#include "helpers/helpers.h"
+#include "helpers/system_resource.h"
+#include "helpers/timing.h"
+#include "raw_image_loader.h"
+
+namespace Nyxus
+{
+
+	/// @brief Generates kernel-sized child ROIs by sliding a 3D kernel across a parent ROI's image cube.
+	/// Only creates child ROIs where the kernel center voxel is non-zero.
+	/// @param parent The parent ROI (must have aux_image_cube populated)
+	/// @param kernel_size The kernel size (odd integer >= 3)
+	/// @param childLabels [out] Set of child ROI labels
+	/// @param childRoiData [out] Map of child label -> child LR
+	/// @param childToParentMap [out] Map of child label -> (parent_label, center_x, center_y, center_z)
+	/// @param startLabel Starting label for child ROIs to avoid collisions across parents
+	/// @return Number of child ROIs generated
+#pragma clang optimize off
+	int generateChildRois_3D (
+		const LR & parent,
+		int kernel_size,
+		// out:
+		std::unordered_set<int> & childLabels,
+		std::unordered_map<int, LR> & childRoiData,
+		std::unordered_map<int, FmapChildInfo> & childToParentMap,
+		int64_t startLabel)
+	{
+		int half = kernel_size / 2;
+		int childCount = 0;
+
+		int parentW = parent.aabb.get_width();
+		int parentH = parent.aabb.get_height();
+		int parentD = parent.aabb.get_z_depth();
+		int parentXmin = parent.aabb.get_xmin();
+		int parentYmin = parent.aabb.get_ymin();
+		int parentZmin = parent.aabb.get_zmin();
+
+		const auto& cube = parent.aux_image_cube;
+
+		// Slide kernel across the parent ROI's bounding box in 3D
+		for (int cz = half; cz < parentD - half; cz++)
+		{
+			for (int cy = half; cy < parentH - half; cy++)
+			{
+				for (int cx = half; cx < parentW - half; cx++)
+				{
+					// Check if the kernel center voxel is within the mask
+					auto centerVal = cube.xyz(cx, cy, cz);
+					if (centerVal == 0)
+						continue;
+
+					int64_t childLabel64 = startLabel + childCount;
+					if (childLabel64 > std::numeric_limits<int>::max())
+						throw std::overflow_error("Child ROI label overflow — too many child ROIs generated across all parents");
+					int childLabel = (int)childLabel64;
+
+					// Create child LR
+					LR child(childLabel);
+
+					// Set up child's AABB in image coordinates
+					int childXmin = parentXmin + cx - half;
+					int childYmin = parentYmin + cy - half;
+					int childZmin = parentZmin + cz - half;
+					int childXmax = parentXmin + cx + half;
+					int childYmax = parentYmin + cy + half;
+					int childZmax = parentZmin + cz + half;
+
+					child.init_aabb_3D(childXmin, childYmin, childZmin);
+					child.update_aabb_3D(childXmax, childYmax, childZmax);
+					child.make_nonanisotropic_aabb();
+
+					// Extract voxels from the parent's image cube
+					double cmin = std::numeric_limits<double>::max();
+					double cmax = std::numeric_limits<double>::lowest();
+					for (int kz = 0; kz < kernel_size; kz++)
+					{
+						for (int ky = 0; ky < kernel_size; ky++)
+						{
+							for (int kx = 0; kx < kernel_size; kx++)
+							{
+								int localX = cx - half + kx;
+								int localY = cy - half + ky;
+								int localZ = cz - half + kz;
+								auto val = cube.xyz(localX, localY, localZ);
+								if (val != 0)
+								{
+									int imgX = parentXmin + localX;
+									int imgY = parentYmin + localY;
+									int imgZ = parentZmin + localZ;
+									child.raw_pixels_3D.push_back(Pixel3(imgX, imgY, imgZ, val));
+									child.aux_area++;
+									if (val < cmin) cmin = val;
+									if (val > cmax) cmax = val;
+								}
+							}
+						}
+					}
+					if (child.aux_area > 0)
+					{
+						// Use parent ROI's min/max so all kernel patches share
+						// the same binning range (consistent with pyradiomics
+						// fixed-width global binning).
+						child.aux_min = parent.aux_min;
+						child.aux_max = parent.aux_max;
+					}
+
+					// Allocate and populate image cube
+					child.aux_image_cube.allocate(kernel_size, kernel_size, kernel_size);
+					child.aux_image_cube.calculate_from_pixelcloud(child.raw_pixels_3D, child.aabb);
+
+					// Initialize feature value buffers
+					child.initialize_fvals();
+
+					// Store
+					childLabels.insert(childLabel);
+					childRoiData[childLabel] = std::move(child);
+					childToParentMap[childLabel] = { parent.label, parentXmin + cx, parentYmin + cy, parentZmin + cz };
+
+					childCount++;
+				}
+			}
+		}
+
+		return childCount;
+	}
+#pragma clang optimize on
+
+	/// @brief Processes a single intensity-segmentation image pair in 3D feature maps mode.
+	/// Gathers parent ROI metrics, loads voxels, generates 3D child ROIs per kernel,
+	/// and outputs features for each child.
+	/// @param globalChildLabel [in/out] Running child label counter, persists across file pairs.
+	static bool processIntSegImagePair_3D_fmaps (
+		Environment & env,
+		const std::string & intens_fpath,
+		const std::string & label_fpath,
+		size_t filepair_index,
+		size_t t_index,
+		const std::vector<std::string>& z_indices,
+		int64_t & globalChildLabel)
+	{
+		// Phase 1: gather ROI metrics
+		VERBOSLVL2 (env.get_verbosity_level(), std::cout << "Gathering ROI metrics (3D fmaps)\n");
+		bool okGather = false;
+		if (z_indices.size())
+			okGather = gatherRoisMetrics_25D (env, filepair_index, intens_fpath, label_fpath, z_indices);
+		else
+			okGather = gatherRoisMetrics_3D (env, filepair_index, intens_fpath, label_fpath, t_index);
+		if (!okGather)
+		{
+			std::string msg = "Error gathering ROI metrics from " + intens_fpath + " / " + label_fpath + "\n";
+			std::cerr << msg;
+			throw (std::runtime_error(msg));
+		}
+
+		if (env.uniqueLabels.size() == 0)
+			return true;
+
+		// Collect parent ROI labels
+		std::vector<int> parentLabels;
+		for (auto lab : env.uniqueLabels)
+		{
+			LR& r = env.roiData[lab];
+			r.initialize_fvals();
+			if (env.roi_is_blacklisted("", lab))
+			{
+				r.blacklisted = true;
+				continue;
+			}
+			parentLabels.push_back(lab);
+		}
+
+		// Phase 2 (fmaps): Process each parent ROI
+		for (auto parentLab : parentLabels)
+		{
+			LR& parentROI = env.roiData[parentLab];
+
+			// Check that the parent ROI is large enough for the kernel in all dimensions
+			int parentW = parentROI.aabb.get_width();
+			int parentH = parentROI.aabb.get_height();
+			int parentD = parentROI.aabb.get_z_depth();
+			if (parentW < env.fmaps_kernel_size() || parentH < env.fmaps_kernel_size() || parentD < env.fmaps_kernel_size())
+			{
+				VERBOSLVL2 (env.get_verbosity_level(),
+					std::cout << "Skipping ROI " << parentLab
+						<< " (too small for kernel: " << parentW << "x" << parentH << "x" << parentD
+						<< " < " << env.fmaps_kernel_size() << ")\n");
+				continue;
+			}
+
+			// Step a: Load parent ROI voxels and allocate image cube
+			std::vector<int> singleParent = { parentLab };
+
+			if (env.anisoOptions.customized() == false)
+				scanTrivialRois_3D (env, singleParent, intens_fpath, label_fpath, t_index);
+			else
+			{
+				double ax = env.anisoOptions.get_aniso_x(),
+					ay = env.anisoOptions.get_aniso_y(),
+					az = env.anisoOptions.get_aniso_z();
+				scanTrivialRois_3D_anisotropic (env, singleParent, intens_fpath, label_fpath, t_index, ax, ay, az);
+			}
+
+			allocateTrivialRoisBuffers_3D (singleParent, env.roiData, env.hostCache);
+
+			// Step b: Generate child ROIs
+			std::unordered_set<int> childLabels;
+			std::unordered_map<int, LR> childRoiData;
+			std::unordered_map<int, FmapChildInfo> childToParentMap;
+
+			int nChildren = generateChildRois_3D (
+				parentROI,
+				env.fmaps_kernel_size(),
+				childLabels,
+				childRoiData,
+				childToParentMap,
+				globalChildLabel);
+
+			VERBOSLVL2 (env.get_verbosity_level(),
+				std::cout << "ROI " << parentLab << ": generated " << nChildren << " child ROIs (3D)\n");
+
+			globalChildLabel += nChildren;
+
+			if (nChildren > 0)
+			{
+				// Capture parent geometry before the swap invalidates the reference
+				int parentXmin = parentROI.aabb.get_xmin();
+				int parentYmin = parentROI.aabb.get_ymin();
+				int parentZmin = parentROI.aabb.get_zmin();
+
+				// Step c: Compute features on child ROIs and output results
+				reduceAndOutputChildRois_fmaps (
+					env,
+					std::move(childLabels), std::move(childRoiData), childToParentMap,
+					intens_fpath, label_fpath,
+					parentLab,
+					parentXmin, parentYmin, parentZmin,
+					parentW, parentH, parentD);
+			}
+
+			// Free parent ROI buffers
+			freeTrivialRoisBuffers_3D (singleParent, env.roiData);
+
+#ifdef WITH_PYTHON_H
+			if (PyErr_CheckSignals() != 0)
+			{
+				sureprint("\nAborting per user input\n");
+				throw pybind11::error_already_set();
+			}
+#endif
+		}
+
+		return true;
+	}
+
+	/// @brief Entry point for the 3D feature maps workflow.
+	/// Prescans all image pairs, then iterates time frames and file pairs,
+	/// generating 3D child ROIs and computing volumetric features at each kernel position.
+	/// @return 0 on success, nonzero on error.
+	int processDataset_3D_fmaps (
+		Environment & env,
+		const std::vector <Imgfile3D_layoutA>& intensFiles,
+		const std::vector <Imgfile3D_layoutA>& labelFiles,
+		int numReduceThreads,
+		const SaveOption saveOption,
+		const std::string & outputPath)
+	{
+		reset_csv_header_state();
+
+		//********************** prescan ***********************
+
+		size_t nf = intensFiles.size();
+
+		VERBOSLVL1 (env.get_verbosity_level(), std::cout << "phase 0 (3D fmaps prescanning)\n");
+		env.dataset.reset_dataset_props();
+
+		for (size_t i = 0; i < nf; i++)
+		{
+			SlideProps& p = env.dataset.dataset_props.emplace_back (intensFiles[i].fdir + intensFiles[i].fname, labelFiles[i].fdir + labelFiles[i].fname);
+
+			VERBOSLVL1 (env.get_verbosity_level(), std::cout << "prescanning " << p.fname_int);
+			if (! scan_slide_props(p, 3, env.anisoOptions, env.resultOptions.need_annotation()))
+			{
+				VERBOSLVL1 (env.get_verbosity_level(), std::cout << "error prescanning pair " << p.fname_int << " and " << p.fname_seg << std::endl);
+				return 1;
+			}
+			VERBOSLVL1 (env.get_verbosity_level(), std::cout << "\t " << p.slide_w << " W x " << p.slide_h << " H x " << p.volume_d << " D\n");
+		}
+
+		env.dataset.update_dataset_props_extrema();
+		VERBOSLVL1 (env.get_verbosity_level(), std::cout << "\t finished prescanning \n");
+
+		// One-time initialization
+		init_slide_rois (env.uniqueLabels, env.roiData);
+
+		bool ok = true;
+		int64_t globalChildLabel = 1;
+
+		// Iterate intensity-mask pairs
+		for (size_t i = 0; i < nf; i++)
+		{
+			// Iterate time frames
+			for (size_t t = 0; t < env.dataset.dataset_props[i].inten_time; t++)
+			{
+				clear_slide_rois (env.uniqueLabels, env.roiData);
+
+				auto& ifile = intensFiles[i],
+					& mfile = labelFiles[i];
+
+				int digits = 2, k = (int)std::pow(10.f, digits);
+				float perCent = float(i * 100 * k / nf) / float(k);
+				VERBOSLVL1 (env.get_verbosity_level(), std::cout << "[ " << std::setw(digits + 2) << perCent << "% ]\t" << " INT: " << ifile.fname << " SEG: " << mfile.fname << " T:" << t << "\n")
+
+				if (! processIntSegImagePair_3D_fmaps(env, ifile.fdir+ifile.fname, mfile.fdir+mfile.fname, i, t, intensFiles[i].z_indices, globalChildLabel))
+				{
+					std::cerr << "Error in 3D feature maps processing for " << ifile.fname << " @ " << __FILE__ << ":" << __LINE__ << "\n";
+					return 1;
+				}
+
+#ifdef WITH_PYTHON_H
+				if (PyErr_CheckSignals() != 0)
+				{
+					sureprint("\nAborting per user input\n");
+					throw pybind11::error_already_set();
+				}
+#endif
+			} //- time frames
+		} //- inten-mask pairs
+
+		return 0; // success
+	}
+
+} // namespace Nyxus

--- a/src/nyx/workflow_pythonapi.cpp
+++ b/src/nyx/workflow_pythonapi.cpp
@@ -82,6 +82,140 @@ namespace Nyxus
 		return true;
 	}
 	
+	/// @brief In-memory feature maps processing for a single image pair.
+	/// Gathers parent ROIs, generates child ROIs per kernel, computes features, saves to buffer.
+	/// @param globalChildLabel [in/out] Running child label counter, persists across file pairs to avoid label collisions.
+	bool processIntSegImagePairInMemory_fmaps (
+		Environment & env,
+		const py::array_t<unsigned int, py::array::c_style | py::array::forcecast>& intens,
+		const py::array_t<unsigned int, py::array::c_style | py::array::forcecast>& label,
+		int pair_index,
+		const std::string& intens_name,
+		const std::string& seg_name,
+		int64_t & globalChildLabel)
+	{
+		// Phase 1: gather parent ROI metrics
+		if (! gatherRoisMetricsInMemory (env, intens, label, pair_index))
+			return false;
+
+		if (env.uniqueLabels.size() == 0)
+			return true;
+
+		// Set up parent ROIs
+		for (auto lab : env.uniqueLabels)
+		{
+			LR& r = env.roiData[lab];
+			r.make_nonanisotropic_aabb();
+			r.initialize_fvals();
+		}
+
+		// Collect parent labels, skipping blacklisted and oversized ROIs
+		std::vector<int> parentLabels;
+		for (auto lab : env.uniqueLabels)
+		{
+			LR& r = env.roiData[lab];
+			if (env.roi_is_blacklisted("", lab))
+			{
+				r.blacklisted = true;
+				continue;
+			}
+
+			// Skip oversized ROIs that exceed RAM limit (matching non-fmaps behavior)
+			size_t roiFootprint = r.get_ram_footprint_estimate(env.uniqueLabels.size());
+			size_t ramLim = env.get_ram_limit();
+			if (roiFootprint >= ramLim)
+			{
+				VERBOSLVL1 (env.get_verbosity_level(),
+					std::cout << "Skipping oversized ROI " << lab
+						<< " (estimated " << roiFootprint << " bytes >= RAM limit " << ramLim << " bytes)\n");
+				continue;
+			}
+
+			parentLabels.push_back(lab);
+		}
+
+		// Phase 2: process each parent ROI
+		for (auto parentLab : parentLabels)
+		{
+			LR& parentROI = env.roiData[parentLab];
+
+			int parentW = parentROI.aabb.get_width();
+			int parentH = parentROI.aabb.get_height();
+			if (parentW < env.fmaps_kernel_size() || parentH < env.fmaps_kernel_size())
+			{
+				VERBOSLVL2 (env.get_verbosity_level(),
+					std::cout << "Skipping ROI " << parentLab
+						<< " (too small for kernel: " << parentW << "x" << parentH
+						<< " < " << env.fmaps_kernel_size() << ")\n");
+				continue;
+			}
+
+			// Scan parent ROI pixels from in-memory arrays
+			std::vector<int> singleParent = { parentLab };
+			scanTrivialRoisInMemory (singleParent, intens, label, pair_index, env);
+
+			// Allocate image matrix for parent
+			allocateTrivialRoisBuffers (singleParent, env.roiData, env.hostCache);
+
+			// Generate child ROIs
+			std::unordered_set<int> childLabels;
+			std::unordered_map<int, LR> childRoiData;
+			std::unordered_map<int, FmapChildInfo> childToParentMap;
+
+			int nChildren = generateChildRois (
+				parentROI,
+				env.fmaps_kernel_size(),
+				childLabels,
+				childRoiData,
+				childToParentMap,
+				globalChildLabel);
+
+			VERBOSLVL2 (env.get_verbosity_level(),
+				std::cout << "ROI " << parentLab << ": generated " << nChildren << " child ROIs\n");
+
+			globalChildLabel += nChildren;
+
+			if (nChildren > 0)
+			{
+				// Capture parent geometry before the swap invalidates the reference
+				int parentXmin = parentROI.aabb.get_xmin();
+				int parentYmin = parentROI.aabb.get_ymin();
+
+				// RAII guard swaps env's ROI data with child data and restores on scope exit (even on exception)
+				EnvRoiSwapGuard guard (env, std::move(childLabels), std::move(childRoiData));
+
+				std::vector<int> childLabelVec(env.uniqueLabels.begin(), env.uniqueLabels.end());
+				std::sort(childLabelVec.begin(), childLabelVec.end());
+
+				// Compute features on child ROIs
+				reduce_trivial_rois_manual (childLabelVec, env);
+
+				// Save as spatial feature map arrays
+				save_features_2_fmap_arrays (
+					env.theResultsCache,
+					env,
+					intens_name,
+					seg_name,
+					parentLab,
+					parentXmin, parentYmin, /*parent_zmin=*/ 0,
+					parentW, parentH, /*parent_d=*/ 1,
+					env.fmaps_kernel_size(),
+					env.uniqueLabels,
+					env.roiData,
+					childToParentMap);
+			}
+
+			// Free parent ROI buffers
+			freeTrivialRoisBuffers (singleParent, env.roiData);
+
+			// Allow keyboard interrupt
+			if (PyErr_CheckSignals() != 0)
+				throw pybind11::error_already_set();
+		}
+
+		return true;
+	}
+
 	std::optional<std::string> processMontage(
 		Environment & env,
 		const py::array_t<unsigned int, py::array::c_style | py::array::forcecast>& intensity_images,
@@ -91,16 +225,19 @@ namespace Nyxus
 		const std::vector<std::string>& seg_names,
 		const SaveOption saveOption,
 		const std::string& outputPath)
-	{	
+	{
 		// prepare the output
 
 		bool write_apache = (saveOption == SaveOption::saveArrowIPC || saveOption == SaveOption::saveParquet);
 
-		if (write_apache) 
+		if (env.fmaps_prevents_arrow())
+			return { "Arrow/Parquet output is not supported in feature maps (fmaps) mode." };
+
+		if (write_apache)
 		{
 			env.arrow_stream = ArrowOutputStream();
 			auto [status, msg] = env.arrow_stream.create_arrow_file (saveOption, get_arrow_filename(outputPath, env.nyxus_result_fname, saveOption), Nyxus::get_header(env));
-			if (!status) 
+			if (!status)
 				return { "error creating Arrow file: " + msg.value() };
 		}
 
@@ -129,44 +266,55 @@ namespace Nyxus
 		VERBOSLVL1(env.get_verbosity_level(), std::cout << "\t finished prescanning \n");
 
 		//****** extract features
-		
+
+		int64_t globalChildLabel = 1;	// Persists across file pairs to avoid label collisions in fmaps mode
+
 		for (int i_pair = 0; i_pair < n_pairs; i_pair++)
 		{
 			VERBOSLVL4 (env.get_verbosity_level(), std::cout << "processMontage() pair " << i_pair << "/" << n_pairs << "\n");
 
 			clear_slide_rois (env.uniqueLabels, env.roiData);	// Clear ROI label list, ROI data, etc.
 
-			std::vector<int> unprocessed_rois;
-
-			if (! processIntSegImagePairInMemory (env, intensity_images, label_images, i_pair, intensity_names[i_pair], seg_names[i_pair], unprocessed_rois))
-				return { "error processing a slide pair" };
-
-			if (write_apache) 
+			if (env.fmaps_mode)
 			{
-				auto [status, msg] = env.arrow_stream.write_arrow_file (Nyxus::get_feature_values(env.theFeatureSet, env.uniqueLabels, env.roiData, env.dataset));
-				if (!status) 
-					return { "error writing Arrow file: " + msg.value() };
-			} 
-			else 
-			{
-				if (! save_features_2_buffer(env.theResultsCache, env, DEFAULT_T_INDEX))
-					return { "error saving results to a buffer" };
+				// Feature maps mode: generate child ROIs and compute features
+				if (! processIntSegImagePairInMemory_fmaps (env, intensity_images, label_images, i_pair, intensity_names[i_pair], seg_names[i_pair], globalChildLabel))
+					return { "error processing fmaps for a slide pair" };
 			}
-
-			if (unprocessed_rois.size() > 0) 
+			else
 			{
-				std::string erm = "the following ROIS are oversized and cannot be processed: ";
-				for (const auto& roi: unprocessed_rois)
-				{
-					erm += std::to_string(roi);
-					erm += ", ";
-				}
-				
-				// remove trailing space and comma
-				erm.pop_back();
-				erm.pop_back();
+				std::vector<int> unprocessed_rois;
 
-				return { erm };
+				if (! processIntSegImagePairInMemory (env, intensity_images, label_images, i_pair, intensity_names[i_pair], seg_names[i_pair], unprocessed_rois))
+					return { "error processing a slide pair" };
+
+				if (write_apache)
+				{
+					auto [status, msg] = env.arrow_stream.write_arrow_file (Nyxus::get_feature_values(env.theFeatureSet, env.uniqueLabels, env.roiData, env.dataset));
+					if (!status)
+						return { "error writing Arrow file: " + msg.value() };
+				}
+				else
+				{
+					if (! save_features_2_buffer(env.theResultsCache, env, DEFAULT_T_INDEX))
+						return { "error saving results to a buffer" };
+				}
+
+				if (unprocessed_rois.size() > 0)
+				{
+					std::string erm = "the following ROIS are oversized and cannot be processed: ";
+					for (const auto& roi: unprocessed_rois)
+					{
+						erm += std::to_string(roi);
+						erm += ", ";
+					}
+
+					// remove trailing space and comma
+					erm.pop_back();
+					erm.pop_back();
+
+					return { erm };
+				}
 			}
 
 			// allow keyboard interrupt
@@ -174,7 +322,7 @@ namespace Nyxus
 				throw pybind11::error_already_set();
 		}
 
-		if (write_apache) 
+		if (write_apache)
 		{
 			// close arrow file after use
 			auto [status, msg] = env.arrow_stream.close_arrow_file();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD 20)
 message(STATUS "Build tests")
 #==== Compiler Options
 set(CMAKE_CXX_STANDARD 17)

--- a/tests/test_all.cc
+++ b/tests/test_all.cc
@@ -15,6 +15,7 @@
 #include "test_ibsi_ngldm.h"
 #include "test_ibsi_ngtdm.h"
 #include "test_glcm.h"
+#include "test_glcm_custom_direction.h"
 #include "test_gldm.h"
 #include "test_glrlm.h"
 #include "test_glszm.h"
@@ -1309,6 +1310,28 @@ TEST(TEST_NYXUS, TEST_IBSI_INTENSITY_ROOT_MEAN_SQUARED)
 	ASSERT_NO_THROW(test_ibsi_root_mean_squared_intensity());
 }
 
+
+//***** 2D GLCM Custom Direction Tests *****
+
+TEST(TEST_NYXUS, TEST_GLCM_CUSTOM_DIRECTION_ACTIVATION)
+{
+	ASSERT_NO_THROW(test_glcm_custom_direction_activation());
+}
+
+TEST(TEST_NYXUS, TEST_GLCM_CUSTOM_DIRECTION_VS_TRADITIONAL_0DEG)
+{
+	ASSERT_NO_THROW(test_glcm_custom_direction_vs_traditional_0deg());
+}
+
+TEST(TEST_NYXUS, TEST_GLCM_CUSTOM_DIRECTION_DIFFERENT_DIRECTIONS)
+{
+	ASSERT_NO_THROW(test_glcm_custom_direction_different_directions());
+}
+
+TEST(TEST_NYXUS, TEST_GLCM_CUSTOM_DIRECTION_RESPECTS_MASK)
+{
+	ASSERT_NO_THROW(test_glcm_custom_direction_respects_mask());
+}
 
 //***** 2D GLDM regression ***** 
 

--- a/tests/test_all.cc
+++ b/tests/test_all.cc
@@ -31,10 +31,81 @@
 #include "test_compat_3d_ngtdm.h"
 #include "test_compat_3d_glrlm.h"
 #include "test_compat_3d_glszm.h"
+#include "test_fmaps.h"
+#include "test_fmaps_3d.h"
 #ifdef USE_ARROW
     #include "test_arrow.h"
     #include "test_arrow_file_name.h"
 #endif
+
+
+//***** Feature maps *****
+
+TEST(TEST_NYXUS, TEST_FMAPS_CHILD_ROI_COUNT) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps_child_roi_count());
+}
+
+TEST(TEST_NYXUS, TEST_FMAPS_CHILD_ROI_DIMENSIONS) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps_child_roi_dimensions());
+}
+
+TEST(TEST_NYXUS, TEST_FMAPS_PARENT_MAPPING) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps_parent_mapping());
+}
+
+TEST(TEST_NYXUS, TEST_FMAPS_CHILD_PIXEL_VALUES) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps_child_pixel_values());
+}
+
+TEST(TEST_NYXUS, TEST_FMAPS_NONORIGIN_PARENT) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps_nonorigin_parent());
+}
+
+TEST(TEST_NYXUS, TEST_FMAPS_SPARSE_MASK) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps_sparse_mask());
+}
+
+TEST(TEST_NYXUS, TEST_FMAPS_PARENT_TOO_SMALL) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps_parent_too_small());
+}
+
+TEST(TEST_NYXUS, TEST_FMAPS_START_LABEL_OFFSET) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps_start_label_offset());
+}
+
+//***** 3D Feature maps *****
+
+TEST(TEST_NYXUS, TEST_FMAPS3D_CHILD_ROI_COUNT) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps3d_child_roi_count());
+}
+
+TEST(TEST_NYXUS, TEST_FMAPS3D_CHILD_ROI_DIMENSIONS) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps3d_child_roi_dimensions());
+}
+
+TEST(TEST_NYXUS, TEST_FMAPS3D_PARENT_MAPPING) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps3d_parent_mapping());
+}
+
+TEST(TEST_NYXUS, TEST_FMAPS3D_CHILD_VOXEL_VALUES) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps3d_child_voxel_values());
+}
+
+TEST(TEST_NYXUS, TEST_FMAPS3D_NONORIGIN_PARENT) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps3d_nonorigin_parent());
+}
+
+TEST(TEST_NYXUS, TEST_FMAPS3D_SPARSE_MASK) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps3d_sparse_mask());
+}
+
+TEST(TEST_NYXUS, TEST_FMAPS3D_PARENT_TOO_SMALL) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps3d_parent_too_small());
+}
+
+TEST(TEST_NYXUS, TEST_FMAPS3D_START_LABEL_OFFSET) {
+	ASSERT_NO_THROW(Nyxus::test_fmaps3d_start_label_offset());
+}
 
 
 //***** 2D contour and multicontour *****

--- a/tests/test_fmaps.h
+++ b/tests/test_fmaps.h
@@ -1,0 +1,214 @@
+#pragma once
+
+#include "../src/nyx/roi_cache.h"
+#include "../src/nyx/globals.h"
+#include "../src/nyx/environment.h"
+#include "test_main_nyxus.h"
+
+namespace Nyxus
+{
+	/// Helper: populates a test parent ROI (output param to avoid copy).
+	static void make_test_parent (
+		LR& parent, int W, int H,
+		int xoff = 0, int yoff = 0,
+		PixIntens (*intensity_fn)(int, int) = nullptr)
+	{
+		for (int y = 0; y < H; y++)
+			for (int x = 0; x < W; x++)
+			{
+				int gx = xoff + x, gy = yoff + y;
+				PixIntens val = intensity_fn ? intensity_fn(x, y) : 100;
+				if (val == 0)
+					continue;
+				if (parent.aux_area == 0)
+					init_label_record_3(parent, gx, gy, val);
+				else
+					update_label_record_3(parent, gx, gy, val);
+				parent.raw_pixels.push_back(Pixel2(gx, gy, val));
+			}
+		parent.make_nonanisotropic_aabb();
+		parent.aux_image_matrix.allocate(W, H);
+		parent.aux_image_matrix.calculate_from_pixelcloud(parent.raw_pixels, parent.aabb);
+	}
+
+	/// Helper: run generateChildRois and return the count.
+	struct FmapTestResult
+	{
+		int nChildren;
+		std::unordered_set<int> childLabels;
+		std::unordered_map<int, LR> childRoiData;
+		std::unordered_map<int, FmapChildInfo> childToParentMap;
+	};
+
+	static FmapTestResult run_generate (const LR& parent, int kernel_size, int64_t startLabel = 1)
+	{
+		FmapTestResult r;
+		r.nChildren = generateChildRois(parent, kernel_size, r.childLabels, r.childRoiData, r.childToParentMap, startLabel);
+		return r;
+	}
+
+	// Intensity functions for tests that need non-uniform values
+	static PixIntens intensity_varying (int x, int y) { return 10 * (y + 1) + (x + 1); }
+	static PixIntens intensity_offset (int x, int y) { return (PixIntens)(x + y + 1); }
+	static PixIntens intensity_checkerboard (int x, int y) { return ((x + y) % 2 == 0) ? 100 : 0; }
+
+	/// Test correct child count and output container sizes
+	static void test_fmaps_child_roi_count()
+	{
+		LR parent(1);
+		make_test_parent(parent, 8, 8);
+		auto res = run_generate(parent, 3);
+
+		int expected = (8 - 2) * (8 - 2); // 36
+		if (res.nChildren != expected)
+			throw std::runtime_error("Expected " + std::to_string(expected) + " children, got " + std::to_string(res.nChildren));
+		if ((int)res.childLabels.size() != res.nChildren)
+			throw std::runtime_error("childLabels size mismatch");
+		if ((int)res.childRoiData.size() != res.nChildren)
+			throw std::runtime_error("childRoiData size mismatch");
+		if ((int)res.childToParentMap.size() != res.nChildren)
+			throw std::runtime_error("childToParentMap size mismatch");
+	}
+
+	/// Test that each child AABB is kernel_size x kernel_size
+	static void test_fmaps_child_roi_dimensions()
+	{
+		LR parent(1);
+		make_test_parent(parent, 6, 6);
+		auto res = run_generate(parent, 3);
+
+		for (auto& [label, child] : res.childRoiData)
+		{
+			int cw = child.aabb.get_width(), ch = child.aabb.get_height();
+			if (cw != 3 || ch != 3)
+				throw std::runtime_error("Child " + std::to_string(label) +
+					" dimensions " + std::to_string(cw) + "x" + std::to_string(ch) + ", expected 3x3");
+		}
+	}
+
+	/// Test that all children map back to the correct parent label
+	static void test_fmaps_parent_mapping()
+	{
+		LR parent(42);
+		make_test_parent(parent, 5, 5);
+		auto res = run_generate(parent, 3);
+
+		for (auto& [label, info] : res.childToParentMap)
+		{
+			if (info.parent_label != 42)
+				throw std::runtime_error("Child " + std::to_string(label) +
+					" has parent_label " + std::to_string(info.parent_label) + ", expected 42");
+		}
+	}
+
+	/// Test that child pixel intensities match the parent's image matrix
+	static void test_fmaps_child_pixel_values()
+	{
+		LR parent(1);
+		make_test_parent(parent, 5, 5, 0, 0, intensity_varying);
+		auto res = run_generate(parent, 3);
+
+		// Find the child centered at (2,2)
+		for (auto& [label, info] : res.childToParentMap)
+		{
+			if (info.center_x == 2 && info.center_y == 2)
+			{
+				const LR& child = res.childRoiData.at(label);
+				if (child.aux_area != 9)
+					throw std::runtime_error("Center child should have 9 pixels, got " + std::to_string(child.aux_area));
+
+				for (const auto& px : child.raw_pixels)
+				{
+					PixIntens expected = 10 * (px.y + 1) + (px.x + 1);
+					if (px.inten != expected)
+						throw std::runtime_error("Pixel (" + std::to_string(px.x) + "," + std::to_string(px.y) +
+							") intensity " + std::to_string(px.inten) + ", expected " + std::to_string(expected));
+				}
+				return;
+			}
+		}
+		throw std::runtime_error("Could not find child ROI at center (2,2)");
+	}
+
+	/// Test coordinate handling with an offset parent (not at origin)
+	static void test_fmaps_nonorigin_parent()
+	{
+		const int xoff = 50, yoff = 100;
+		LR parent(1);
+		make_test_parent(parent, 6, 6, xoff, yoff, intensity_offset);
+		auto res = run_generate(parent, 3);
+
+		int expected = (6 - 2) * (6 - 2);
+		if (res.nChildren != expected)
+			throw std::runtime_error("Nonorigin parent: expected " + std::to_string(expected) +
+				" children, got " + std::to_string(res.nChildren));
+
+		for (auto& [label, child] : res.childRoiData)
+		{
+			if (child.aabb.get_xmin() < xoff || child.aabb.get_ymin() < yoff)
+				throw std::runtime_error("Child AABB not offset correctly");
+		}
+
+		for (auto& [label, info] : res.childToParentMap)
+		{
+			if (info.center_x < xoff || info.center_y < yoff)
+				throw std::runtime_error("Child center not in global coordinates");
+		}
+	}
+
+	/// Test sparse mask: checkerboard pattern exercises the zero-center skip path
+	static void test_fmaps_sparse_mask()
+	{
+		LR parent(1);
+		make_test_parent(parent, 7, 7, 0, 0, intensity_checkerboard);
+		auto res = run_generate(parent, 3);
+
+		// Count expected: kernel centers at (1..5, 1..5), only non-zero centers produce children
+		int expectedCount = 0;
+		for (int cy = 1; cy <= 5; cy++)
+			for (int cx = 1; cx <= 5; cx++)
+				if ((cx + cy) % 2 == 0)
+					expectedCount++;
+
+		if (res.nChildren != expectedCount)
+			throw std::runtime_error("Sparse mask: expected " + std::to_string(expectedCount) +
+				" children, got " + std::to_string(res.nChildren));
+
+		for (auto& [label, child] : res.childRoiData)
+		{
+			if (child.aux_area > 9)
+				throw std::runtime_error("Sparse mask: child has too many pixels");
+			if (child.aux_area == 0)
+				throw std::runtime_error("Sparse mask: child has zero pixels");
+		}
+	}
+
+	/// Test that parent smaller than kernel produces zero children
+	static void test_fmaps_parent_too_small()
+	{
+		LR parent(1);
+		make_test_parent(parent, 3, 3);
+		auto res = run_generate(parent, 5);
+
+		if (res.nChildren != 0)
+			throw std::runtime_error("Parent too small: expected 0 children, got " + std::to_string(res.nChildren));
+	}
+
+	/// Test that startLabel offsets prevent label collisions across batches
+	static void test_fmaps_start_label_offset()
+	{
+		LR parent(1);
+		make_test_parent(parent, 5, 5);
+		auto r1 = run_generate(parent, 3, 1);
+		auto r2 = run_generate(parent, 3, 1 + r1.nChildren);
+
+		for (auto lab : r2.childLabels)
+			if (r1.childLabels.count(lab) > 0)
+				throw std::runtime_error("Label collision: label " + std::to_string(lab) + " in both batches");
+
+		int minLabel2 = *std::min_element(r2.childLabels.begin(), r2.childLabels.end());
+		if (minLabel2 != 1 + r1.nChildren)
+			throw std::runtime_error("Second batch min label should be " + std::to_string(1 + r1.nChildren) +
+				", got " + std::to_string(minLabel2));
+	}
+}

--- a/tests/test_fmaps_3d.h
+++ b/tests/test_fmaps_3d.h
@@ -1,0 +1,209 @@
+#pragma once
+
+#include "../src/nyx/roi_cache.h"
+#include "../src/nyx/globals.h"
+#include "../src/nyx/environment.h"
+#include "test_main_nyxus.h"
+#include "test_fmaps.h"  // reuse FmapTestResult
+
+namespace Nyxus
+{
+	/// Helper: populates a test 3D parent ROI (output param to avoid copy).
+	static void make_test_parent_3D (
+		LR& parent, int W, int H, int D,
+		int xoff = 0, int yoff = 0, int zoff = 0,
+		PixIntens (*intensity_fn)(int, int, int) = nullptr)
+	{
+		for (int z = 0; z < D; z++)
+			for (int y = 0; y < H; y++)
+				for (int x = 0; x < W; x++)
+				{
+					int gx = xoff + x, gy = yoff + y, gz = zoff + z;
+					PixIntens val = intensity_fn ? intensity_fn(x, y, z) : 100;
+					if (val == 0)
+						continue;
+					if (parent.aux_area == 0)
+						init_label_record_3D(parent, gx, gy, gz, parent.label, val);
+					else
+						update_label_record_3D(parent, gx, gy, gz, parent.label, val);
+					parent.raw_pixels_3D.push_back(Pixel3(gx, gy, gz, val));
+				}
+		parent.make_nonanisotropic_aabb();
+		parent.aux_image_cube.allocate(W, H, D);
+		parent.aux_image_cube.calculate_from_pixelcloud(parent.raw_pixels_3D, parent.aabb);
+	}
+
+	/// Helper: run generateChildRois_3D and return the count.
+	static FmapTestResult run_generate_3D (const LR& parent, int kernel_size, int64_t startLabel = 1)
+	{
+		FmapTestResult r;
+		r.nChildren = generateChildRois_3D(parent, kernel_size, r.childLabels, r.childRoiData, r.childToParentMap, startLabel);
+		return r;
+	}
+
+	// Intensity functions for 3D tests
+	static PixIntens intensity_varying_3D (int x, int y, int z) { return 100 * (z + 1) + 10 * (y + 1) + (x + 1); }
+	static PixIntens intensity_offset_3D (int x, int y, int z) { return (PixIntens)(x + y + z + 1); }
+	static PixIntens intensity_checkerboard_3D (int x, int y, int z) { return ((x + y + z) % 2 == 0) ? 100 : 0; }
+
+	/// Test correct child count and output container sizes for 3D
+	static void test_fmaps3d_child_roi_count()
+	{
+		LR parent(1);
+		make_test_parent_3D(parent, 8, 8, 8);
+		auto res = run_generate_3D(parent, 3);
+
+		int expected = (8 - 2) * (8 - 2) * (8 - 2); // 216
+		if (res.nChildren != expected)
+			throw std::runtime_error("Expected " + std::to_string(expected) + " children, got " + std::to_string(res.nChildren));
+		if ((int)res.childLabels.size() != res.nChildren)
+			throw std::runtime_error("childLabels size mismatch");
+		if ((int)res.childRoiData.size() != res.nChildren)
+			throw std::runtime_error("childRoiData size mismatch");
+		if ((int)res.childToParentMap.size() != res.nChildren)
+			throw std::runtime_error("childToParentMap size mismatch");
+	}
+
+	/// Test that each child AABB is kernel_size x kernel_size x kernel_size
+	static void test_fmaps3d_child_roi_dimensions()
+	{
+		LR parent(1);
+		make_test_parent_3D(parent, 6, 6, 6);
+		auto res = run_generate_3D(parent, 3);
+
+		for (auto& [label, child] : res.childRoiData)
+		{
+			int cw = child.aabb.get_width(), ch = child.aabb.get_height(), cd = child.aabb.get_z_depth();
+			if (cw != 3 || ch != 3 || cd != 3)
+				throw std::runtime_error("Child " + std::to_string(label) +
+					" dimensions " + std::to_string(cw) + "x" + std::to_string(ch) + "x" + std::to_string(cd) + ", expected 3x3x3");
+		}
+	}
+
+	/// Test that all children map back to the correct parent label
+	static void test_fmaps3d_parent_mapping()
+	{
+		LR parent(42);
+		make_test_parent_3D(parent, 5, 5, 5);
+		auto res = run_generate_3D(parent, 3);
+
+		for (auto& [label, info] : res.childToParentMap)
+		{
+			if (info.parent_label != 42)
+				throw std::runtime_error("Child " + std::to_string(label) +
+					" has parent_label " + std::to_string(info.parent_label) + ", expected 42");
+		}
+	}
+
+	/// Test that child voxel intensities match the parent's image cube
+	static void test_fmaps3d_child_voxel_values()
+	{
+		LR parent(1);
+		make_test_parent_3D(parent, 5, 5, 5, 0, 0, 0, intensity_varying_3D);
+		auto res = run_generate_3D(parent, 3);
+
+		// Find the child centered at (2,2,2)
+		for (auto& [label, info] : res.childToParentMap)
+		{
+			if (info.center_x == 2 && info.center_y == 2 && info.center_z == 2)
+			{
+				const LR& child = res.childRoiData.at(label);
+				if (child.aux_area != 27)
+					throw std::runtime_error("Center child should have 27 voxels, got " + std::to_string(child.aux_area));
+
+				for (const auto& px : child.raw_pixels_3D)
+				{
+					PixIntens expected = 100 * (px.z + 1) + 10 * (px.y + 1) + (px.x + 1);
+					if (px.inten != expected)
+						throw std::runtime_error("Voxel (" + std::to_string(px.x) + "," + std::to_string(px.y) + "," + std::to_string(px.z) +
+							") intensity " + std::to_string(px.inten) + ", expected " + std::to_string(expected));
+				}
+				return;
+			}
+		}
+		throw std::runtime_error("Could not find child ROI at center (2,2,2)");
+	}
+
+	/// Test coordinate handling with an offset parent (not at origin)
+	static void test_fmaps3d_nonorigin_parent()
+	{
+		const int xoff = 50, yoff = 100, zoff = 25;
+		LR parent(1);
+		make_test_parent_3D(parent, 6, 6, 6, xoff, yoff, zoff, intensity_offset_3D);
+		auto res = run_generate_3D(parent, 3);
+
+		int expected = (6 - 2) * (6 - 2) * (6 - 2); // 64
+		if (res.nChildren != expected)
+			throw std::runtime_error("Nonorigin parent: expected " + std::to_string(expected) +
+				" children, got " + std::to_string(res.nChildren));
+
+		for (auto& [label, child] : res.childRoiData)
+		{
+			if (child.aabb.get_xmin() < xoff || child.aabb.get_ymin() < yoff || child.aabb.get_zmin() < zoff)
+				throw std::runtime_error("Child AABB not offset correctly");
+		}
+
+		for (auto& [label, info] : res.childToParentMap)
+		{
+			if (info.center_x < xoff || info.center_y < yoff || info.center_z < zoff)
+				throw std::runtime_error("Child center not in global coordinates");
+		}
+	}
+
+	/// Test sparse mask: 3D checkerboard pattern exercises the zero-center skip path
+	static void test_fmaps3d_sparse_mask()
+	{
+		LR parent(1);
+		make_test_parent_3D(parent, 7, 7, 7, 0, 0, 0, intensity_checkerboard_3D);
+		auto res = run_generate_3D(parent, 3);
+
+		// Count expected: kernel centers at (1..5, 1..5, 1..5), only non-zero centers produce children
+		int expectedCount = 0;
+		for (int cz = 1; cz <= 5; cz++)
+			for (int cy = 1; cy <= 5; cy++)
+				for (int cx = 1; cx <= 5; cx++)
+					if ((cx + cy + cz) % 2 == 0)
+						expectedCount++;
+
+		if (res.nChildren != expectedCount)
+			throw std::runtime_error("Sparse mask: expected " + std::to_string(expectedCount) +
+				" children, got " + std::to_string(res.nChildren));
+
+		for (auto& [label, child] : res.childRoiData)
+		{
+			if (child.aux_area > 27)
+				throw std::runtime_error("Sparse mask: child has too many voxels");
+			if (child.aux_area == 0)
+				throw std::runtime_error("Sparse mask: child has zero voxels");
+		}
+	}
+
+	/// Test that parent smaller than kernel produces zero children
+	static void test_fmaps3d_parent_too_small()
+	{
+		LR parent(1);
+		make_test_parent_3D(parent, 3, 3, 3);
+		auto res = run_generate_3D(parent, 5);
+
+		if (res.nChildren != 0)
+			throw std::runtime_error("Parent too small: expected 0 children, got " + std::to_string(res.nChildren));
+	}
+
+	/// Test that startLabel offsets prevent label collisions across batches
+	static void test_fmaps3d_start_label_offset()
+	{
+		LR parent(1);
+		make_test_parent_3D(parent, 5, 5, 5);
+		auto r1 = run_generate_3D(parent, 3, 1);
+		auto r2 = run_generate_3D(parent, 3, 1 + r1.nChildren);
+
+		for (auto lab : r2.childLabels)
+			if (r1.childLabels.count(lab) > 0)
+				throw std::runtime_error("Label collision: label " + std::to_string(lab) + " in both batches");
+
+		int minLabel2 = *std::min_element(r2.childLabels.begin(), r2.childLabels.end());
+		if (minLabel2 != 1 + r1.nChildren)
+			throw std::runtime_error("Second batch min label should be " + std::to_string(1 + r1.nChildren) +
+				", got " + std::to_string(minLabel2));
+	}
+}

--- a/tests/test_glcm_custom_direction.h
+++ b/tests/test_glcm_custom_direction.h
@@ -1,0 +1,272 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <cmath>
+
+#include "../src/nyx/roi_cache.h"
+#include "../src/nyx/features/glcm.h"
+#include "../src/nyx/features/pixel.h"
+#include "../src/nyx/features/image_cube.h"
+#include "../src/nyx/environment.h"
+#include "test_data.h"
+#include "test_main_nyxus.h"
+
+#include <unordered_map>
+
+// Test helper: create a direction field with uniform direction
+// For 2D: creates a SimpleCube with depth=2 containing [dx, dy] at each pixel
+void create_uniform_direction_field_2d(
+    SimpleCube<float>& dir_field, 
+    int width, 
+    int height, 
+    float dx, 
+    float dy)
+{
+    // Allocate: width × height × 2 (two channels: dx and dy)
+    dir_field.allocate(width, height, 2);
+    
+    // Fill the direction field (normalization handled during binning)
+    // Channel 0 = dx, Channel 1 = dy
+    for (int row = 0; row < height; row++)
+    {
+        for (int col = 0; col < width; col++)
+        {
+            dir_field.zyx(0, row, col) = dx;  // dx component
+            dir_field.zyx(1, row, col) = dy;  // dy component
+        }
+    }
+}
+
+// Test 1: Verify that custom direction field mode is activated correctly
+void test_glcm_custom_direction_activation()
+{
+    // Setup feature settings
+    Fsettings s;
+    s.resize((int)NyxSetting::__COUNT__);
+    s[(int)NyxSetting::SOFTNAN].rval = 0.0;
+    s[(int)NyxSetting::TINY].rval = 0.0;
+    s[(int)NyxSetting::SINGLEROI].bval = false;
+    s[(int)NyxSetting::GREYDEPTH].ival = 100;
+    s[(int)NyxSetting::PIXELSIZEUM].rval = 100;
+    s[(int)NyxSetting::PIXELDISTANCE].ival = 5;
+    s[(int)NyxSetting::USEGPU].bval = false;
+    s[(int)NyxSetting::VERBOSLVL].ival = 0;
+    s[(int)NyxSetting::IBSI].bval = false;
+    s[(int)NyxSetting::GLCM_GREYDEPTH].ival = 100;
+    s[(int)NyxSetting::GLCM_OFFSET].ival = 1;
+    
+    // Load test ROI data
+    LR roidata;
+    load_masked_test_roi_data(roidata, ibsi_phantom_z1_intensity, ibsi_phantom_z1_mask, 
+                               sizeof(ibsi_phantom_z1_mask) / sizeof(NyxusPixel));
+    
+    // Create direction field (horizontal direction: dx=1, dy=0)
+    SimpleCube<float> dir_field;
+    create_uniform_direction_field_2d(dir_field, 
+                                      roidata.aux_image_matrix.width, 
+                                      roidata.aux_image_matrix.height,
+                                      1.0f, 0.0f);
+    
+    // Test with custom direction field
+    GLCMFeature f;
+    f.set_direction_field(&dir_field);
+    
+    ASSERT_NO_THROW(f.calculate(roidata, s));
+    
+    // Initialize feature buffer
+    roidata.initialize_fvals();
+    f.save_value(roidata.fvals);
+    
+    // Direction field mode produces 4 values (one per canonical direction: 0°, 45°, 90°, 135°)
+    // Pixels are binned to their closest canonical direction
+    ASSERT_EQ(roidata.fvals[(int)Feature2D::GLCM_CONTRAST].size(), 4);
+    ASSERT_EQ(roidata.fvals[(int)Feature2D::GLCM_ENERGY].size(), 4);
+    ASSERT_EQ(roidata.fvals[(int)Feature2D::GLCM_ENTROPY].size(), 4);
+    
+    // Cleanup
+    GLCMFeature::direction_field = nullptr;
+}
+
+// Test 2: Compare traditional 0-degree angle vs custom direction field with dx=1, dy=0
+void test_glcm_custom_direction_vs_traditional_0deg()
+{
+    // Setup
+    Fsettings s;
+    s.resize((int)NyxSetting::__COUNT__);
+    s[(int)NyxSetting::SOFTNAN].rval = 0.0;
+    s[(int)NyxSetting::TINY].rval = 0.0;
+    s[(int)NyxSetting::SINGLEROI].bval = false;
+    s[(int)NyxSetting::GREYDEPTH].ival = 100;
+    s[(int)NyxSetting::PIXELSIZEUM].rval = 100;
+    s[(int)NyxSetting::PIXELDISTANCE].ival = 5;
+    s[(int)NyxSetting::USEGPU].bval = false;
+    s[(int)NyxSetting::VERBOSLVL].ival = 0;
+    s[(int)NyxSetting::IBSI].bval = false;
+    s[(int)NyxSetting::GLCM_GREYDEPTH].ival = 100;
+    s[(int)NyxSetting::GLCM_OFFSET].ival = 1;
+    GLCMFeature::symmetric_glcm = false;
+    
+    // Traditional mode: 0 degrees only
+    GLCMFeature::angles = { 0 };
+    
+    LR roidata_traditional;
+    load_masked_test_roi_data(roidata_traditional, ibsi_phantom_z1_intensity, ibsi_phantom_z1_mask,
+                               sizeof(ibsi_phantom_z1_mask) / sizeof(NyxusPixel));
+    
+    GLCMFeature f_traditional;
+    f_traditional.calculate(roidata_traditional, s);
+    roidata_traditional.initialize_fvals();
+    f_traditional.save_value(roidata_traditional.fvals);
+    
+    // Custom direction field mode: uniform horizontal direction (dx=1, dy=0)
+    // This should be equivalent to 0 degrees
+    LR roidata_custom;
+    load_masked_test_roi_data(roidata_custom, ibsi_phantom_z1_intensity, ibsi_phantom_z1_mask,
+                               sizeof(ibsi_phantom_z1_mask) / sizeof(NyxusPixel));
+    
+    SimpleCube<float> dir_field;
+    create_uniform_direction_field_2d(dir_field,
+                                      roidata_custom.aux_image_matrix.width,
+                                      roidata_custom.aux_image_matrix.height,
+                                      1.0f, 0.0f);
+    
+    GLCMFeature f_custom;
+    f_custom.set_direction_field(&dir_field);
+    f_custom.calculate(roidata_custom, s);
+    roidata_custom.initialize_fvals();
+    f_custom.save_value(roidata_custom.fvals);
+    
+    // Compare results - they should be very close (within floating point tolerance)
+    // Traditional mode with 0° gives 1 value at index [0]
+    // Custom mode with uniform dx=1,dy=0 bins all pixels to 0° (index 0 of the 4 directions)
+    double trad_contrast = roidata_traditional.fvals[(int)Feature2D::GLCM_CONTRAST][0];
+    double custom_contrast = roidata_custom.fvals[(int)Feature2D::GLCM_CONTRAST][0];  // 0° direction
+    
+    double trad_energy = roidata_traditional.fvals[(int)Feature2D::GLCM_ENERGY][0];
+    double custom_energy = roidata_custom.fvals[(int)Feature2D::GLCM_ENERGY][0];
+    
+    double trad_entropy = roidata_traditional.fvals[(int)Feature2D::GLCM_ENTROPY][0];
+    double custom_entropy = roidata_custom.fvals[(int)Feature2D::GLCM_ENTROPY][0];
+    
+    // Values should match closely (within 1% tolerance due to potential rounding differences)
+    ASSERT_TRUE(agrees_gt(trad_contrast, custom_contrast, 1.0));
+    ASSERT_TRUE(agrees_gt(trad_energy, custom_energy, 1.0));
+    ASSERT_TRUE(agrees_gt(trad_entropy, custom_entropy, 1.0));
+    
+    // Cleanup
+    GLCMFeature::direction_field = nullptr;
+    GLCMFeature::angles = { 0, 45, 90, 135 };
+}
+
+// Test 3: Verify different direction fields produce different results
+void test_glcm_custom_direction_different_directions()
+{
+    // Setup
+    Fsettings s;
+    s.resize((int)NyxSetting::__COUNT__);
+    s[(int)NyxSetting::SOFTNAN].rval = 0.0;
+    s[(int)NyxSetting::TINY].rval = 0.0;
+    s[(int)NyxSetting::SINGLEROI].bval = false;
+    s[(int)NyxSetting::GREYDEPTH].ival = 100;
+    s[(int)NyxSetting::PIXELSIZEUM].rval = 100;
+    s[(int)NyxSetting::PIXELDISTANCE].ival = 5;
+    s[(int)NyxSetting::USEGPU].bval = false;
+    s[(int)NyxSetting::VERBOSLVL].ival = 0;
+    s[(int)NyxSetting::IBSI].bval = false;
+    s[(int)NyxSetting::GLCM_GREYDEPTH].ival = 100;
+    s[(int)NyxSetting::GLCM_OFFSET].ival = 1;
+    
+    // Horizontal direction (dx=1, dy=0)
+    LR roidata_horizontal;
+    load_masked_test_roi_data(roidata_horizontal, ibsi_phantom_z1_intensity, ibsi_phantom_z1_mask,
+                               sizeof(ibsi_phantom_z1_mask) / sizeof(NyxusPixel));
+    
+    SimpleCube<float> dir_field_h;
+    create_uniform_direction_field_2d(dir_field_h,
+                                      roidata_horizontal.aux_image_matrix.width,
+                                      roidata_horizontal.aux_image_matrix.height,
+                                      1.0f, 0.0f);
+    
+    GLCMFeature f_horizontal;
+    f_horizontal.set_direction_field(&dir_field_h);
+    f_horizontal.calculate(roidata_horizontal, s);
+    roidata_horizontal.initialize_fvals();
+    f_horizontal.save_value(roidata_horizontal.fvals);
+    
+    // Vertical direction (dx=0, dy=1)
+    LR roidata_vertical;
+    load_masked_test_roi_data(roidata_vertical, ibsi_phantom_z1_intensity, ibsi_phantom_z1_mask,
+                               sizeof(ibsi_phantom_z1_mask) / sizeof(NyxusPixel));
+    
+    SimpleCube<float> dir_field_v;
+    create_uniform_direction_field_2d(dir_field_v,
+                                      roidata_vertical.aux_image_matrix.width,
+                                      roidata_vertical.aux_image_matrix.height,
+                                      0.0f, 1.0f);
+    
+    GLCMFeature f_vertical;
+    f_vertical.set_direction_field(&dir_field_v);
+    f_vertical.calculate(roidata_vertical, s);
+    roidata_vertical.initialize_fvals();
+    f_vertical.save_value(roidata_vertical.fvals);
+    
+    // Results should be different (unless the image has perfect symmetry)
+    // Horizontal (dx=1, dy=0) bins to 0° (index 0)
+    // Vertical (dx=0, dy=1) bins to 90° (index 2)
+    double h_contrast = roidata_horizontal.fvals[(int)Feature2D::GLCM_CONTRAST][0];  // 0° direction
+    double v_contrast = roidata_vertical.fvals[(int)Feature2D::GLCM_CONTRAST][2];    // 90° direction
+    
+    // We expect different values, but both should be valid (non-NaN, non-negative)
+    ASSERT_FALSE(std::isnan(h_contrast));
+    ASSERT_FALSE(std::isnan(v_contrast));
+    ASSERT_GE(h_contrast, 0.0);
+    ASSERT_GE(v_contrast, 0.0);
+    
+    // Cleanup
+    GLCMFeature::direction_field = nullptr;
+}
+
+// Test 4: Verify mask is still respected with custom direction fields
+void test_glcm_custom_direction_respects_mask()
+{
+    // Setup
+    Fsettings s;
+    s.resize((int)NyxSetting::__COUNT__);
+    s[(int)NyxSetting::SOFTNAN].rval = 0.0;
+    s[(int)NyxSetting::TINY].rval = 0.0;
+    s[(int)NyxSetting::SINGLEROI].bval = false;
+    s[(int)NyxSetting::GREYDEPTH].ival = 100;
+    s[(int)NyxSetting::PIXELSIZEUM].rval = 100;
+    s[(int)NyxSetting::PIXELDISTANCE].ival = 5;
+    s[(int)NyxSetting::USEGPU].bval = false;
+    s[(int)NyxSetting::VERBOSLVL].ival = 0;
+    s[(int)NyxSetting::IBSI].bval = false;
+    s[(int)NyxSetting::GLCM_GREYDEPTH].ival = 100;
+    s[(int)NyxSetting::GLCM_OFFSET].ival = 1;
+    
+    LR roidata;
+    load_masked_test_roi_data(roidata, ibsi_phantom_z1_intensity, ibsi_phantom_z1_mask,
+                               sizeof(ibsi_phantom_z1_mask) / sizeof(NyxusPixel));
+    
+    SimpleCube<float> dir_field;
+    create_uniform_direction_field_2d(dir_field,
+                                      roidata.aux_image_matrix.width,
+                                      roidata.aux_image_matrix.height,
+                                      1.0f, 0.0f);
+    
+    GLCMFeature f;
+    f.set_direction_field(&dir_field);
+    
+    // Should not throw - mask should be properly handled
+    ASSERT_NO_THROW(f.calculate(roidata, s));
+    
+    roidata.initialize_fvals();
+    f.save_value(roidata.fvals);
+    
+    // Results should be valid (not NaN)
+    double contrast = roidata.fvals[(int)Feature2D::GLCM_CONTRAST][0];
+    ASSERT_FALSE(std::isnan(contrast));
+    
+    // Cleanup
+    GLCMFeature::direction_field = nullptr;
+}


### PR DESCRIPTION
- Need to Merge 326 first
- Added support for custom per-pixel direction fields in GLCM texture analysis - Enables spatially-varying GLCM directions instead of averaging fixed angles (0°, 45°, 90°, 135°) - requires fmaps mode enabled (from 326)
- Direction field loading from TIFF/NIfTI files - Supports multi-channel images specifying dx, dy (and dz for 3D) direction vectors at each pixel location