### PR TITLE
fix the contour environment issue and add a reproducible regression test

### DIFF
--- a/src/nyx/env_features.cpp
+++ b/src/nyx/env_features.cpp
@@ -702,6 +702,15 @@ void Environment::compile_feature_settings()
 		}
 }
 
+void Environment::sync_feature_settings_single_roi()
+{
+	for (auto& wrapd_s : f_settings_)
+	{
+		auto& s = wrapd_s.get();
+		s[(int)NyxSetting::SINGLEROI].bval = singleROI;
+	}
+}
+
 const Fsettings& Environment::get_feature_settings (const std::type_info& ftype)
 {
 	size_t h = ftype.hash_code();

--- a/src/nyx/environment.h
+++ b/src/nyx/environment.h
@@ -198,6 +198,7 @@ public:
 	std::vector<std::reference_wrapper<Fsettings>> f_settings_;
 	std::map<size_t, int> feature2settings_;
 	void compile_feature_settings();
+	void sync_feature_settings_single_roi();
 	const Fsettings & get_feature_settings (const std::type_info& ftype);
 
 	// Meta-parameters

--- a/src/nyx/python/new_bindings_py.cpp
+++ b/src/nyx/python/new_bindings_py.cpp
@@ -228,6 +228,7 @@ py::tuple featurize_directory_imp(
 
     // (whole-slide flag)
     env.singleROI = (intensity_dir == labels_dir);
+    env.sync_feature_settings_single_roi();
 
     // read the dataset directory (file names, file pairs)
     std::vector<std::string> intensFiles, labelFiles;
@@ -364,6 +365,7 @@ py::tuple featurize_directory_imq_imp (
 
     // Set the whole-slide/multi-ROI flag
     theEnvironment.singleROI = intensity_dir == labels_dir;
+    theEnvironment.sync_feature_settings_single_roi();
 
     // Read image pairs from the intensity and label directories applying the filepattern
     std::vector<std::string> intensFiles, labelFiles;
@@ -453,6 +455,7 @@ py::tuple featurize_directory_3D_imp(
 
     // Set the whole-slide/multi-ROI flag
     theEnvironment.singleROI = intensity_dir == labels_dir;
+    theEnvironment.sync_feature_settings_single_roi();
 
     // We're good to extract features. Reset the feature results cache
     theEnvironment.theResultsCache.clear();
@@ -552,6 +555,7 @@ py::tuple featurize_montage_imp (
 
     // Set the whole-slide/multi-ROI flag
     theEnvironment.singleROI = false;
+    theEnvironment.sync_feature_settings_single_roi();
 
     auto intens_buffer = intensity_images.request();
     auto label_buffer = label_images.request();
@@ -629,6 +633,7 @@ py::tuple featurize_fname_lists_imp (uint64_t instid, const py::list& int_fnames
 
     // Set the whole-slide/multi-ROI flag
     theEnvironment.singleROI = single_roi;
+    theEnvironment.sync_feature_settings_single_roi();
 
     // Check intensity file names 
     std::vector<std::string> intensFiles;
@@ -739,6 +744,7 @@ py::tuple featurize_fname_lists_3D_imp (
 
     // set the whole-slide/multi-ROI flag
     theEnvironment.singleROI = single_roi;
+    theEnvironment.sync_feature_settings_single_roi();
 
     // python-side file name lists to c++ vectors 
     std::vector <Imgfile3D_layoutA> ifiles, mfiles;
@@ -1089,6 +1095,3 @@ PYBIND11_MODULE(backend, m)
     m.def("set_metaparam_imp", &set_metaparam_imp, "Setting a common or feature-specific metaparameter");
     m.def("get_metaparam_imp", &get_metaparam_imp, "Getting a common or feature-specific metaparameter value");
 }
-
-
-


### PR DESCRIPTION
This goes further than the surface level multicontour_.clear() fix, the stale environment which were getting re-used won't be hanging around after this fix. In particular SINGLEROI state in the Python backend cache, where cached Environment objects could be reused and their feature settings still reflected an old whole-slide configuration, that is fixed with this change.