### PR TITLE
feat: add 2D test coverage for touch and morphology feature families

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -536,6 +536,7 @@ jobs:
             CMAKE_CXX_COMPILER="$CXX"
             CXXFLAGS="-isysroot $SDKROOT -stdlib=libc++ -mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET"
             LDFLAGS="-isysroot $SDKROOT -lc++ -lc++abi -mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET"
+            PIP_ONLY_BINARY="imagecodecs"
             ARROW_HAVE_LIBATOMIC=OFF
             REPAIR_LIBRARY_PATH="/tmp/nyxus_bld/local_install/lib:/tmp/nyxus_bld/local_install/lib64"
             NYXUS_DEP_DIR="/tmp/nyxus_bld/local_install"

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -365,6 +365,7 @@ jobs:
             CMAKE_CXX_COMPILER="$CXX"
             CXXFLAGS="-isysroot $SDKROOT -stdlib=libc++ -mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET"
             LDFLAGS="-isysroot $SDKROOT -lc++ -lc++abi -mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET"
+            PIP_ONLY_BINARY="imagecodecs"
             ARROW_HAVE_LIBATOMIC=OFF
             REPAIR_LIBRARY_PATH="/tmp/nyxus_bld/local_install/lib:/tmp/nyxus_bld/local_install/lib64"
             NYXUS_DEP_DIR="/tmp/nyxus_bld/local_install"

--- a/src/nyx/features/basic_morphology.cpp
+++ b/src/nyx/features/basic_morphology.cpp
@@ -99,7 +99,7 @@ void BasicMorphologyFeatures::calculate (LR& r, const Fsettings& sett)
 	val_EXTENT = n / r.aabb.get_area();
 
 	//==== Basic morphology :: Aspect ratio
-	val_ASPECT_RATIO = r.aabb.get_width() / r.aabb.get_height();
+	val_ASPECT_RATIO = static_cast<double>(r.aabb.get_width()) / static_cast<double>(r.aabb.get_height());
 }
 
 void BasicMorphologyFeatures::osized_add_online_pixel(size_t x, size_t y, uint32_t intensity) {} // Not providing online calculation for these group of features
@@ -192,7 +192,7 @@ void BasicMorphologyFeatures::osized_calculate (LR& r, const Fsettings& s, Image
 	val_EXTENT = n / r.aabb.get_area();
 
 	//==== Basic morphology :: Aspect ratio
-	val_ASPECT_RATIO = r.aabb.get_width() / r.aabb.get_height();
+	val_ASPECT_RATIO = static_cast<double>(r.aabb.get_width()) / static_cast<double>(r.aabb.get_height());
 }
 
 void BasicMorphologyFeatures::save_value(std::vector<std::vector<double>>& fvals)

--- a/src/nyx/features/convex_hull_nontriv.cpp
+++ b/src/nyx/features/convex_hull_nontriv.cpp
@@ -1,4 +1,5 @@
 #define _USE_MATH_DEFINES	// For M_PI, etc.
+#include <algorithm>
 #include <cmath>
 #include "../dataset.h"
 #include "../feature_method.h"
@@ -51,33 +52,39 @@ void ConvexHullFeature::build_convex_hull (const std::vector<Pixel2>& cloud, std
 	std::vector<Pixel2>& upperCH = convhull;
 	std::vector<Pixel2> lowerCH;
 
-	size_t n = cloud.size();
-	
-	//	No need to sort pixels because we accumulate them in a raster pattern without multithreading//
-	//	std::vector<Pixel2> cloud = roi_cloud;	// Safely copy the ROI for fear of changing the original pixels order
-	//	std::sort (cloud.begin(), cloud.end(), compare_locations);
-	//
+	// Monotonic-chain hull construction requires x/y-sorted input.
+	// Avoid copying/sorting when the ingestion path already provides it.
+	const std::vector<Pixel2>* orderedCloud = &cloud;
+	std::vector<Pixel2> sortedCloud;
+	if (!std::is_sorted(cloud.begin(), cloud.end(), compare_locations))
+	{
+		sortedCloud = cloud;
+		std::sort(sortedCloud.begin(), sortedCloud.end(), compare_locations);
+		orderedCloud = &sortedCloud;
+	}
+	const std::vector<Pixel2>& ordered = *orderedCloud;
+	size_t n = ordered.size();
 
 	// Computing upper convex hull
-	upperCH.push_back (cloud[0]);
-	upperCH.push_back (cloud[1]);
+	upperCH.push_back (ordered[0]);
+	upperCH.push_back (ordered[1]);
 
 	for (size_t i = 2; i < n; i++)
 	{
-		while (upperCH.size() > 1 && (!right_turn(upperCH[upperCH.size() - 2], upperCH[upperCH.size() - 1], cloud[i])))
+		while (upperCH.size() > 1 && (!right_turn(upperCH[upperCH.size() - 2], upperCH[upperCH.size() - 1], ordered[i])))
 			upperCH.pop_back();
-		upperCH.push_back(cloud[i]);
+		upperCH.push_back(ordered[i]);
 	}
 
 	// Computing lower convex hull
-	lowerCH.push_back(cloud[n - 1]);
-	lowerCH.push_back(cloud[n - 2]);
+	lowerCH.push_back(ordered[n - 1]);
+	lowerCH.push_back(ordered[n - 2]);
 
 	for (size_t i = 2; i < n; i++)
 	{
-		while (lowerCH.size() > 1 && (!right_turn(lowerCH[lowerCH.size() - 2], lowerCH[lowerCH.size() - 1], cloud[n - i - 1])))
+		while (lowerCH.size() > 1 && (!right_turn(lowerCH[lowerCH.size() - 2], lowerCH[lowerCH.size() - 1], ordered[n - i - 1])))
 			lowerCH.pop_back();
-		lowerCH.push_back(cloud[n - i - 1]);
+		lowerCH.push_back(ordered[n - i - 1]);
 	}
 
 	// We could use 
@@ -99,34 +106,43 @@ void ConvexHullFeature::build_convex_hull (const OutOfRamPixelCloud& cloud, std:
 	std::vector<Pixel2>& upperCH = convhull;
 	std::vector<Pixel2> lowerCH;
 
-	size_t n = cloud.size();
-
-//
-//	No need to sort pixels because we accumulate them in a raster pattern without multithreading
-//	std::vector<Pixel2> cloud = roi_cloud;	// Safely copy the ROI for fear of changing the original pixels order
-//	std::sort(cloud.begin(), cloud.end(), compare_locations);
-//
+	// Monotonic-chain hull construction requires x/y-sorted input.
+	// We must materialize out-of-RAM pixels, but can still skip sorting
+	// when their storage order is already monotonic.
+	std::vector<Pixel2> orderedCloud;
+	orderedCloud.reserve(cloud.size());
+	bool alreadySorted = true;
+	for (size_t i = 0; i < cloud.size(); ++i)
+	{
+		Pixel2 px = cloud.get_at(i);
+		if (!orderedCloud.empty() && compare_locations(px, orderedCloud.back()))
+			alreadySorted = false;
+		orderedCloud.push_back(px);
+	}
+	if (!alreadySorted)
+		std::sort(orderedCloud.begin(), orderedCloud.end(), compare_locations);
+	size_t n = orderedCloud.size();
  
 	// Computing upper convex hull
-	upperCH.push_back(cloud[0]);
-	upperCH.push_back(cloud[1]);
+	upperCH.push_back(orderedCloud[0]);
+	upperCH.push_back(orderedCloud[1]);
 
 	for (size_t i = 2; i < n; i++)
 	{
-		while (upperCH.size() > 1 && (!right_turn(upperCH[upperCH.size() - 2], upperCH[upperCH.size() - 1], cloud[i])))
+		while (upperCH.size() > 1 && (!right_turn(upperCH[upperCH.size() - 2], upperCH[upperCH.size() - 1], orderedCloud[i])))
 			upperCH.pop_back();
-		upperCH.push_back(cloud[i]);
+		upperCH.push_back(orderedCloud[i]);
 	}
 
 	// Computing lower convex hull
-	lowerCH.push_back(cloud[n-1]);
-	lowerCH.push_back(cloud[n-2]);
+	lowerCH.push_back(orderedCloud[n-1]);
+	lowerCH.push_back(orderedCloud[n-2]);
 
 	for (size_t i = 2; i < n; i++)
 	{
-		while (lowerCH.size() > 1 && (!right_turn(lowerCH[lowerCH.size() - 2], lowerCH[lowerCH.size() - 1], cloud[n - i - 1])))
+		while (lowerCH.size() > 1 && (!right_turn(lowerCH[lowerCH.size() - 2], lowerCH[lowerCH.size() - 1], orderedCloud[n - i - 1])))
 			lowerCH.pop_back();
-		lowerCH.push_back(cloud[n - i - 1]);
+		lowerCH.push_back(orderedCloud[n - i - 1]);
 	}
 
 	// We could use 

--- a/src/nyx/features/neighbors.cpp
+++ b/src/nyx/features/neighbors.cpp
@@ -1,4 +1,5 @@
 #define _USE_MATH_DEFINES	// For M_PI, etc.
+#include <array>
 #include <cmath>
 #include <memory>
 #include <unordered_map>
@@ -8,11 +9,23 @@
 #include <chrono>
 #include <thread>
 #include <future>
+#include <limits>
 #include "../globals.h"
 #include "../environment.h"
 #include "neighbors.h"
 
 using namespace Nyxus;
+
+namespace
+{
+	double direction_angle_deg(double x1, double y1, double x2, double y2)
+	{
+		double ang = std::atan2(y2 - y1, x2 - x1) * 180.0 / M_PI;
+		if (ang < 0.0)
+			ang += 360.0;
+		return ang;
+	}
+}
 
 bool NeighborsFeature::required(const FeatureSet& fs)
 {
@@ -117,7 +130,18 @@ void NeighborsFeature::manual_reduce (
 	const std::unordered_set<int> & uniqueLabels)
 {
 	int radius = STNGS_PIXELDISTANCE(s);	// former theEnvironment.get_pixel_distance()
-	int n_threads = 1; 
+	int n_threads = 1;
+	const int percentTouchingIdx = static_cast<int>(Feature2D::PERCENT_TOUCHING);
+	const int numNeighborsIdx = static_cast<int>(Feature2D::NUM_NEIGHBORS);
+	const int centroidXIdx = static_cast<int>(Feature2D::CENTROID_X);
+	const int centroidYIdx = static_cast<int>(Feature2D::CENTROID_Y);
+	const int closestNeighbor1DistIdx = static_cast<int>(Feature2D::CLOSEST_NEIGHBOR1_DIST);
+	const int closestNeighbor1AngIdx = static_cast<int>(Feature2D::CLOSEST_NEIGHBOR1_ANG);
+	const int closestNeighbor2DistIdx = static_cast<int>(Feature2D::CLOSEST_NEIGHBOR2_DIST);
+	const int closestNeighbor2AngIdx = static_cast<int>(Feature2D::CLOSEST_NEIGHBOR2_ANG);
+	const int angBetweenNeighborsMeanIdx = static_cast<int>(Feature2D::ANG_BW_NEIGHBORS_MEAN);
+	const int angBetweenNeighborsStddevIdx = static_cast<int>(Feature2D::ANG_BW_NEIGHBORS_STDDEV);
+	const int angBetweenNeighborsModeIdx = static_cast<int>(Feature2D::ANG_BW_NEIGHBORS_MODE);
 
 	//==== Collision detection, method 1 (greedy)
 	auto n_ul = uniqueLabels.size();
@@ -125,6 +149,7 @@ void NeighborsFeature::manual_reduce (
 	std::vector <int> LabsVec;
 	LabsVec.reserve (uniqueLabels.size());
 	LabsVec.insert (LabsVec.end(), uniqueLabels.begin(), uniqueLabels.end());
+	std::sort(LabsVec.begin(), LabsVec.end());
 
 	std::vector <std::pair<int, int>> CM2;
 	CM2.reserve (n_ul * n_ul / 4);	// estimate: 25% of the segment population
@@ -143,8 +168,7 @@ void NeighborsFeature::manual_reduce (
 				continue;	// No need to check the upper triangle for single-threaded runs. Multi-threaded runs require the upper triangle for thread-safe results.
 
 			LR& r2 = roiData[l2];
-			bool noOverlap = r2.aabb.get_xmin() > r1.aabb.get_xmax() || r2.aabb.get_xmax() < r1.aabb.get_xmin() 
-				|| r2.aabb.get_ymin() > r1.aabb.get_ymax() || r2.aabb.get_ymax() < r1.aabb.get_ymin() ;
+			bool noOverlap = aabbNoOverlap(r1, r2, radius);
 			if (! noOverlap)
 			{
 				CM2.push_back( {l1, l2});
@@ -237,15 +261,23 @@ void NeighborsFeature::manual_reduce (
 
 			// Iterate r1's outer pixels
 			double mind = K1[0].min_sqdist(K2);
-			size_t n_touchingOuterPixels = 0;
+			size_t n_touchingOuterPixels1 = 0;
 			for (auto& cp : K1)
 			{
 				double minD = cp.min_sqdist(K2);
 				mind = std::min(mind, minD);		//--We aren't interested in max distance-->	maxd = std::max(maxd, maxD);
 
 				// Maintain touching pixels stats
-				if (minD == 0) // (minD <= radius2)
-					n_touchingOuterPixels++;
+				if (minD <= radius2)
+					n_touchingOuterPixels1++;
+			}
+
+			size_t n_touchingOuterPixels2 = 0;
+			for (auto& cp : K2)
+			{
+				double minD = cp.min_sqdist(K1);
+				if (minD <= radius2)
+					n_touchingOuterPixels2++;
 			}
 
 			// Check versus the radius
@@ -253,26 +285,27 @@ void NeighborsFeature::manual_reduce (
 				continue;
 
 			// Save partial statis of r1's touching pixel stats
-			r1.fvals[(int)Feature2D::PERCENT_TOUCHING][0] += n_touchingOuterPixels;
+			r1.fvals[percentTouchingIdx][0] += n_touchingOuterPixels1;
+			r2.fvals[percentTouchingIdx][0] += n_touchingOuterPixels2;
 
 			// Definitely neighbors
-			r1.fvals[(int)Feature2D::NUM_NEIGHBORS][0]++;
+			r1.fvals[numNeighborsIdx][0]++;
 			r1.aux_neighboring_labels.push_back(l2);
 
 			// We're single-threaded here so it's safe to update both r1 and r2
-			r2.fvals[(int)Feature2D::NUM_NEIGHBORS][0]++;
+			r2.fvals[numNeighborsIdx][0]++;
 			r2.aux_neighboring_labels.push_back(l1);
 		}
-		for (auto pa : CM2)
+		for (auto l : uniqueLabels)
 		{
-			auto l1 = pa.first;
-			LR& r1 = roiData[l1];
+			LR& r1 = roiData[l];
 
 			std::vector<Pixel2> K1;
 			r1.merge_multicontour(K1);
 
 			// Finalize the % touching calculation
-			r1.fvals[(int)Feature2D::PERCENT_TOUCHING][0] = 100.0 * double(r1.fvals[(int)Feature2D::PERCENT_TOUCHING][0]) / double(K1.size());
+			if (!K1.empty())
+				r1.fvals[percentTouchingIdx][0] = 100.0 * static_cast<double>(r1.fvals[percentTouchingIdx][0]) / static_cast<double>(K1.size());
 		}
 	}
 	else
@@ -402,25 +435,25 @@ void NeighborsFeature::manual_reduce (
 	for (auto l : uniqueLabels)
 	{
 		LR& r = roiData[l];
-		int n_neigs = int(r.fvals[(int)Feature2D::NUM_NEIGHBORS][0]);
+		int n_neigs = static_cast<int>(r.fvals[numNeighborsIdx][0]);
 
 		// Any neighbors of this ROI ?
 		if (n_neigs == 0)
 			continue;
 
-		double cenx = r.fvals[(int)Feature2D::CENTROID_X][0],
-			ceny = r.fvals[(int)Feature2D::CENTROID_Y][0];
+		double cenx = r.fvals[centroidXIdx][0],
+			ceny = r.fvals[centroidYIdx][0];
 
 		std::vector<double> dists;
 		dists.reserve(r.aux_neighboring_labels.size());
 		for (auto l_neig : r.aux_neighboring_labels)
 		{
 			LR& r_neig = roiData[l_neig];
-			double cenx_n = r_neig.fvals[(int)Feature2D::CENTROID_X][0],
-				ceny_n = r_neig.fvals[(int)Feature2D::CENTROID_Y][0],
+			double cenx_n = r_neig.fvals[centroidXIdx][0],
+				ceny_n = r_neig.fvals[centroidYIdx][0],
 				dx = cenx - cenx_n,
 				dy = ceny - ceny_n,
-				dist = dx * dx + dy * dy;
+				dist = std::sqrt(dx * dx + dy * dy);
 			dists.push_back(dist);
 		}
 
@@ -430,62 +463,73 @@ void NeighborsFeature::manual_reduce (
 		auto closest1label = r.aux_neighboring_labels[closest_1_idx];
 
 		// Save distance to neighbor #1
-		r.fvals[(int)Feature2D::CLOSEST_NEIGHBOR1_DIST][0] = dists[closest_1_idx];
+		r.fvals[closestNeighbor1DistIdx][0] = dists[closest_1_idx];
 
 		// Save angle with neighbor #1
 		LR& r1 = roiData[closest1label];
-		r.fvals[(int)Feature2D::CLOSEST_NEIGHBOR1_ANG][0] = 180.0 * angle(cenx, ceny, r1.fvals[(int)Feature2D::CENTROID_X][0], r1.fvals[(int)Feature2D::CENTROID_X][0]);
+		r.fvals[closestNeighbor1AngIdx][0] = direction_angle_deg(cenx, ceny, r1.fvals[centroidXIdx][0], r1.fvals[centroidYIdx][0]);
 
 		// Find idx of 2nd minimum
 		if (n_neigs > 1)
 		{
-			auto lambSkip1st = [&ite1st](double a, double b)
-			{
-				return ((b != (*ite1st)) && (a > b));
-			};
-			auto ite2nd = std::min_element(dists.begin(), dists.end(), lambSkip1st);
-			auto closest_2_idx = std::distance(dists.begin(), ite2nd);
+			std::vector<double> dists_copy = dists;
+			dists_copy[closest_1_idx] = std::numeric_limits<double>::infinity();
+			auto ite2nd = std::min_element(dists_copy.begin(), dists_copy.end());
+			auto closest_2_idx = std::distance(dists_copy.begin(), ite2nd);
 			auto closest2label = r.aux_neighboring_labels[closest_2_idx];
 
 			// Save distance to neighbor #2
-			r.fvals[(int)Feature2D::CLOSEST_NEIGHBOR2_DIST][0] = dists[closest_2_idx];
+			r.fvals[closestNeighbor2DistIdx][0] = dists[closest_2_idx];
 
 			// Save angle with neighbor #2
 			LR& r2 = roiData[closest2label];
-			r.fvals[(int)Feature2D::CLOSEST_NEIGHBOR2_ANG][0] = 180.0 * angle(cenx, ceny, r2.fvals[(int)Feature2D::CENTROID_X][0], r2.fvals[(int)Feature2D::CENTROID_X][0]);
+			r.fvals[closestNeighbor2AngIdx][0] = direction_angle_deg(cenx, ceny, r2.fvals[centroidXIdx][0], r2.fvals[centroidYIdx][0]);
 		}
 	}
 
 	// Angle between neighbors
-	Moments2 mom2;
-	std::vector<int> anglesRounded;
 	for (auto l : uniqueLabels)
 	{
 		LR& r = roiData[l];
-		int n_neigs = int(r.fvals[(int)Feature2D::NUM_NEIGHBORS][0]);
+		int n_neigs = static_cast<int>(r.fvals[numNeighborsIdx][0]);
 
 		// Any neighbors of this ROI ?
 		if (n_neigs == 0)
 			continue;
 
-		double cenx = r.fvals[(int)Feature2D::CENTROID_X][0],
-			ceny = r.fvals[(int)Feature2D::CENTROID_Y][0];
+		double cenx = r.fvals[centroidXIdx][0],
+			ceny = r.fvals[centroidYIdx][0];
+
+		Moments2 mom2;
+		std::array<int, 361> angleCounts{};
 
 		// Iterate all the neighbors
 		for (auto l_neig : r.aux_neighboring_labels)
 		{
 			LR& r_neig = roiData[l_neig];
-			double cenx_n = r_neig.fvals[(int)Feature2D::CENTROID_X][0],
-				ceny_n = r_neig.fvals[(int)Feature2D::CENTROID_Y][0];
+			double cenx_n = r_neig.fvals[centroidXIdx][0],
+				ceny_n = r_neig.fvals[centroidYIdx][0];
 
-			double ang = 180.0 * angle (cenx, ceny, cenx_n, ceny_n);	
+			double ang = direction_angle_deg(cenx, ceny, cenx_n, ceny_n);
 			mom2.add(ang);
-			anglesRounded.push_back(ang);
+			int roundedAngle = static_cast<int>(std::round(ang));
+			roundedAngle = std::max(0, std::min(360, roundedAngle));
+			++angleCounts[roundedAngle];
 		}
 
-		r.fvals[(int)Feature2D::ANG_BW_NEIGHBORS_MEAN][0] = mom2.mean();
-		r.fvals[(int)Feature2D::ANG_BW_NEIGHBORS_STDDEV][0] = mom2.std();
-		r.fvals[(int)Feature2D::ANG_BW_NEIGHBORS_MODE][0] = mode(anglesRounded);
+		int angleMode = 0;
+		int angleModeCount = 0;
+		for (size_t i = 0; i < angleCounts.size(); ++i)
+		{
+			if (angleCounts[i] > angleModeCount)
+			{
+				angleModeCount = angleCounts[i];
+				angleMode = static_cast<int>(i);
+			}
+		}
+		r.fvals[angBetweenNeighborsMeanIdx][0] = mom2.mean();
+		r.fvals[angBetweenNeighborsStddevIdx][0] = mom2.std();
+		r.fvals[angBetweenNeighborsModeIdx][0] = angleMode;
 	}
 }
 

--- a/tests/test_all.cc
+++ b/tests/test_all.cc
@@ -5,6 +5,8 @@
 #include "test_contour.h"
 #include "test_pixel_intensity_features.h"
 #include "test_morphology_features.h"
+#include "test_shape_morphology_2d.h"
+#include "test_neighbors_2d.h"
 #include "test_initialization.h"
 #include "test_ibsi_glcm.h"
 #include "test_ibsi_gldm.h"
@@ -832,6 +834,51 @@ TEST(TEST_NYXUS, TEST_PIXEL_INTENSITY_COVERED_IMAGE_INTENSITY_RANGE)
 TEST(TEST_NYXUS, TEST_MORPHOLOGY_PERIMETER) 
 {
 	ASSERT_NO_THROW(test_morphology_perimeter());
+}
+
+TEST(TEST_NYXUS, TEST_SHAPE2D_BASIC_MORPHOLOGY_FEATURES)
+{
+	ASSERT_NO_THROW(test_shape2d_basic_morphology_features());
+}
+
+TEST(TEST_NYXUS, TEST_SHAPE2D_ELLIPSE_FEATURES)
+{
+	ASSERT_NO_THROW(test_shape2d_ellipse_features());
+}
+
+TEST(TEST_NYXUS, TEST_SHAPE2D_CONTOUR_FEATURES)
+{
+	ASSERT_NO_THROW(test_shape2d_contour_features());
+}
+
+TEST(TEST_NYXUS, TEST_SHAPE2D_CONVEX_HULL_FEATURES)
+{
+	ASSERT_NO_THROW(test_shape2d_convex_hull_features());
+}
+
+TEST(TEST_NYXUS, TEST_SHAPE2D_EXTREMA_FEATURES)
+{
+	ASSERT_NO_THROW(test_shape2d_extrema_features());
+}
+
+TEST(TEST_NYXUS, TEST_SHAPE2D_MISC_FEATURES)
+{
+	ASSERT_NO_THROW(test_shape2d_misc_shape_features());
+}
+
+TEST(TEST_NYXUS, TEST_NEIGHBORHOOD2D_COUNTS_TOUCHING)
+{
+	ASSERT_NO_THROW(test_neighborhood2d_counts_and_touching());
+}
+
+TEST(TEST_NYXUS, TEST_NEIGHBORHOOD2D_CLOSEST_NEIGHBORS)
+{
+	ASSERT_NO_THROW(test_neighborhood2d_closest_neighbors());
+}
+
+TEST(TEST_NYXUS, TEST_NEIGHBORHOOD2D_ANGLE_STATS)
+{
+	ASSERT_NO_THROW(test_neighborhood2d_neighbor_angle_stats());
 }
 
 

--- a/tests/test_data.h
+++ b/tests/test_data.h
@@ -249,6 +249,50 @@ const static int ibsi_fig3_17c_gldzm_ground_truth[] =
 	1, 1
 };
 
+//
+// Synthetic 2D ROI for shape and morphology regression coverage.
+// The mask defines a single irregular concave ROI; the intensity image
+// adds an asymmetric gradient so weighted-centroid and edge-intensity
+// features have non-trivial values.
+//
+
+const static NyxusPixel shape2d_morphology_intensity[] = {
+	{0, 0, 0}, {1, 0, 0}, {2, 0, 12}, {3, 0, 14}, {4, 0, 0}, {5, 0, 0}, {6, 0, 0}, {7, 0, 0},
+	{0, 1, 0}, {1, 1, 18}, {2, 1, 20}, {3, 1, 24}, {4, 1, 26}, {5, 1, 0}, {6, 1, 0}, {7, 1, 0},
+	{0, 2, 30}, {1, 2, 32}, {2, 2, 35}, {3, 2, 38}, {4, 2, 42}, {5, 2, 45}, {6, 2, 0}, {7, 2, 0},
+	{0, 3, 34}, {1, 3, 37}, {2, 3, 40}, {3, 3, 0}, {4, 3, 48}, {5, 3, 52}, {6, 3, 0}, {7, 3, 0},
+	{0, 4, 0}, {1, 4, 44}, {2, 4, 47}, {3, 4, 51}, {4, 4, 55}, {5, 4, 0}, {6, 4, 0}, {7, 4, 0},
+	{0, 5, 0}, {1, 5, 0}, {2, 5, 53}, {3, 5, 58}, {4, 5, 62}, {5, 5, 0}, {6, 5, 0}, {7, 5, 0},
+	{0, 6, 0}, {1, 6, 0}, {2, 6, 0}, {3, 6, 63}, {4, 6, 68}, {5, 6, 0}, {6, 6, 0}, {7, 6, 0},
+	{0, 7, 0}, {1, 7, 0}, {2, 7, 0}, {3, 7, 0}, {4, 7, 0}, {5, 7, 0}, {6, 7, 0}, {7, 7, 0}
+};
+
+const static NyxusPixel shape2d_morphology_mask[] = {
+	{0, 0, 0}, {1, 0, 0}, {2, 0, 1}, {3, 0, 1}, {4, 0, 0}, {5, 0, 0}, {6, 0, 0}, {7, 0, 0},
+	{0, 1, 0}, {1, 1, 1}, {2, 1, 1}, {3, 1, 1}, {4, 1, 1}, {5, 1, 0}, {6, 1, 0}, {7, 1, 0},
+	{0, 2, 1}, {1, 2, 1}, {2, 2, 1}, {3, 2, 1}, {4, 2, 1}, {5, 2, 1}, {6, 2, 0}, {7, 2, 0},
+	{0, 3, 1}, {1, 3, 1}, {2, 3, 1}, {3, 3, 0}, {4, 3, 1}, {5, 3, 1}, {6, 3, 0}, {7, 3, 0},
+	{0, 4, 0}, {1, 4, 1}, {2, 4, 1}, {3, 4, 1}, {4, 4, 1}, {5, 4, 0}, {6, 4, 0}, {7, 4, 0},
+	{0, 5, 0}, {1, 5, 0}, {2, 5, 1}, {3, 5, 1}, {4, 5, 1}, {5, 5, 0}, {6, 5, 0}, {7, 5, 0},
+	{0, 6, 0}, {1, 6, 0}, {2, 6, 0}, {3, 6, 1}, {4, 6, 1}, {5, 6, 0}, {6, 6, 0}, {7, 6, 0},
+	{0, 7, 0}, {1, 7, 0}, {2, 7, 0}, {3, 7, 0}, {4, 7, 0}, {5, 7, 0}, {6, 7, 0}, {7, 7, 0}
+};
+
+//
+// Synthetic multi-label 2D scene for neighborhood/touching regression coverage.
+// Labels are stored in the intensity slot and represent five ROIs:
+// a central 3x3 ROI with left/top/right/bottom neighbors at a 1-pixel
+// contour distance.
+//
+
+const static NyxusPixel neighborhood2d_scene_labels[] = {
+	{4, 2, 3}, {5, 2, 3}, {4, 3, 3}, {5, 3, 3},
+	{2, 4, 2}, {3, 4, 2}, {4, 4, 1}, {5, 4, 1}, {6, 4, 1}, {7, 4, 4}, {8, 4, 4},
+	{2, 5, 2}, {3, 5, 2}, {4, 5, 1}, {5, 5, 1}, {6, 5, 1}, {7, 5, 4}, {8, 5, 4},
+	{4, 6, 1}, {5, 6, 1}, {6, 6, 1}, {7, 6, 4}, {8, 6, 4},
+	{5, 7, 5}, {6, 7, 5}, {5, 8, 5}, {6, 8, 5}
+};
+
 // Phantom for ROI perimeter feature calculation - nonzero pixels of ROI mask generated in Matlab as:
 // BW_noholes = imfill(imread('circles.png', 'holes'))
 const static NyxusPixel roiDataForPerimeterTest[] = {

--- a/tests/test_neighbors_2d.h
+++ b/tests/test_neighbors_2d.h
@@ -1,0 +1,181 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "../src/nyx/roi_cache.h"
+#include "../src/nyx/features/basic_morphology.h"
+#include "../src/nyx/features/contour.h"
+#include "../src/nyx/features/neighbors.h"
+#include "test_data.h"
+#include "test_main_nyxus.h"
+
+static std::unordered_map<int, std::unordered_map<std::string, double>> neighborhood2d_truth{
+	{1, {
+		{"NUM_NEIGHBORS", 4.0},
+		{"PERCENT_TOUCHING", 87.5},
+		{"CLOSEST_NEIGHBOR1_DIST", 2.5},
+		{"CLOSEST_NEIGHBOR1_ANG", 0.0},
+		{"CLOSEST_NEIGHBOR2_DIST", 2.54950975679639},
+		{"CLOSEST_NEIGHBOR2_ANG", 191.30993247402},
+		{"ANG_BW_NEIGHBORS_MEAN", 132.172516881495},
+		{"ANG_BW_NEIGHBORS_STDDEV", 115.230018010206},
+		{"ANG_BW_NEIGHBORS_MODE", 0.0},
+	}},
+	{2, {
+		{"NUM_NEIGHBORS", 1.0},
+		{"PERCENT_TOUCHING", 33.3333333333333},
+		{"CLOSEST_NEIGHBOR1_DIST", 2.54950975679639},
+		{"CLOSEST_NEIGHBOR1_ANG", 11.3099324740202},
+		{"CLOSEST_NEIGHBOR2_DIST", 0.0},
+		{"CLOSEST_NEIGHBOR2_ANG", 0.0},
+		{"ANG_BW_NEIGHBORS_MEAN", 11.3099324740202},
+		{"ANG_BW_NEIGHBORS_STDDEV", 0.0},
+		{"ANG_BW_NEIGHBORS_MODE", 11.0},
+	}},
+	{3, {
+		{"NUM_NEIGHBORS", 1.0},
+		{"PERCENT_TOUCHING", 66.6666666666667},
+		{"CLOSEST_NEIGHBOR1_DIST", 2.54950975679639},
+		{"CLOSEST_NEIGHBOR1_ANG", 78.6900675259798},
+		{"CLOSEST_NEIGHBOR2_DIST", 0.0},
+		{"CLOSEST_NEIGHBOR2_ANG", 0.0},
+		{"ANG_BW_NEIGHBORS_MEAN", 78.6900675259798},
+		{"ANG_BW_NEIGHBORS_STDDEV", 0.0},
+		{"ANG_BW_NEIGHBORS_MODE", 79.0},
+	}},
+	{4, {
+		{"NUM_NEIGHBORS", 1.0},
+		{"PERCENT_TOUCHING", 50.0},
+		{"CLOSEST_NEIGHBOR1_DIST", 2.5},
+		{"CLOSEST_NEIGHBOR1_ANG", 180.0},
+		{"CLOSEST_NEIGHBOR2_DIST", 0.0},
+		{"CLOSEST_NEIGHBOR2_ANG", 0.0},
+		{"ANG_BW_NEIGHBORS_MEAN", 180.0},
+		{"ANG_BW_NEIGHBORS_STDDEV", 0.0},
+		{"ANG_BW_NEIGHBORS_MODE", 180.0},
+	}},
+	{5, {
+		{"NUM_NEIGHBORS", 1.0},
+		{"PERCENT_TOUCHING", 33.3333333333333},
+		{"CLOSEST_NEIGHBOR1_DIST", 2.54950975679639},
+		{"CLOSEST_NEIGHBOR1_ANG", 258.69006752598},
+		{"CLOSEST_NEIGHBOR2_DIST", 0.0},
+		{"CLOSEST_NEIGHBOR2_ANG", 0.0},
+		{"ANG_BW_NEIGHBORS_MEAN", 258.69006752598},
+		{"ANG_BW_NEIGHBORS_STDDEV", 0.0},
+		{"ANG_BW_NEIGHBORS_MODE", 259.0},
+	}}
+};
+
+static Fsettings make_neighbors2d_settings()
+{
+	Fsettings s;
+	s.resize(static_cast<int>(NyxSetting::__COUNT__));
+	s[static_cast<int>(NyxSetting::SOFTNAN)].rval = 0.0;
+	s[static_cast<int>(NyxSetting::TINY)].rval = 0.0;
+	s[static_cast<int>(NyxSetting::SINGLEROI)].bval = false;
+	s[static_cast<int>(NyxSetting::GREYDEPTH)].ival = 128;
+	s[static_cast<int>(NyxSetting::PIXELSIZEUM)].rval = 1.0;
+	s[static_cast<int>(NyxSetting::XYRES)].rval = 1.0;
+	s[static_cast<int>(NyxSetting::PIXELDISTANCE)].ival = 1;
+	s[static_cast<int>(NyxSetting::USEGPU)].bval = false;
+	s[static_cast<int>(NyxSetting::VERBOSLVL)].ival = 0;
+	s[static_cast<int>(NyxSetting::IBSI)].bval = false;
+	return s;
+}
+
+static void calculate_neighborhood2d_feature_values(std::unordered_map<int, LR>& roiData)
+{
+	Fsettings s = make_neighbors2d_settings();
+	std::unordered_set<int> uniqueLabels;
+
+	for (const auto& px : neighborhood2d_scene_labels)
+	{
+		int label = static_cast<int>(px.intensity);
+		uniqueLabels.insert(label);
+
+		auto [it, inserted] = roiData.try_emplace(label, label);
+		LR& roi = it->second;
+
+		if (inserted)
+			init_label_record_3(roi, static_cast<int>(px.x), static_cast<int>(px.y), 1);
+		else
+			update_label_record_3(roi, static_cast<int>(px.x), static_cast<int>(px.y), 1);
+
+		roi.raw_pixels.push_back(Pixel2(static_cast<size_t>(px.x), static_cast<size_t>(px.y), static_cast<PixIntens>(1)));
+	}
+
+	BasicMorphologyFeatures basic;
+	ContourFeature contour;
+	for (auto& item : roiData)
+	{
+		LR& roi = item.second;
+		roi.make_nonanisotropic_aabb();
+		roi.aux_image_matrix = ImageMatrix(roi.raw_pixels);
+		roi.initialize_fvals();
+
+		basic.calculate(roi, s);
+		basic.save_value(roi.fvals);
+
+		contour.calculate(roi, s);
+		contour.save_value(roi.fvals);
+	}
+
+	NeighborsFeature::manual_reduce(roiData, s, uniqueLabels);
+}
+
+static void assert_neighbor2d_feature(
+	const std::unordered_map<int, LR>& roiData,
+	int label,
+	Nyxus::Feature2D feature,
+	const std::string& feature_name,
+	double frac_tolerance = 1000.0)
+{
+	ASSERT_TRUE(neighborhood2d_truth.count(label) > 0);
+	ASSERT_TRUE(neighborhood2d_truth[label].count(feature_name) > 0);
+	ASSERT_TRUE(agrees_gt(roiData.at(label).fvals[static_cast<int>(feature)][0], neighborhood2d_truth[label][feature_name], frac_tolerance));
+}
+
+void test_neighborhood2d_counts_and_touching()
+{
+	std::unordered_map<int, LR> roiData;
+	calculate_neighborhood2d_feature_values(roiData);
+
+	for (int label : {1, 2, 3, 4, 5})
+	{
+		assert_neighbor2d_feature(roiData, label, Nyxus::Feature2D::NUM_NEIGHBORS, "NUM_NEIGHBORS");
+		assert_neighbor2d_feature(roiData, label, Nyxus::Feature2D::PERCENT_TOUCHING, "PERCENT_TOUCHING");
+	}
+}
+
+void test_neighborhood2d_closest_neighbors()
+{
+	std::unordered_map<int, LR> roiData;
+	calculate_neighborhood2d_feature_values(roiData);
+
+	for (int label : {1, 2, 3, 4, 5})
+	{
+		assert_neighbor2d_feature(roiData, label, Nyxus::Feature2D::CLOSEST_NEIGHBOR1_DIST, "CLOSEST_NEIGHBOR1_DIST");
+		assert_neighbor2d_feature(roiData, label, Nyxus::Feature2D::CLOSEST_NEIGHBOR1_ANG, "CLOSEST_NEIGHBOR1_ANG");
+		assert_neighbor2d_feature(roiData, label, Nyxus::Feature2D::CLOSEST_NEIGHBOR2_DIST, "CLOSEST_NEIGHBOR2_DIST");
+		assert_neighbor2d_feature(roiData, label, Nyxus::Feature2D::CLOSEST_NEIGHBOR2_ANG, "CLOSEST_NEIGHBOR2_ANG");
+	}
+}
+
+void test_neighborhood2d_neighbor_angle_stats()
+{
+	std::unordered_map<int, LR> roiData;
+	calculate_neighborhood2d_feature_values(roiData);
+
+	for (int label : {1, 2, 3, 4, 5})
+	{
+		assert_neighbor2d_feature(roiData, label, Nyxus::Feature2D::ANG_BW_NEIGHBORS_MEAN, "ANG_BW_NEIGHBORS_MEAN");
+		assert_neighbor2d_feature(roiData, label, Nyxus::Feature2D::ANG_BW_NEIGHBORS_STDDEV, "ANG_BW_NEIGHBORS_STDDEV");
+		assert_neighbor2d_feature(roiData, label, Nyxus::Feature2D::ANG_BW_NEIGHBORS_MODE, "ANG_BW_NEIGHBORS_MODE");
+	}
+}

--- a/tests/test_shape_morphology_2d.h
+++ b/tests/test_shape_morphology_2d.h
@@ -1,0 +1,255 @@
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <string>
+#include <unordered_map>
+
+#include "../src/nyx/roi_cache.h"
+#include "../src/nyx/features/basic_morphology.h"
+#include "../src/nyx/features/contour.h"
+#include "../src/nyx/features/convex_hull.h"
+#include "../src/nyx/features/ellipse_fitting.h"
+#include "../src/nyx/features/extrema.h"
+#include "../src/nyx/features/roi_radius.h"
+#include "../src/nyx/features/euler_number.h"
+#include "../src/nyx/features/fractal_dim.h"
+#include "../src/nyx/features/circle.h"
+#include "test_data.h"
+#include "test_main_nyxus.h"
+
+static std::unordered_map<std::string, double> shape2d_truth{
+	{"AREA_PIXELS_COUNT", 26.0},
+	{"AREA_UM2", 104.0},
+	{"CENTROID_X", 2.61538461538462},
+	{"CENTROID_Y", 2.84615384615385},
+	{"WEIGHTED_CENTROID_X", 3.84160305343511},
+	{"WEIGHTED_CENTROID_Y", 4.43893129770992},
+	{"MASS_DISPLACEMENT", 2.01011235208395},
+	{"COMPACTNESS", 0.065356393729344},
+	{"BBOX_XMIN", 0.0},
+	{"BBOX_YMIN", 0.0},
+	{"BBOX_WIDTH", 6.0},
+	{"BBOX_HEIGHT", 7.0},
+	{"DIAMETER_EQUAL_AREA", 33.1042281631142},
+	{"EXTENT", 0.619047619047619},
+	{"ASPECT_RATIO", 0.857142857142857},
+	{"MAJOR_AXIS_LENGTH", 6.96881616898619},
+	{"MINOR_AXIS_LENGTH", 5.48870991295738},
+	{"ELONGATION", 0.787610087547462},
+	{"ECCENTRICITY", 0.616173960820708},
+	{"ORIENTATION", 70.4173944984207},
+	{"ROUNDNESS", 0.681656295209303},
+	{"PERIMETER", 26.9349412836191},
+	{"DIAMETER_EQUAL_PERIMETER", 8.57365809435587},
+	{"EDGE_MEAN_INTENSITY", 41.8333333333333},
+	{"EDGE_STDDEV_INTENSITY", 16.7691944455582},
+	{"EDGE_MAX_INTENSITY", 68.0},
+	{"EDGE_MIN_INTENSITY", 12.0},
+	{"EDGE_INTEGRATED_INTENSITY", 753.0},
+	{"CIRCULARITY", 0.671081973229055},
+	{"CONVEX_HULL_AREA", 24.0},
+	{"SOLIDITY", 1.08333333333333},
+	{"EULER_NUMBER", -2.0},
+	{"FRACT_DIM_BOXCOUNT", -0.830074998557687},
+	{"FRACT_DIM_PERIMETER", -1.97227924244155},
+	{"DIAMETER_MIN_ENCLOSING_CIRCLE", 6.32475519180298},
+	{"DIAMETER_CIRCUMSCRIBING_CIRCLE", 12.3317073399088},
+	{"DIAMETER_INSCRIBING_CIRCLE", 0.828486893405308},
+	{"ROI_RADIUS_MEAN", 1.07692307692308},
+	{"ROI_RADIUS_MAX", 4.0},
+	{"ROI_RADIUS_MEDIAN", 1.0},
+	{"EXTREMA_P1_X", 2.0},
+	{"EXTREMA_P1_Y", 0.0},
+	{"EXTREMA_P2_X", 3.0},
+	{"EXTREMA_P2_Y", 0.0},
+	{"EXTREMA_P3_X", 5.0},
+	{"EXTREMA_P3_Y", 2.0},
+	{"EXTREMA_P4_X", 5.0},
+	{"EXTREMA_P4_Y", 3.0},
+	{"EXTREMA_P5_X", 4.0},
+	{"EXTREMA_P5_Y", 6.0},
+	{"EXTREMA_P6_X", 3.0},
+	{"EXTREMA_P6_Y", 6.0},
+	{"EXTREMA_P7_X", 0.0},
+	{"EXTREMA_P7_Y", 3.0},
+	{"EXTREMA_P8_X", 0.0},
+	{"EXTREMA_P8_Y", 2.0},
+};
+
+static Fsettings make_shape2d_settings()
+{
+	Fsettings s;
+	s.resize(static_cast<int>(NyxSetting::__COUNT__));
+	s[static_cast<int>(NyxSetting::SOFTNAN)].rval = 0.0;
+	s[static_cast<int>(NyxSetting::TINY)].rval = 0.0;
+	s[static_cast<int>(NyxSetting::SINGLEROI)].bval = false;
+	s[static_cast<int>(NyxSetting::GREYDEPTH)].ival = 128;
+	s[static_cast<int>(NyxSetting::PIXELSIZEUM)].rval = 2.0;
+	s[static_cast<int>(NyxSetting::XYRES)].rval = 1.0;
+	s[static_cast<int>(NyxSetting::PIXELDISTANCE)].ival = 1;
+	s[static_cast<int>(NyxSetting::USEGPU)].bval = false;
+	s[static_cast<int>(NyxSetting::VERBOSLVL)].ival = 0;
+	s[static_cast<int>(NyxSetting::IBSI)].bval = false;
+	return s;
+}
+
+static void calculate_shape2d_feature_values(std::vector<std::vector<double>>& fvals)
+{
+	Fsettings s = make_shape2d_settings();
+
+	LR roidata(101);
+	load_masked_test_roi_data(
+		roidata,
+		shape2d_morphology_intensity,
+		shape2d_morphology_mask,
+		sizeof(shape2d_morphology_mask) / sizeof(NyxusPixel));
+	roidata.initialize_fvals();
+
+	BasicMorphologyFeatures basic;
+	basic.calculate(roidata, s);
+	basic.save_value(roidata.fvals);
+
+	ContourFeature contour;
+	contour.calculate(roidata, s);
+	contour.save_value(roidata.fvals);
+
+	ConvexHullFeature hull;
+	hull.calculate(roidata, s);
+	hull.save_value(roidata.fvals);
+
+	EllipseFittingFeature ellipse;
+	ellipse.calculate(roidata, s);
+	ellipse.save_value(roidata.fvals);
+
+	ExtremaFeature extrema;
+	extrema.calculate(roidata, s);
+	extrema.save_value(roidata.fvals);
+
+	RoiRadiusFeature radius;
+	radius.calculate(roidata, s);
+	radius.save_value(roidata.fvals);
+
+	EulerNumberFeature euler;
+	euler.calculate(roidata, s);
+	euler.save_value(roidata.fvals);
+
+	FractalDimensionFeature fractal;
+	fractal.calculate(roidata, s);
+	fractal.save_value(roidata.fvals);
+
+	EnclosingInscribingCircumscribingCircleFeature circle;
+	circle.calculate(roidata, s);
+	circle.save_value(roidata.fvals);
+
+	fvals = roidata.fvals;
+}
+
+static void assert_shape2d_feature(
+	const std::vector<std::vector<double>>& fvals,
+	Nyxus::Feature2D feature,
+	const std::string& feature_name,
+	double frac_tolerance = 1000.0)
+{
+	ASSERT_TRUE(shape2d_truth.count(feature_name) > 0);
+	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], shape2d_truth[feature_name], frac_tolerance));
+}
+
+void test_shape2d_basic_morphology_features()
+{
+	std::vector<std::vector<double>> fvals;
+	calculate_shape2d_feature_values(fvals);
+
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::AREA_PIXELS_COUNT, "AREA_PIXELS_COUNT");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::AREA_UM2, "AREA_UM2");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::CENTROID_X, "CENTROID_X");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::CENTROID_Y, "CENTROID_Y");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::WEIGHTED_CENTROID_X, "WEIGHTED_CENTROID_X");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::WEIGHTED_CENTROID_Y, "WEIGHTED_CENTROID_Y");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::MASS_DISPLACEMENT, "MASS_DISPLACEMENT");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::COMPACTNESS, "COMPACTNESS");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::BBOX_XMIN, "BBOX_XMIN");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::BBOX_YMIN, "BBOX_YMIN");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::BBOX_WIDTH, "BBOX_WIDTH");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::BBOX_HEIGHT, "BBOX_HEIGHT");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::DIAMETER_EQUAL_AREA, "DIAMETER_EQUAL_AREA");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTENT, "EXTENT");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::ASPECT_RATIO, "ASPECT_RATIO");
+}
+
+void test_shape2d_ellipse_features()
+{
+	std::vector<std::vector<double>> fvals;
+	calculate_shape2d_feature_values(fvals);
+
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::MAJOR_AXIS_LENGTH, "MAJOR_AXIS_LENGTH");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::MINOR_AXIS_LENGTH, "MINOR_AXIS_LENGTH");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::ELONGATION, "ELONGATION");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::ECCENTRICITY, "ECCENTRICITY");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::ORIENTATION, "ORIENTATION");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::ROUNDNESS, "ROUNDNESS");
+}
+
+void test_shape2d_contour_features()
+{
+	std::vector<std::vector<double>> fvals;
+	calculate_shape2d_feature_values(fvals);
+
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::PERIMETER, "PERIMETER");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::DIAMETER_EQUAL_PERIMETER, "DIAMETER_EQUAL_PERIMETER");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EDGE_MEAN_INTENSITY, "EDGE_MEAN_INTENSITY");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EDGE_STDDEV_INTENSITY, "EDGE_STDDEV_INTENSITY");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EDGE_MAX_INTENSITY, "EDGE_MAX_INTENSITY");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EDGE_MIN_INTENSITY, "EDGE_MIN_INTENSITY");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EDGE_INTEGRATED_INTENSITY, "EDGE_INTEGRATED_INTENSITY");
+}
+
+void test_shape2d_convex_hull_features()
+{
+	std::vector<std::vector<double>> fvals;
+	calculate_shape2d_feature_values(fvals);
+
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::CIRCULARITY, "CIRCULARITY");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::CONVEX_HULL_AREA, "CONVEX_HULL_AREA");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::SOLIDITY, "SOLIDITY");
+}
+
+void test_shape2d_extrema_features()
+{
+	std::vector<std::vector<double>> fvals;
+	calculate_shape2d_feature_values(fvals);
+
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P1_X, "EXTREMA_P1_X");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P1_Y, "EXTREMA_P1_Y");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P2_X, "EXTREMA_P2_X");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P2_Y, "EXTREMA_P2_Y");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P3_X, "EXTREMA_P3_X");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P3_Y, "EXTREMA_P3_Y");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P4_X, "EXTREMA_P4_X");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P4_Y, "EXTREMA_P4_Y");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P5_X, "EXTREMA_P5_X");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P5_Y, "EXTREMA_P5_Y");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P6_X, "EXTREMA_P6_X");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P6_Y, "EXTREMA_P6_Y");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P7_X, "EXTREMA_P7_X");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P7_Y, "EXTREMA_P7_Y");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P8_X, "EXTREMA_P8_X");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTREMA_P8_Y, "EXTREMA_P8_Y");
+}
+
+void test_shape2d_misc_shape_features()
+{
+	std::vector<std::vector<double>> fvals;
+	calculate_shape2d_feature_values(fvals);
+
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EULER_NUMBER, "EULER_NUMBER");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::FRACT_DIM_BOXCOUNT, "FRACT_DIM_BOXCOUNT");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::FRACT_DIM_PERIMETER, "FRACT_DIM_PERIMETER");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::DIAMETER_MIN_ENCLOSING_CIRCLE, "DIAMETER_MIN_ENCLOSING_CIRCLE");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::DIAMETER_CIRCUMSCRIBING_CIRCLE, "DIAMETER_CIRCUMSCRIBING_CIRCLE");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::DIAMETER_INSCRIBING_CIRCLE, "DIAMETER_INSCRIBING_CIRCLE");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::ROI_RADIUS_MEAN, "ROI_RADIUS_MEAN");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::ROI_RADIUS_MAX, "ROI_RADIUS_MAX");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::ROI_RADIUS_MEDIAN, "ROI_RADIUS_MEDIAN");
+}


### PR DESCRIPTION
Here are the cross verification scripts and their output logs : [2d_shape and 2d_neighbors touch](https://github.com/vjaganat90/external-verif-nyxus/compare/main...morphology_touch_tests)