### PR TITLE
ci(windows): fix prereq build on new windows-latest (VS2026 / CMake 4)

### DIFF
--- a/ci-utils/install_prereq_win.bat
+++ b/ci-utils/install_prereq_win.bat
@@ -20,12 +20,17 @@ SETLOCAL DisableDelayedExpansion
 mkdir local_install
 mkdir local_install\include
 
+rem Absolute install prefix (forward slashes, no quotes/spaces) for find_package().
+rem Relative -DCMAKE_PREFIX_PATH=../../local_install is NOT reliably honored by
+rem find_package() config search on newer CMake, so use an absolute path.
+set "ABS_INSTALL=%CD:\=/%/local_install"
+
 curl -L https://github.com/pybind/pybind11/archive/refs/tags/v2.12.0.zip -o v2.12.0.zip
 tar -xvf v2.12.0.zip
 pushd pybind11-2.12.0
 mkdir build_man
 pushd build_man
-cmake -DCMAKE_INSTALL_PREFIX=../../local_install/  -DPYBIND11_TEST=OFF ..
+cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX=../../local_install/  -DPYBIND11_TEST=OFF ..
 cmake --build . --config Release --target install  
 popd
 popd
@@ -35,7 +40,7 @@ tar -xvf zlib131.zip
 pushd zlib-1.3.1
 mkdir build_man
 pushd build_man
-cmake -DCMAKE_INSTALL_PREFIX=../../local_install/ ..  
+cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX=../../local_install/ ..  
 cmake --build . --config Release --target install --parallel 4  
 popd
 popd
@@ -61,7 +66,7 @@ if "%BUILD_Z5_DEP%" == "1" (
     pushd c-blosc-1.21.6
     mkdir build_man
     pushd build_man
-    cmake -DCMAKE_INSTALL_PREFIX=../../local_install/ ..   
+    cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX=../../local_install/ ..   
     cmake --build . --config Release --target install  --parallel 4
     popd
     popd
@@ -71,7 +76,7 @@ if "%BUILD_Z5_DEP%" == "1" (
     pushd xtl-0.8.0 
     mkdir build_man
     pushd build_man
-    cmake -DCMAKE_INSTALL_PREFIX=../../local_install/ ..  
+    cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX=../../local_install/ ..  
     cmake --build . --config Release --target install 
     popd
     popd
@@ -81,7 +86,7 @@ if "%BUILD_Z5_DEP%" == "1" (
     pushd xtensor-0.26.0
     mkdir build_man
     pushd build_man
-    cmake -DCMAKE_INSTALL_PREFIX=../../local_install/ ..  
+    cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX=../../local_install/ ..  
     cmake --build . --config Release --target install 
     popd
     popd
@@ -91,7 +96,7 @@ if "%BUILD_Z5_DEP%" == "1" (
     pushd xsimd-13.2.0 
     mkdir build_man
     pushd build_man
-    cmake -DCMAKE_INSTALL_PREFIX=../../local_install/ ..  
+    cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX=../../local_install/ ..  
     cmake --build . --config Release --target install  
     popd
     popd
@@ -101,7 +106,7 @@ if "%BUILD_Z5_DEP%" == "1" (
     pushd json-3.11.2
     mkdir build_man
     pushd build_man
-    cmake -DCMAKE_INSTALL_PREFIX=../../local_install/ -DJSON_BuildTests=OFF ..  
+    cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX=../../local_install/ -DJSON_BuildTests=OFF ..  
     cmake --build . --config Release --target install  --parallel 4
     popd
     popd
@@ -111,7 +116,7 @@ if "%BUILD_Z5_DEP%" == "1" (
     pushd z5-2.0.20
     mkdir build_man
     pushd build_man
-    cmake -DCMAKE_INSTALL_PREFIX=../../local_install/   -DCMAKE_PREFIX_PATH=../../local_install/ -DWITH_BLOSC=ON -DBUILD_Z5PY=OFF ..
+    cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX=../../local_install/   -DCMAKE_PREFIX_PATH=%ABS_INSTALL% -DWITH_BLOSC=ON -DBUILD_Z5PY=OFF ..
     cmake --build . --config Release --target install  --parallel 4
     popd
     popd
@@ -127,7 +132,7 @@ if "%BUILD_ARROW%" == "1" (
     pushd cpp
     mkdir build
     pushd build
-    cmake .. -A x64 -DCMAKE_INSTALL_PREFIX=../../../local_install/ -DCMAKE_PREFIX_PATH=../../../local_install/ -DARROW_PARQUET=ON -DARROW_WITH_SNAPPY=ON -DARROW_BUILD_TESTS=OFF -DBOOST_ROOT=%_ROOTDIR%/boost_1_88_0
+    cmake .. -A x64 -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX=../../../local_install/ -DCMAKE_PREFIX_PATH=%ABS_INSTALL% -DARROW_PARQUET=ON -DARROW_WITH_SNAPPY=ON -DARROW_BUILD_TESTS=OFF -DBOOST_ROOT=%_ROOTDIR%/boost_1_88_0
     cmake --build . --config Release --target install --parallel 4
     popd 
     popd
@@ -142,7 +147,7 @@ if "%BUILD_DCMTK_DEP%" == "1" (
     pushd libpng-1.6.53
     mkdir build_man
     pushd build_man
-    cmake -DCMAKE_INSTALL_PREFIX=../../local_install/   -DCMAKE_PREFIX_PATH=../../local_install/   ..
+    cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX=../../local_install/   -DCMAKE_PREFIX_PATH=%ABS_INSTALL%   ..
     cmake --build . --config Release --target install --parallel 4
     popd
     popd
@@ -152,7 +157,7 @@ if "%BUILD_DCMTK_DEP%" == "1" (
     pushd openjpeg-2.5.0
     mkdir build_man
     pushd build_man
-    cmake -DCMAKE_INSTALL_PREFIX=../../local_install/   -DCMAKE_PREFIX_PATH=../../local_install/  -DBUILD_CODEC=OFF  ..
+    cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX=../../local_install/   -DCMAKE_PREFIX_PATH=%ABS_INSTALL%  -DBUILD_CODEC=OFF  ..
     cmake --build . --config Release --target install --parallel 4
     popd
     popd
@@ -163,7 +168,7 @@ tar -xf v1.19.zip
 pushd libdeflate-1.19
 mkdir build_man
 pushd build_man
-cmake -DCMAKE_INSTALL_PREFIX=../../local_install/   -DCMAKE_PREFIX_PATH=../../local_install/  ..
+cmake -DCMAKE_INSTALL_PREFIX=../../local_install/   -DCMAKE_PREFIX_PATH=%ABS_INSTALL%  ..
 cmake --build . --config Release --target install --parallel 4
 popd
 popd
@@ -173,7 +178,7 @@ tar -xf 3.1.0.zip
 pushd libjpeg-turbo-3.1.0
 mkdir build_man
 pushd build_man
-cmake -DCMAKE_INSTALL_PREFIX=../../local_install/   -DCMAKE_PREFIX_PATH=../../local_install/  ..
+cmake -DCMAKE_INSTALL_PREFIX=../../local_install/   -DCMAKE_PREFIX_PATH=%ABS_INSTALL%  ..
 cmake --build . --config Release --target install --parallel 4
 popd
 popd
@@ -189,7 +194,7 @@ tar -xf tiff-4.7.0.zip
 pushd tiff-4.7.0
 mkdir build_man
 pushd build_man
-cmake -DCMAKE_INSTALL_PREFIX=../../local_install/   -DCMAKE_PREFIX_PATH=../../local_install/  ..
+cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX=../../local_install/   -DCMAKE_PREFIX_PATH=%ABS_INSTALL%  ..
 cmake --build . --config Release --target install
 popd
 popd
@@ -205,7 +210,7 @@ if "%BUILD_DCMTK_DEP%" == "1" (
     pushd dcmtk-DCMTK-3.6.9
     mkdir build_man
     pushd build_man
-    cmake -DCMAKE_INSTALL_PREFIX=../../local_install/ -DCMAKE_PREFIX_PATH=../../local_install/ -DBUILD_SHARED_LIBS=ON -DDCMTK_WITH_ICONV=OFF -DDCMTK_WITH_TIFF=ON -DWITH_LIBTIFFINC=../../local_install -DDCMTK_WITH_PNG=ON -DWITH_LIBPNGINC=../../local_install -DDCMTK_WITH_ZLIB=ON -DWITH_ZLIBINC=../../local_install -DDCMTK_WITH_OPENJPEG=ON -DWITH_OPENJPEGINC=../../local_install  -DBUILD_APPS=OFF ..
+    cmake -DCMAKE_INSTALL_PREFIX=../../local_install/ -DCMAKE_PREFIX_PATH=%ABS_INSTALL% -DBUILD_SHARED_LIBS=ON -DDCMTK_WITH_ICONV=OFF -DDCMTK_WITH_TIFF=ON -DWITH_LIBTIFFINC=../../local_install -DDCMTK_WITH_PNG=ON -DWITH_LIBPNGINC=../../local_install -DDCMTK_WITH_ZLIB=ON -DWITH_ZLIBINC=../../local_install -DDCMTK_WITH_OPENJPEG=ON -DWITH_OPENJPEGINC=../../local_install  -DBUILD_APPS=OFF ..
     cmake --build . --config Release --target install --parallel 4
     popd
     popd
@@ -215,7 +220,7 @@ if "%BUILD_DCMTK_DEP%" == "1" (
     pushd fmjpeg2koj-fix_cmake
     mkdir build_man
     pushd build_man
-    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_CXX_FLAGS_RELEASE="/MT /O2 /D NDEBUG /Zc:__cplusplus" -DCMAKE_INSTALL_PREFIX=../../local_install/   -DCMAKE_PREFIX_PATH=../../local_install/  -DFMJPEG2K=%ROOTDIR%\local_install\  ..
+    cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_CXX_FLAGS_RELEASE="/MT /O2 /D NDEBUG /Zc:__cplusplus" -DCMAKE_INSTALL_PREFIX=../../local_install/   -DCMAKE_PREFIX_PATH=%ABS_INSTALL%  -DFMJPEG2K=%ROOTDIR%\local_install\  ..
     cmake --build . --config Release --target install --parallel 4
     popd
     popd


### PR DESCRIPTION
1. find_package() could not locate DCMTK/OpenJPEG configs even though the libs installed fine (DCMTK builds against openjpeg). Cause: relative -DCMAKE_PREFIX_PATH=../../local_install is not honored by config-mode find_package() on CMake 4.x (verified locally on cmake 4.2.1: relative prefix fails to find an installed package config, absolute succeeds). Use an absolute ABS_INSTALL path for all -DCMAKE_PREFIX_PATH values.

2. Mirror install_prereq_linux.sh: add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to older dependency configures (CMake 4 dropped < 3.5 compatibility), so the independently built z5/Arrow stack does not fail silently.