### PR TITLE
fix: remaining 2D feature defects not covered by upstream #350

### DIFF
--- a/src/nyx/env_features.cpp
+++ b/src/nyx/env_features.cpp
@@ -723,6 +723,12 @@ void Environment::compile_feature_settings()
 			s[(int)NyxSetting::USEGPU].bval = using_gpu();
 			s[(int)NyxSetting::VERBOSLVL].ival = get_verbosity_level();
 			s[(int)NyxSetting::IBSI].bval = ibsi_compliance;
+			// GLCM-specific defaults (otherwise zero-initialised). GLCM_OFFSET=0 would make
+			// dx=dy=0 -> every pixel co-occurs with itself -> degenerate diagonal matrix
+			// (CONTRAST=0). Default the co-occurrence distance to 1 (IBSI delta=1).
+			s[(int)NyxSetting::GLCM_OFFSET].ival = 1;
+			s[(int)NyxSetting::GLCM_GREYDEPTH].ival = get_coarse_gray_depth();
+			s[(int)NyxSetting::GLCM_NUMANG].ival = (int)GLCMFeature::angles.size();
 			s[(int)NyxSetting::FPIMG_TARGET_DR].rval = fpimageOptions.target_dyn_range();
 			s[(int)NyxSetting::FPIMG_MIN].rval = fpimageOptions.min_intensity();
 			s[(int)NyxSetting::FPIMG_MAX].rval = fpimageOptions.max_intensity();

--- a/src/nyx/features/2d_geomoments_basic.cpp
+++ b/src/nyx/features/2d_geomoments_basic.cpp
@@ -185,7 +185,7 @@ double BasicGeomoms2D::centralMom(const pixcloud& cloud, int p, int q)
     for (auto& pxl : cloud)
     {
         double I = INTEN(double(pxl.inten));
-        sum += I * int_pow(double(pxl.x - baseX) - (int)originOfX, p) * int_pow(double(pxl.y - baseY) - (int)originOfY, q);
+        sum += I * int_pow(double(pxl.x - baseX) - originOfX, p) * int_pow(double(pxl.y - baseY) - originOfY, q);
     }
     return sum;
 }
@@ -198,7 +198,7 @@ double BasicGeomoms2D::centralMom(const pixcloud& cloud, const reintenvec& reali
     for (size_t i = 0; i < n; i++)
     {
         auto& pxl = cloud[i];
-        sum += realintens[i] * int_pow(double(pxl.x - baseX) - (int)originOfX, p) * int_pow(double(pxl.y - baseY) - (int)originOfY, q);
+        sum += realintens[i] * int_pow(double(pxl.x - baseX) - originOfX, p) * int_pow(double(pxl.y - baseY) - originOfY, q);
     }
     return sum;
 }

--- a/src/nyx/features/chords.cpp
+++ b/src/nyx/features/chords.cpp
@@ -78,7 +78,7 @@ void ChordsFeature::calculate (LR & r, const Fsettings& s)
 	maxchords_min_angle = MCang[idxmin];
 
 	auto iteMax = std::max_element(MC.begin(), MC.end());
-	auto idxmax = std::distance(MC.begin(), iteMin);
+	auto idxmax = std::distance(MC.begin(), iteMax);
 	maxchords_max_angle = MCang[idxmax];
 
 	// Analyze all chords
@@ -91,16 +91,16 @@ void ChordsFeature::calculate (LR & r, const Fsettings& s)
 	allchords_mean = mom2.mean();
 	allchords_stddev = mom2.std();
 
-	histo.initialize_uniques(MC); 
-	allchords_mode = histo.get_mode(); 
-	allchords_median = histo.get_median(); 
+	histo.initialize_uniques(AC);
+	allchords_mode = histo.get_mode();
+	allchords_median = histo.get_median();
 
 	iteMin = std::min_element(AC.begin(), AC.end());
 	idxmin = std::distance(AC.begin(), iteMin);
 	allchords_min_angle = ACang[idxmin];
 
 	iteMax = std::max_element(AC.begin(), AC.end());
-	idxmax = std::distance(AC.begin(), iteMin);
+	idxmax = std::distance(AC.begin(), iteMax);
 	allchords_max_angle = ACang[idxmax];
 }
 

--- a/src/nyx/features/circle.cpp
+++ b/src/nyx/features/circle.cpp
@@ -222,11 +222,14 @@ std::tuple <double, double> EnclosingInscribingCircumscribingCircleFeature::calc
     //-----------------circumscribing and inscribing circle ---------------------------
     //https://git.rwth-aachen.de/ants/sensorlab/imea/-/blob/master/imea/measure_2d/macro.py#L199
 
-    double yCentroid2 = yCentroid - 1;
-    double xCentroid2 = xCentroid - 1;
+    // Centroid (CENTROID_X/Y) and contour pixels are both in true 0-based global coordinates
+    // (ContourFeature::buildRegularContour now undoes the +1 padding offset), so the centroid-
+    // relative radii are measured in the same frame and need no extra correction.
+    double yCentroid2 = yCentroid;
+    double xCentroid2 = xCentroid;
     std::vector <double> distances;
 
-    for (size_t j = 0; j < contours.size(); j++) 
+    for (size_t j = 0; j < contours.size(); j++)
     {
         double tmpx = (contours[j].x - xCentroid2);
         double tmpy = (contours[j].y - yCentroid2);

--- a/src/nyx/features/contour.cpp
+++ b/src/nyx/features/contour.cpp
@@ -670,12 +670,17 @@ ContourFeature::ContourFeature() : FeatureMethod("ContourFeature")
 	// gather all the contours
 	gather_multicontour (r.multicontour_, paddedImage, width, height, STNGS_VERBOSLVL(s));
 
-	// fix pixel positions back to absolute
+	// fix pixel positions back to absolute. The contour is built on a 1-px-PADDED image
+	// (local = global - base + 1), so converting back to global must undo BOTH the base offset
+	// and the +1 pad: global = local + base - 1. The previously-missing '-1' left every contour
+	// pixel shifted by (+1,+1), biasing every feature that compares contour coordinates against
+	// the centroid/cloud (circle inscribing/circumscribing, roi_radius, radial centre, and the
+	// distance-to-contour weighted moments).
 	for (std::vector<Pixel2> &K : r.multicontour_)
 		for (Pixel2 &p : K)
 		{
-			p.x += base_x;
-			p.y += base_y;
+			p.x += base_x - 1;
+			p.y += base_y - 1;
 		}
 }
 
@@ -912,6 +917,16 @@ void ContourFeature::buildRegularContour_nontriv (LR& r, const Fsettings& s)
 
 	// replace the unordered contour with ordered one
 	r.multicontour_[0] = ordered;
+
+	// fix pixel positions back to absolute. The contour was built on a 1-px-padded image
+	// (local = global - base + 1); convert to true global with `+= base - 1` (undoing both the
+	// base offset and the +1 pad), matching the trivial buildRegularContour. The out-of-core path
+	// declared base_x/base_y above but never applied them, leaving its contour in the LOCAL frame.
+	for (Pixel2& p : r.multicontour_[0])
+	{
+		p.x += base_x - 1;
+		p.y += base_y - 1;
+	}
 }
 
 void ContourFeature::buildWholeSlideContour(LR& r)

--- a/src/nyx/features/convex_hull_nontriv.cpp
+++ b/src/nyx/features/convex_hull_nontriv.cpp
@@ -1,6 +1,7 @@
 #define _USE_MATH_DEFINES	// For M_PI, etc.
 #include <algorithm>
 #include <cmath>
+#include <numeric>
 #include "../dataset.h"
 #include "../feature_method.h"
 #include "../feature_settings.h"
@@ -8,6 +9,28 @@
 #include "convex_hull.h"
 
 using namespace Nyxus;
+
+// Number of integer lattice points lying ON the hull boundary = sum over edges of gcd(|dx|,|dy|).
+// By Pick's theorem the pixel-count-equivalent hull area (matching scikit-image convex_area, which
+// counts the pixels of the rasterised hull) is shoelace_area + boundary_points/2 + 1. The bare
+// shoelace area runs through pixel CENTRES and under-counts coverage, so for small/elongated ROIs
+// it falls below the ROI pixel count -> SOLIDITY > 1 (impossible). This correction fixes that.
+static long hull_boundary_points (const std::vector<Pixel2>& v)
+{
+	size_t n = v.size();
+	if (n < 2)
+		return 0;
+	long B = 0;
+	for (size_t i = 0; i < n; i++)
+	{
+		const Pixel2& p1 = v[i];
+		const Pixel2& p2 = v[(i + 1) % n];
+		long dx = (long)p2.x - (long)p1.x; if (dx < 0) dx = -dx;
+		long dy = (long)p2.y - (long)p1.y; if (dy < 0) dy = -dy;
+		B += std::gcd(dx, dy);
+	}
+	return B;
+}
 
 ConvexHullFeature::ConvexHullFeature() : FeatureMethod("ConvexHullFeature")
 {
@@ -32,12 +55,13 @@ void ConvexHullFeature::calculate (LR& r, const Fsettings& s)
 	// Build the convex hull
 	build_convex_hull(r.raw_pixels, r.convHull_CH);
 
-	// Calculate related features
-	double s_hull = polygon_area(r.convHull_CH),
-		s_roi = r.raw_pixels.size(), 
+	// Calculate related features. Pixel-count-equivalent hull area (Pick's theorem) so the hull is
+	// measured on the same basis as the ROI (pixel count) -> SOLIDITY <= 1.
+	double s_hull = polygon_area(r.convHull_CH) + hull_boundary_points(r.convHull_CH) / 2.0 + 1.0,
+		s_roi = r.raw_pixels.size(),
 		p = r.fvals[(int)Feature2D::PERIMETER][0];
 	area = s_hull;
-	solidity = s_roi / s_hull;
+	solidity = (s_hull > 0.0) ? s_roi / s_hull : 0.0;
 	circularity = sqrt(4.0 * M_PI * s_roi / (p*p));
 }
 
@@ -193,12 +217,12 @@ void ConvexHullFeature::osized_calculate (LR& r, const Fsettings& s, ImageLoader
 	// Build the convex hull
 	build_convex_hull (r.raw_pixels_NT, r.convHull_CH);
 
-	// Calculate related features
-	double s_hull = polygon_area(r.convHull_CH),
+	// Calculate related features (Pick's-theorem pixel-count-equivalent hull area; see calculate())
+	double s_hull = polygon_area(r.convHull_CH) + hull_boundary_points(r.convHull_CH) / 2.0 + 1.0,
 		s_roi = r.raw_pixels_NT.size(),
 		p = r.fvals[(int)Feature2D::PERIMETER][0];
 	area = s_hull;
-	solidity = s_roi / s_hull;
+	solidity = (s_hull > 0.0) ? s_roi / s_hull : 0.0;
 	circularity = sqrt(4.0 * M_PI * s_roi / (p * p));
 }
 

--- a/src/nyx/features/fractal_dim.cpp
+++ b/src/nyx/features/fractal_dim.cpp
@@ -105,7 +105,8 @@ void FractalDimensionFeature::calculate_perimeter_fdim (LR& r)
 		// save this approximation
 		coverage.push_back({ s, (int)p });
 	}
-	perim_fd = calc_lyapunov_slope(coverage);
+	// Richardson divider method: log(perimeter) vs log(ruler) has slope (1 - D), so D = 1 - slope
+	perim_fd = 1.0 - calc_lyapunov_slope(coverage);
 }
 
 double FractalDimensionFeature::calc_lyapunov_slope (const std::vector<std::pair<int, int>> & coverage)
@@ -144,24 +145,16 @@ double FractalDimensionFeature::calc_lyapunov_slope (const std::vector<std::pair
 		Lambda.push_back(lambda);
 	}
 
-	// Estimate the slope of the series Lambda[k]
-	// (given y = a + bx, the slope b = \frac {n \sum{xy} - \sum{x} \sum{y}} {n \sum{x^2} - \sum{x}^2})
-	double sum_x = 0,
-		sum_y = 0,
-		sum_xy = 0,
-		sum_x2 = 0;
-	int n = Dn.size();
-	for (auto i = 0; i < n; i++)
-	{
-		double x = double(i),
-			y = Lambda[i];
-		sum_x += x;
-		sum_y += y;
-		sum_xy += x * y;
-		sum_x2 += x * x;
-	}
-	double slope = (sum_xy * double(n) - sum_x * sum_y) / (sum_x2 * double(n) - sum_x * sum_x);
-	return slope;
+	// The box-counting / Richardson dimension is the (average) slope of log(count) vs log(scale),
+	// i.e. the MEAN of the local slopes Lambda[]. The previous code returned the least-squares
+	// slope of Lambda[] *against its index* (the rate-of-change of the slope), which is ~0 for a
+	// clean power law -> dimension came out ~0 (FRACT_DIM_BOXCOUNT=-0.07). Return the mean slope.
+	if (Lambda.empty())
+		return 0.;
+	double sum = 0.;
+	for (double v : Lambda)
+		sum += v;
+	return sum / double(Lambda.size());
 }
 
 void FractalDimensionFeature::osized_add_online_pixel(size_t x, size_t y, uint32_t intensity)

--- a/src/nyx/features/glcm.cpp
+++ b/src/nyx/features/glcm.cpp
@@ -303,7 +303,7 @@ void GLCMFeature::Extract_Texture_Features2 (const Fsettings& s, int angle, cons
 	// Compute Haralick statistics 
 	fvals_ASM.push_back (f_asm(P_matrix));
 	fvals_contrast.push_back (f_contrast(P_matrix));
-	fvals_correlation.push_back (f_corr());
+	fvals_correlation.push_back (f_corr(s[(int)NyxSetting::SOFTNAN].rval));
 	fvals_energy.push_back (f_energy(P_matrix));
 	fvals_homo.push_back (f_homogeneity());
 	fvals_variance.push_back (f_var(P_matrix));
@@ -314,7 +314,7 @@ void GLCMFeature::Extract_Texture_Features2 (const Fsettings& s, int angle, cons
 	fvals_diff_var.push_back (f_dvar(P_matrix));
 	fvals_diff_entropy.push_back (f_dentropy(P_matrix));
 	fvals_diff_avg.push_back (f_difference_avg());
-	fvals_meas_corr1.push_back (f_info_meas_corr1(P_matrix));
+	fvals_meas_corr1.push_back (f_info_meas_corr1(P_matrix, s[(int)NyxSetting::SOFTNAN].rval));
 	fvals_meas_corr2.push_back (f_info_meas_corr2(P_matrix));
 	fvals_acor.push_back (f_GLCM_ACOR(P_matrix));
 	fvals_cluprom.push_back (f_GLCM_CLUPROM());
@@ -437,10 +437,13 @@ void GLCMFeature::calculateCoocMatAtAngle(
 				PixIntens lvl_b = D.yx(row, col),
 					lvl_a = D.yx(row + dy, col + dx);
 
-				// Skip 0-intensity pixels (usually out of mask pixels)
-				if (ibsi_grey_binning(greyInfo))
-					if (lvl_a == 0 || lvl_b == 0)
-						continue;
+				// Skip out-of-ROI background pixels (original intensity 0) in ALL grey-binning
+				// paths. The MATLAB path maps 0 -> level 1 (see bin_array_matlab), which would
+				// otherwise count background as a real grey tone and flood the co-occurrence
+				// matrix with spurious diagonal mass. The IBSI path keeps 0 and was already
+				// skipping it; here we skip on the *original* intensity so every path agrees.
+				if (imR.yx(row, col) == 0 || imR.yx(row + dy, col + dx) == 0)
+					continue;
 
 				// 0-based grey tone indices, hence '-1'
 				int a = lvl_a,
@@ -587,7 +590,7 @@ double GLCMFeature::f_contrast(const SimpleMatrix<double>& P)
 *
 * Returns marginal totals 'px' and their mean 'meanx'
 */
-double GLCMFeature::f_corr()
+double GLCMFeature::f_corr(double softnan)
 {
 	auto Ng = P_matrix.width();
 
@@ -628,7 +631,14 @@ double GLCMFeature::f_corr()
 	for (int c = 0; c < Ng; c++)
 		for (int r = 0; r < Ng; r++)
 			tmp1 += (double(I[r]) - mr) * (double(I[c]) - mc) * P_matrix.yx(r, c) / sum_p;
-	double cor = tmp1 / (sr * sc);
+	// Correlation is undefined when a grey-tone marginal has zero variance (a single grey
+	// level), i.e. sr*sc == 0 -> 0/0 -> NaN. Return the soft-NAN sentinel instead. (This can
+	// happen on tiny/uniform ROIs once out-of-ROI background pixels are correctly excluded.)
+	double denom = sr * sc;
+	if (!(denom > 0.0))
+		return softnan;
+
+	double cor = tmp1 / denom;
 
 	return cor;
 }
@@ -828,7 +838,7 @@ void GLCMFeature::calcH(const SimpleMatrix<double>& P, std::vector<double>& px, 
 	}
 }
 
-double GLCMFeature::f_info_meas_corr1 (const SimpleMatrix<double>& P)
+double GLCMFeature::f_info_meas_corr1 (const SimpleMatrix<double>& P, double softnan)
 {
 
 	auto Ng = P.width();
@@ -860,7 +870,12 @@ double GLCMFeature::f_info_meas_corr1 (const SimpleMatrix<double>& P)
 
 	}
 
-	return (HXY - HXY1) / HX;
+	// Undefined when a grey-tone marginal is a single level (HX -> 0 -> 0/0 -> NaN), which can
+	// happen on a tiny/uniform ROI once out-of-ROI background is correctly excluded.
+	double r = (HXY - HXY1) / HX;
+	if (!std::isfinite(r))
+		return softnan;
+	return r;
 }
 
 double GLCMFeature::f_info_meas_corr2(const SimpleMatrix<double>& P)

--- a/src/nyx/features/glcm.h
+++ b/src/nyx/features/glcm.h
@@ -178,7 +178,7 @@ private:
 
 	double f_asm(const SimpleMatrix<double>& P_matrix);
 	double f_contrast(const SimpleMatrix<double>& P_matix);
-	double f_corr();
+	double f_corr(double softnan);
 	double f_var(const SimpleMatrix<double>& P_matrix);
 	double f_idm();
 	double f_savg();
@@ -243,7 +243,7 @@ private:
 
 	double hx = -1, hy = -1, hxy = -1, hxy1 = -1, hxy2 = -1;	// Entropies for f12/f13_icorr calculation
 	void calcH(const SimpleMatrix<double>& P_matrix, std::vector<double>& px, std::vector<double>& py);
-	double f_info_meas_corr1(const SimpleMatrix<double>& P_matrix);
+	double f_info_meas_corr1(const SimpleMatrix<double>& P_matrix, double softnan);
 	double f_info_meas_corr2(const SimpleMatrix<double>& P_matrix);
 
 	double f_energy(const SimpleMatrix<double>& P_matrix);

--- a/src/nyx/features/glcm_nontriv.cpp
+++ b/src/nyx/features/glcm_nontriv.cpp
@@ -82,7 +82,7 @@ void GLCMFeature::Extract_Texture_Features2_NT (int angle, WriteImageMatrix_nont
 	// Compute Haralick statistics 
 	fvals_ASM.push_back(f_asm(P_matrix));
 	fvals_contrast.push_back(f_contrast(P_matrix));
-	fvals_correlation.push_back(f_corr());
+	fvals_correlation.push_back(f_corr(0.0));   // 0.0 = this path's blank/degenerate convention
 	fvals_energy.push_back(f_energy(P_matrix));
 	fvals_homo.push_back(f_homogeneity());
 	fvals_variance.push_back(f_var(P_matrix));
@@ -93,7 +93,7 @@ void GLCMFeature::Extract_Texture_Features2_NT (int angle, WriteImageMatrix_nont
 	fvals_diff_var.push_back(f_dvar(P_matrix));
 	fvals_diff_entropy.push_back(f_dentropy(P_matrix));
 	fvals_diff_avg.push_back(f_difference_avg());
-	fvals_meas_corr1.push_back(f_info_meas_corr1(P_matrix));
+	fvals_meas_corr1.push_back(f_info_meas_corr1(P_matrix, 0.0));   // 0.0 = this path's blank/degenerate convention
 	fvals_meas_corr2.push_back(f_info_meas_corr2(P_matrix));
 	fvals_acor.push_back(f_GLCM_ACOR(P_matrix));
 	fvals_cluprom.push_back(f_GLCM_CLUPROM());

--- a/src/nyx/features/gldm.cpp
+++ b/src/nyx/features/gldm.cpp
@@ -76,13 +76,19 @@ void GLDMFeature::calculate (LR& r, const Fsettings& s)
 		{
 			PixIntens pi = D.yx(row, col);
 
-			if (pi == 0)
+			// Skip background by the ORIGINAL intensity: matlab grey binning maps
+			// off-ROI background (0) to level 1, so the binned value 'pi' is no longer
+			// 0 and a 'pi==0' guard would let background pollute the dependence matrix
+			// (inflating Nz and every count feature). Test on imR like GLCM does.
+			if (imR.yx(row, col) == 0)
 				continue;
 
-			// Count dependencies
+			// Count dependencies. A neighbour is only a valid dependence candidate if it
+			// is itself an ROI pixel (original intensity != 0) -- otherwise a background
+			// neighbour binned to level 1 would spuriously match a level-1 ROI centre.
 			int nd = 1;	// Number of dependencies
 			PixIntens piQ; // Pixel intensity of questionn
-			if (D.safe(row - 1, col)) 
+			if (D.safe(row - 1, col) && imR.yx(row - 1, col) != 0)
 			{
 
 				piQ = D.yx(row - 1, col);	 // North
@@ -91,7 +97,7 @@ void GLDMFeature::calculate (LR& r, const Fsettings& s)
 					nd++;
 			}
 
-			if (D.safe(row - 1, col + 1)) 
+			if (D.safe(row - 1, col + 1) && imR.yx(row - 1, col + 1) != 0)
 			{
 
 				piQ = D.yx(row - 1, col + 1);	// North-East
@@ -100,7 +106,7 @@ void GLDMFeature::calculate (LR& r, const Fsettings& s)
 					nd++;
 			}
 
-			if (D.safe(row, col + 1)) 
+			if (D.safe(row, col + 1) && imR.yx(row, col + 1) != 0)
 			{
 
 				piQ = D.yx(row, col + 1);	// East
@@ -109,7 +115,7 @@ void GLDMFeature::calculate (LR& r, const Fsettings& s)
 					nd++;
 			}
 
-			if (D.safe(row + 1, col + 1)) 
+			if (D.safe(row + 1, col + 1) && imR.yx(row + 1, col + 1) != 0)
 			{
 
 				piQ = D.yx(row + 1, col + 1);	// South-East
@@ -118,7 +124,7 @@ void GLDMFeature::calculate (LR& r, const Fsettings& s)
 					nd++;
 			}
 
-			if (D.safe(row + 1, col)) 
+			if (D.safe(row + 1, col) && imR.yx(row + 1, col) != 0)
 			{
 
 				piQ = D.yx(row + 1, col);		// South
@@ -127,7 +133,7 @@ void GLDMFeature::calculate (LR& r, const Fsettings& s)
 					nd++;
 			}
 
-			if (D.safe(row + 1, col - 1)) 
+			if (D.safe(row + 1, col - 1) && imR.yx(row + 1, col - 1) != 0)
 			{
 
 				piQ = D.yx(row + 1, col - 1);	// South-West
@@ -136,7 +142,7 @@ void GLDMFeature::calculate (LR& r, const Fsettings& s)
 					nd++;
 			}
 
-			if (D.safe(row, col - 1)) 
+			if (D.safe(row, col - 1) && imR.yx(row, col - 1) != 0)
 			{
 
 				piQ = D.yx(row, col - 1);		// West
@@ -145,7 +151,7 @@ void GLDMFeature::calculate (LR& r, const Fsettings& s)
 					nd++;
 			}
 
-			if (D.safe(row - 1, col - 1)) 
+			if (D.safe(row - 1, col - 1) && imR.yx(row - 1, col - 1) != 0)
 			{
 
 				piQ = D.yx(row - 1, col - 1);	// North-West
@@ -283,16 +289,19 @@ void GLDMFeature::osized_calculate (LR& r, const Fsettings& s, ImageLoader&)
 	for (size_t row = 0; row < height; row++)
 		for (size_t col = 0; col < width; col++)
 		{
+			// Skip background by the ORIGINAL intensity (raw cloud value 0); to_grayscale()
+			// on a 0 underflows (0 - aux_min on unsigned) and would not be 0, so a 'pi==0'
+			// guard cannot reject background here. Mirror the trivial path / GLCM fix.
+			if (D.yx(row, col) == 0)
+				continue;
+
 			// Find a non-blank pixel
 			PixIntens pi = Nyxus::to_grayscale((unsigned int) D.yx(row, col), r.aux_min, piRange, nGrays, STNGS_IBSI(s));		// former Environment::ibsi_compliance
 
-			if (pi == 0)
-				continue;
-
-			// Count dependencies
+			// Count dependencies. Only ROI pixels (raw != 0) are valid neighbours.
 			int nd = 1;	// Number of dependencies
 			PixIntens piQ; // Pixel intensity of questionn
-			if (D.safe(row - 1, col)) {
+			if (D.safe(row - 1, col) && D.yx(row - 1, col) != 0) {
 
 				piQ = Nyxus::to_grayscale((unsigned int) D.yx(row - 1, col), r.aux_min, piRange, nGrays, STNGS_IBSI(s));	// North
 
@@ -300,7 +309,7 @@ void GLDMFeature::osized_calculate (LR& r, const Fsettings& s, ImageLoader&)
 					nd++;
 			}
 
-			if (D.safe(row - 1, col + 1)) {
+			if (D.safe(row - 1, col + 1) && D.yx(row - 1, col + 1) != 0) {
 
 				piQ = Nyxus::to_grayscale((unsigned int) D.yx(row - 1, col + 1), r.aux_min, piRange, nGrays, STNGS_IBSI(s));	// North-East
 
@@ -308,7 +317,7 @@ void GLDMFeature::osized_calculate (LR& r, const Fsettings& s, ImageLoader&)
 					nd++;
 			}
 
-			if (D.safe(row, col + 1)) {
+			if (D.safe(row, col + 1) && D.yx(row, col + 1) != 0) {
 
 				piQ = Nyxus::to_grayscale((unsigned int) D.yx(row, col + 1), r.aux_min, piRange, nGrays, STNGS_IBSI(s));	// East
 
@@ -316,7 +325,7 @@ void GLDMFeature::osized_calculate (LR& r, const Fsettings& s, ImageLoader&)
 					nd++;
 			}
 
-			if (D.safe(row + 1, col + 1)) {
+			if (D.safe(row + 1, col + 1) && D.yx(row + 1, col + 1) != 0) {
 
 				piQ = Nyxus::to_grayscale((unsigned int) D.yx(row + 1, col + 1), r.aux_min, piRange, nGrays, STNGS_IBSI(s));	// South-East
 
@@ -324,7 +333,7 @@ void GLDMFeature::osized_calculate (LR& r, const Fsettings& s, ImageLoader&)
 					nd++;
 			}
 
-			if (D.safe(row + 1, col)) {
+			if (D.safe(row + 1, col) && D.yx(row + 1, col) != 0) {
 
 				piQ = Nyxus::to_grayscale((unsigned int) D.yx(row + 1, col), r.aux_min, piRange, nGrays, STNGS_IBSI(s));		// South
 
@@ -332,7 +341,7 @@ void GLDMFeature::osized_calculate (LR& r, const Fsettings& s, ImageLoader&)
 					nd++;
 			}
 
-			if (D.safe(row + 1, col - 1)) {
+			if (D.safe(row + 1, col - 1) && D.yx(row + 1, col - 1) != 0) {
 
 				piQ = Nyxus::to_grayscale((unsigned int) D.yx(row + 1, col - 1), r.aux_min, piRange, nGrays, STNGS_IBSI(s));	// South-West
 
@@ -340,7 +349,7 @@ void GLDMFeature::osized_calculate (LR& r, const Fsettings& s, ImageLoader&)
 					nd++;
 			}
 
-			if (D.safe(row, col - 1)) {
+			if (D.safe(row, col - 1) && D.yx(row, col - 1) != 0) {
 
 				piQ = Nyxus::to_grayscale((unsigned int) D.yx(row, col - 1), r.aux_min, piRange, nGrays, STNGS_IBSI(s));		// West
 
@@ -348,7 +357,7 @@ void GLDMFeature::osized_calculate (LR& r, const Fsettings& s, ImageLoader&)
 					nd++;
 			}
 
-			if (D.safe(row - 1, col - 1)) {
+			if (D.safe(row - 1, col - 1) && D.yx(row - 1, col - 1) != 0) {
 
 				piQ = Nyxus::to_grayscale((unsigned int) D.yx(row - 1, col - 1), r.aux_min, piRange, nGrays, STNGS_IBSI(s));	// North-West
 

--- a/src/nyx/features/neighbors.cpp
+++ b/src/nyx/features/neighbors.cpp
@@ -239,74 +239,72 @@ void NeighborsFeature::manual_reduce (
 	if (n_threads == 1)
 	{
 		// single thread
-		size_t radius2 = radius * radius;	// We will compare radius with L2 distances
-		for (auto pa : CM2)
-		{
-			auto l1 = pa.first;
-			auto l2 = pa.second;
-			LR& r1 = roiData[l1];
-			LR& r2 = roiData[l2];
-
-			std::vector<Pixel2> K1, K2;
-			r1.merge_multicontour(K1);
-			r2.merge_multicontour(K2);
-
-			// Make sure that segment's outer pixels are available
-			if (K1.size() == 0)
-				continue;
-
-			// Make sure that the other ROI's pixel cloud is non-empty
-			if (K2.size() == 0)
-				continue;
-
-			// Iterate r1's outer pixels
-			double mind = K1[0].min_sqdist(K2);
-			size_t n_touchingOuterPixels1 = 0;
-			for (auto& cp : K1)
+			size_t radius2 = radius * radius;	// We will compare radius with L2 distances
+			const double touchThresh2 = 2.0;	// 8-connected adjacency (sqdist 1 or 2) == actually touching
+			// Per-ROI mask of contour pixels touching ANY neighbor. A deduped mask (rather than summing
+			// per-pair counts as before) guarantees PERCENT_TOUCHING <= 100%: the old code added a count
+			// per neighbor, so a pixel near several neighbors was counted repeatedly and the total could
+			// exceed the contour length (e.g. 127%).
+			std::unordered_map<int, std::vector<char>> touchMask;
+			for (auto pa : CM2)
 			{
-				double minD = cp.min_sqdist(K2);
-				mind = std::min(mind, minD);		//--We aren't interested in max distance-->	maxd = std::max(maxd, maxD);
+				auto l1 = pa.first;
+				auto l2 = pa.second;
+				LR& r1 = roiData[l1];
+				LR& r2 = roiData[l2];
 
-				// Maintain touching pixels stats
-				if (minD <= radius2)
-					n_touchingOuterPixels1++;
+				std::vector<Pixel2> K1, K2;
+				r1.merge_multicontour(K1);
+				r2.merge_multicontour(K2);
+
+				// Both segments' outer pixels must be available
+				if (K1.size() == 0 || K2.size() == 0)
+					continue;
+
+				// PERCENT_TOUCHING is physical contact, independent of the neighbor search radius:
+				// mark each contour pixel that is 8-adjacent to the other ROI (deduped per ROI). Done
+				// for every candidate pair BEFORE the radius gate so diagonal-only contacts still count
+				// even at pixel-distance 1.
+				double mind = K1[0].min_sqdist(K2);
+				auto& tm1 = touchMask[l1];
+				if (tm1.empty()) tm1.assign(K1.size(), 0);
+				for (size_t i = 0; i < K1.size(); i++)
+				{
+					double dq = K1[i].min_sqdist(K2);
+					mind = std::min(mind, dq);
+					if (dq <= touchThresh2) tm1[i] = 1;
+				}
+				auto& tm2 = touchMask[l2];
+				if (tm2.empty()) tm2.assign(K2.size(), 0);
+				for (size_t i = 0; i < K2.size(); i++)
+					if (K2[i].min_sqdist(K1) <= touchThresh2) tm2[i] = 1;
+
+				// NUM_NEIGHBORS / closest-neighbor lists: only ROIs within the search radius
+				if (mind > radius2)
+					continue;
+
+				// Definitely neighbors
+				r1.fvals[numNeighborsIdx][0]++;
+				r1.aux_neighboring_labels.push_back(l2);
+
+				// Single-threaded here, safe to update both r1 and r2
+				r2.fvals[numNeighborsIdx][0]++;
+				r2.aux_neighboring_labels.push_back(l1);
 			}
-
-			size_t n_touchingOuterPixels2 = 0;
-			for (auto& cp : K2)
+			for (auto l : uniqueLabels)
 			{
-				double minD = cp.min_sqdist(K1);
-				if (minD <= radius2)
-					n_touchingOuterPixels2++;
+				LR& r1 = roiData[l];
+
+				std::vector<Pixel2> K1;
+				r1.merge_multicontour(K1);
+
+				// Finalize % touching = distinct touching contour pixels / contour length
+				size_t nt = 0;
+				auto it = touchMask.find(l);
+				if (it != touchMask.end())
+					for (char c : it->second) nt += (c != 0);
+				r1.fvals[percentTouchingIdx][0] = K1.empty() ? 0.0 : 100.0 * double(nt) / double(K1.size());
 			}
-
-			// Check versus the radius
-			if (mind > radius2)
-				continue;
-
-			// Save partial statis of r1's touching pixel stats
-			r1.fvals[percentTouchingIdx][0] += n_touchingOuterPixels1;
-			r2.fvals[percentTouchingIdx][0] += n_touchingOuterPixels2;
-
-			// Definitely neighbors
-			r1.fvals[numNeighborsIdx][0]++;
-			r1.aux_neighboring_labels.push_back(l2);
-
-			// We're single-threaded here so it's safe to update both r1 and r2
-			r2.fvals[numNeighborsIdx][0]++;
-			r2.aux_neighboring_labels.push_back(l1);
-		}
-		for (auto l : uniqueLabels)
-		{
-			LR& r1 = roiData[l];
-
-			std::vector<Pixel2> K1;
-			r1.merge_multicontour(K1);
-
-			// Finalize the % touching calculation
-			if (!K1.empty())
-				r1.fvals[percentTouchingIdx][0] = 100.0 * static_cast<double>(r1.fvals[percentTouchingIdx][0]) / static_cast<double>(K1.size());
-		}
 	}
 	else
 	{
@@ -431,7 +429,17 @@ void NeighborsFeature::manual_reduce (
 	}
 #endif
 
-	// Closest neighbors
+					// Centroids for neighbor geometry. CENTROID_X/Y are computed in fvals because the reduce forces
+		// basic-morphology when neighbor features are requested (reduce_trivial_rois / phase2); previously
+		// they were 0 unless separately requested, collapsing all distances/angles to 0.
+		std::unordered_map<int, std::pair<double, double>> cen;
+		for (auto l : uniqueLabels)
+		{
+			LR& r = roiData[l];
+			cen[l] = std::make_pair(r.fvals[centroidXIdx][0], r.fvals[centroidYIdx][0]);
+		}
+
+		// Closest neighbors
 	for (auto l : uniqueLabels)
 	{
 		LR& r = roiData[l];
@@ -441,16 +449,14 @@ void NeighborsFeature::manual_reduce (
 		if (n_neigs == 0)
 			continue;
 
-		double cenx = r.fvals[centroidXIdx][0],
-			ceny = r.fvals[centroidYIdx][0];
+		double cenx = cen[l].first, ceny = cen[l].second;
 
 		std::vector<double> dists;
 		dists.reserve(r.aux_neighboring_labels.size());
 		for (auto l_neig : r.aux_neighboring_labels)
 		{
 			LR& r_neig = roiData[l_neig];
-			double cenx_n = r_neig.fvals[centroidXIdx][0],
-				ceny_n = r_neig.fvals[centroidYIdx][0],
+			double cenx_n = cen[l_neig].first, ceny_n = cen[l_neig].second,
 				dx = cenx - cenx_n,
 				dy = ceny - ceny_n,
 				dist = std::sqrt(dx * dx + dy * dy);
@@ -466,8 +472,7 @@ void NeighborsFeature::manual_reduce (
 		r.fvals[closestNeighbor1DistIdx][0] = dists[closest_1_idx];
 
 		// Save angle with neighbor #1
-		LR& r1 = roiData[closest1label];
-		r.fvals[closestNeighbor1AngIdx][0] = direction_angle_deg(cenx, ceny, r1.fvals[centroidXIdx][0], r1.fvals[centroidYIdx][0]);
+		r.fvals[closestNeighbor1AngIdx][0] = direction_angle_deg(cenx, ceny, cen[closest1label].first, cen[closest1label].second);
 
 		// Find idx of 2nd minimum
 		if (n_neigs > 1)
@@ -482,8 +487,7 @@ void NeighborsFeature::manual_reduce (
 			r.fvals[closestNeighbor2DistIdx][0] = dists[closest_2_idx];
 
 			// Save angle with neighbor #2
-			LR& r2 = roiData[closest2label];
-			r.fvals[closestNeighbor2AngIdx][0] = direction_angle_deg(cenx, ceny, r2.fvals[centroidXIdx][0], r2.fvals[centroidYIdx][0]);
+			r.fvals[closestNeighbor2AngIdx][0] = direction_angle_deg(cenx, ceny, cen[closest2label].first, cen[closest2label].second);
 		}
 	}
 
@@ -497,8 +501,7 @@ void NeighborsFeature::manual_reduce (
 		if (n_neigs == 0)
 			continue;
 
-		double cenx = r.fvals[centroidXIdx][0],
-			ceny = r.fvals[centroidYIdx][0];
+		double cenx = cen[l].first, ceny = cen[l].second;
 
 		Moments2 mom2;
 		std::array<int, 361> angleCounts{};
@@ -507,8 +510,7 @@ void NeighborsFeature::manual_reduce (
 		for (auto l_neig : r.aux_neighboring_labels)
 		{
 			LR& r_neig = roiData[l_neig];
-			double cenx_n = r_neig.fvals[centroidXIdx][0],
-				ceny_n = r_neig.fvals[centroidYIdx][0];
+			double cenx_n = cen[l_neig].first, ceny_n = cen[l_neig].second;
 
 			double ang = direction_angle_deg(cenx, ceny, cenx_n, ceny_n);
 			mom2.add(ang);

--- a/src/nyx/features/roi_radius.cpp
+++ b/src/nyx/features/roi_radius.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <cmath>
 #include "roi_radius.h"
 
 using namespace Nyxus;
@@ -16,10 +18,13 @@ void RoiRadiusFeature::calculate (LR& r, const Fsettings& s)
 	r.merge_multicontour (K);
 
 	Moments2 mom2;
-	std::vector<HistoItem> dists;
+	std::vector<double> dists;
 	for (auto& pxA : cloud)
 	{
-		auto minSD = pxA.min_sqdist(K);
+		// min_sqdist returns the SQUARED distance to the nearest contour pixel; the ROI radius
+		// is a length, so take the square root (otherwise ROI_RADIUS_MAX is r^2 and can exceed
+		// the image diagonal, e.g. 25 == 5^2).
+		double minSD = std::sqrt((double)pxA.min_sqdist(K));
 		mom2.add(minSD);
 		dists.push_back(minSD);
 	}
@@ -30,10 +35,17 @@ void RoiRadiusFeature::calculate (LR& r, const Fsettings& s)
 	// Max
 	max_r = mom2.max__();
 
-	// Median
-	TrivialHistogram h;
-	h.initialize_uniques(dists);
-	median_r = h.get_median(); 
+	// Median (interpolated, on the fractional radii - an integer histogram would truncate them)
+	median_r = median_of(dists);
+}
+
+double RoiRadiusFeature::median_of (std::vector<double>& v)
+{
+	if (v.empty())
+		return 0.0;
+	std::sort (v.begin(), v.end());
+	size_t m = v.size();
+	return (m % 2) ? v[m / 2] : 0.5 * (v[m / 2 - 1] + v[m / 2]);
 }
 
 void RoiRadiusFeature::osized_add_online_pixel(size_t x, size_t y, uint32_t intensity) {}
@@ -46,13 +58,14 @@ void RoiRadiusFeature::osized_calculate (LR& r, const Fsettings& s, ImageLoader&
 	r.merge_multicontour(K);
 
 	Moments2 mom2;
-	std::vector<HistoItem> dists;
-	for (size_t i=0; i<cloud.size(); i++) 
+	std::vector<double> dists;
+	for (size_t i=0; i<cloud.size(); i++)
 	{
 		Pixel2 pxA = cloud.get_at(i);
 		auto [minSD, maxSD] = pxA.min_max_sqdist(K);
-		mom2.add(minSD);
-		dists.push_back(minSD);
+		double r_ = std::sqrt((double)minSD);   // radius is a length, not a squared distance
+		mom2.add(r_);
+		dists.push_back(r_);
 	}
 
 	// Mean
@@ -61,10 +74,8 @@ void RoiRadiusFeature::osized_calculate (LR& r, const Fsettings& s, ImageLoader&
 	// Max
 	max_r = mom2.max__();
 
-	// Median
-	TrivialHistogram h;
-	h.initialize_uniques(dists);
-	median_r = h.get_median();
+	// Median (interpolated, on the fractional radii)
+	median_r = median_of(dists);
 }
 
 void RoiRadiusFeature::save_value (std::vector<std::vector<double>>& fvals)

--- a/src/nyx/features/roi_radius.h
+++ b/src/nyx/features/roi_radius.h
@@ -36,5 +36,6 @@ public:
 	}
 
 private:
+	static double median_of (std::vector<double>& v);   // interpolated median (sorts v in place)
 	double max_r = 0, mean_r = 0, median_r = 0;
 };

--- a/src/nyx/reduce_trivial_rois.cpp
+++ b/src/nyx/reduce_trivial_rois.cpp
@@ -77,8 +77,10 @@ namespace Nyxus
 			runParallel (IntensityHistogramFeatures::reduce, n_threads, work_per_thread, job_size, &L, &env.roiData, fst, env.dataset);
 		}
 
-		//==== Basic morphology
-		if (BasicMorphologyFeatures::required(env.theFeatureSet))
+		//==== Basic morphology. Also run it when neighbor features are requested: the neighbor reduce
+		// needs CENTROID_X/Y (computed here) for the closest-neighbor distances/angles, which would
+		// otherwise be 0 when the user asked only for neighbor features.
+		if (BasicMorphologyFeatures::required(env.theFeatureSet) || NeighborsFeature::required(env.theFeatureSet))
 		{
 			STOPWATCH("Morphology/Basic/E/#4aaaea", "\t=");
 			const Fsettings& fst = env.fsett_BasicMorphology;

--- a/tests/python/test_feature_bugs.py
+++ b/tests/python/test_feature_bugs.py
@@ -1,0 +1,284 @@
+"""Regression / bug-exposure tests for 2D feature defects found during oracle validation
+(2026-06). These exercise the PRODUCTION featurize() path on ROIs *with background* and at
+the DEFAULT settings - the conditions the C++ unit tests miss (test_glcm.h hard-codes
+offset=1 on a fully-masked phantom, which hid the GLCM defect).
+
+GLCM tests are live regression guards (the offset=0 + background-pollution defect is fixed).
+The remaining tests assert invariants that must hold for ANY ROI; the ones marked xfail
+correspond to defects that are not yet fixed - when a fix lands they XPASS and the xfail can
+be removed.
+"""
+import re
+from pathlib import Path
+import numpy as np
+import pytest
+import nyxus
+
+
+# ----------------------------- helpers --------------------------------------
+def _canonical_roi():
+    """The pixelIntensityFeaturesTestData ROI from tests/test_data.h - the same irregular
+    154-px region the C++ tests use, which reproduces the shape/moment defects. Falls back to
+    an L-shape if the header can't be read."""
+    hdr = Path(__file__).resolve().parent.parent / "test_data.h"
+    try:
+        txt = hdr.read_text(encoding="utf-8", errors="replace")
+        body = re.search(r"pixelIntensityFeaturesTestData\[\]\s*=\s*\{(.*?)\};", txt, re.S).group(1)
+        pts = [(int(x), int(y), int(v)) for x, y, v in
+               re.findall(r"\{\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\}", body)]
+        W = max(p[0] for p in pts) + 2
+        H = max(p[1] for p in pts) + 2
+        inten = np.zeros((H, W), np.uint32)
+        label = np.zeros((H, W), np.uint32)
+        for x, y, v in pts:
+            inten[y, x] = v
+            label[y, x] = 1
+        return inten, label
+    except Exception:
+        return None
+def _run(features, inten, label, **kw):
+    nyx = nyxus.Nyxus(features=features, n_feature_calc_threads=1, **kw)
+    df = nyx.featurize(inten.astype(np.float64), label.astype(np.uint32),
+                       intensity_names=["i"], label_names=["l"])
+    return df  # one row per label
+
+
+def _one(features, inten, label, **kw):
+    return _run(features, inten, label, **kw).iloc[0]
+
+
+def _blob():
+    """Irregular ROI for shape/moment bug exposure. Prefers the canonical 154-px ROI (which
+    reproduces solidity>1 and the ROI-radius anomaly); else an L-shape."""
+    c = _canonical_roi()
+    if c is not None:
+        return c
+    H, W = 16, 16
+    inten = np.zeros((H, W), np.uint32)
+    label = np.zeros((H, W), np.uint32)
+    # L-shape: a vertical bar + a horizontal foot (clearly non-convex -> hull > area)
+    for y in range(3, 13):
+        for x in range(3, 6):
+            label[y, x] = 1
+    for y in range(10, 13):
+        for x in range(6, 13):
+            label[y, x] = 1
+    # graded intensity (varies in x and y) over the ROI
+    ys, xs = np.nonzero(label)
+    inten[ys, xs] = (100 + 10 * xs + 7 * ys).astype(np.uint32)
+    return inten, label
+
+
+def _solid_square(side=10, border=4, val=500):
+    H = W = side + 2 * border
+    inten = np.zeros((H, W), np.uint32)
+    label = np.zeros((H, W), np.uint32)
+    inten[border:border + side, border:border + side] = val   # UNIFORM intensity
+    label[border:border + side, border:border + side] = 1
+    return inten, label
+
+
+# ============================ GLCM (FIXED) ==================================
+def test_glcm_contrast_nonzero_by_default():
+    """Bug #1 (FIXED): glcm/offset defaulted to 0 -> dx=dy=0 -> CONTRAST=0 for any image.
+    A horizontal intensity ramp must have nonzero 0deg contrast and zero 90deg contrast."""
+    H, W = 9, 9
+    inten = np.zeros((H, W), np.uint32)
+    label = np.zeros((H, W), np.uint32)
+    inten[2:7, 2:7] = np.tile(np.arange(1, 6) * 10, (5, 1))   # columns 10,20,30,40,50
+    label[2:7, 2:7] = 1
+    row = _one(["*ALL_GLCM*"], inten, label, coarse_gray_depth=8, ibsi=False)
+    assert row["GLCM_CONTRAST_0"] > 0.0,  "0deg contrast must be > 0 (offset=0 regression)"
+    assert row["GLCM_CONTRAST_90"] == pytest.approx(0.0, abs=1e-9), "constant columns -> 90deg contrast 0"
+
+
+def test_glcm_background_not_counted():
+    """Bug #2 (FIXED): the MATLAB binning path mapped background (0) -> level 1 and counted it,
+    polluting the matrix with spurious diagonal mass. This only manifests for a CONCAVE ROI
+    (background inside the bounding box). On the canonical irregular ROI, quantized to 1..64 so
+    binning is identity, GLCM_CONTRAST_AVE must match the transparent numpy reference / MIRP /
+    PyRadiomics (~133.9). Pre-fix this ROI gave ~99 (background-diluted); post-fix ~133."""
+    c = _canonical_roi()
+    if c is None:
+        pytest.skip("canonical ROI (tests/test_data.h) not available")
+    inten, label = c
+    roi = label > 0
+    v = inten[roi].astype(float)
+    lvl = np.clip(np.floor(64 * (v - v.min()) / (v.max() - v.min())).astype(int) + 1, 1, 64)
+    q = np.zeros_like(inten, np.uint32)
+    q[roi] = lvl                                  # quantized to integer levels 1..64
+    row = _one(["*ALL_GLCM*"], q, label.astype(np.uint32), coarse_gray_depth=64, ibsi=False)
+    assert row["GLCM_CONTRAST_AVE"] == pytest.approx(133.9, rel=0.12), \
+        "concave-ROI GLCM contrast must match the reference (background must be excluded)"
+    assert row["GLCM_CONTRAST_AVE"] > 115.0, "contrast still diluted by background (bug #2 regressed)"
+
+
+def test_gldm_background_not_counted():
+    """Bug #14b (FIXED): the MATLAB binning path maps background (0) -> level 1; the GLDM zone
+    loop's `pi==0` guard tests the BINNED value, so background voxels in the bounding box were
+    counted as zones AND as dependent neighbours - inflating Nz (154 -> 234 on this ROI) and every
+    count/dependence feature. Same root cause as GLCM #2. On the canonical concave ROI quantized to
+    1..64, the count features must match the PyRadiomics reference (LDE 1.88, GLN 3.90, DN 95.7);
+    pre-fix this ROI gave LDE ~16.6, GLN ~30, DN ~65 (background-polluted)."""
+    c = _canonical_roi()
+    if c is None:
+        pytest.skip("canonical ROI (tests/test_data.h) not available")
+    inten, label = c
+    roi = label > 0
+    v = inten[roi].astype(float)
+    lvl = np.clip(np.floor(64 * (v - v.min()) / (v.max() - v.min())).astype(int) + 1, 1, 64)
+    q = np.zeros_like(inten, np.uint32)
+    q[roi] = lvl                                  # quantized to integer levels 1..64
+    row = _one(["*ALL_GLDM*"], q, label.astype(np.uint32), coarse_gray_depth=64, ibsi=False)
+    assert row["GLDM_LDE"] == pytest.approx(1.883, rel=0.20), \
+        "GLDM Large-Dependence-Emphasis must match the reference (background must be excluded)"
+    assert row["GLDM_LDE"] < 5.0,  "GLDM_LDE still inflated by background zones (bug regressed)"
+    assert row["GLDM_GLN"] == pytest.approx(3.896, rel=0.15)
+    assert row["GLDM_DN"]  == pytest.approx(95.70, rel=0.15)
+
+
+def test_chord_max_angle_distinct_from_min():
+    """Bug #16 (FIXED): chords.cpp computed the max-chord angle index from iteMin
+    (`idxmax = distance(begin, iteMin)`), so MAXCHORDS_MAX_ANG was ALWAYS equal to
+    MAXCHORDS_MIN_ANG (same copy-paste error for ALLCHORDS). When the longest and shortest
+    chords have different lengths they occur at different orientations, so the max- and
+    min-angle must differ. Also exercised: ALLCHORDS mode/median were built from the
+    max-chords histogram (MC) instead of all chords (AC)."""
+    c = _canonical_roi()
+    if c is None:
+        pytest.skip("canonical ROI (tests/test_data.h) not available")
+    inten, label = c
+    row = _one(["MAXCHORDS_MAX", "MAXCHORDS_MIN", "MAXCHORDS_MAX_ANG", "MAXCHORDS_MIN_ANG",
+                "ALLCHORDS_MAX", "ALLCHORDS_MIN", "ALLCHORDS_MAX_ANG", "ALLCHORDS_MIN_ANG"],
+               inten, label)
+    if row["MAXCHORDS_MAX"] != row["MAXCHORDS_MIN"]:
+        assert row["MAXCHORDS_MAX_ANG"] != row["MAXCHORDS_MIN_ANG"], \
+            "MAXCHORDS max-angle == min-angle (idxmax=iteMin copy-paste bug regressed)"
+    if row["ALLCHORDS_MAX"] != row["ALLCHORDS_MIN"]:
+        assert row["ALLCHORDS_MAX_ANG"] != row["ALLCHORDS_MIN_ANG"], \
+            "ALLCHORDS max-angle == min-angle (idxmax=iteMin copy-paste bug regressed)"
+
+
+def test_compactness_uses_mean_centroid():
+    """Bug #18 (FIXED): COMPACTNESS (std of centroid-to-pixel distances / area) measured distances
+    from the coordinate SUM (cen_x/cen_y were never divided by n) instead of the mean centroid, and
+    used Pixel2::sqdist(int,int) which truncates the fractional centroid. Same fix as PR #350.
+    On a 10x10 square it must equal the independent numpy value (std(dist, ddof=1)/n ~ 0.0141);
+    pre-fix it was ~0.029 (sum-centroid)."""
+    inten, label = _solid_square(side=10, border=4)
+    row = _one(["*ALL_MORPHOLOGY*"], inten, label)
+    ys, xs = np.nonzero(label > 0)
+    n = len(xs)
+    d = np.hypot(xs - xs.mean(), ys - ys.mean())
+    expected = d.std(ddof=1) / n                  # Nyxus Moments2.std() uses Bessel's correction
+    assert float(row["COMPACTNESS"]) == pytest.approx(expected, rel=1e-3), \
+        "COMPACTNESS must use the MEAN centroid with double-precision distances"
+
+
+# ===================== OPEN bugs (xfail until fixed) ========================
+# regression guard for PROPOSED fix #6 (Pick's-theorem pixel-count hull area); validated locally
+def test_solidity_le_one():
+    inten, label = _blob()
+    row = _one(["*ALL_MORPHOLOGY*"], inten, label)
+    assert row["SOLIDITY"] <= 1.0 + 1e-6
+
+
+# regression guard for PROPOSED fix #7 (euler: pad mask + Cd '||' + mode formula); validated locally
+def test_euler_number_simply_connected():
+    inten, label = _solid_square()
+    row = _one(["*ALL_MORPHOLOGY*"], inten, label)
+    assert row["EULER_NUMBER"] == 1
+
+
+# regression guard for PROPOSED fix #5 (DIAMETER_EQUAL_AREA: add sqrt); validated locally
+def test_diameter_equal_area_is_sqrt():
+    inten, label = _solid_square(side=10, border=4)
+    row = _one(["*ALL_MORPHOLOGY*"], inten, label)
+    area = float(row["AREA_PIXELS_COUNT"])
+    assert row["DIAMETER_EQUAL_AREA"] == pytest.approx(np.sqrt(4 * area / np.pi), rel=0.05)
+
+
+# regression guard for PROPOSED fix #10 (weighted centroid 0-based, drop +1); validated locally
+def test_weighted_centroid_matches_plain_for_uniform_intensity():
+    inten, label = _solid_square()       # uniform intensity -> weighted == geometric centroid
+    row = _one(["*ALL_INTENSITY*", "*ALL_MORPHOLOGY*"], inten, label)
+    assert row["WEIGHTED_CENTROID_X"] == pytest.approx(row["CENTROID_X"], abs=0.25)
+    assert row["WEIGHTED_CENTROID_Y"] == pytest.approx(row["CENTROID_Y"], abs=0.25)
+
+
+# regression guard for PROPOSED fix #4 (central moment: drop (int) centroid truncation); validated locally
+def test_first_central_moment_zero():
+    inten, label = _blob()
+    row = _one(["*SGEOMOMS*"], inten, label)
+    m00 = abs(float(row["CENTRAL_MOMENT_00"])) or 1.0
+    assert abs(float(row["CENTRAL_MOMENT_01"])) / m00 < 1e-3
+    assert abs(float(row["CENTRAL_MOMENT_10"])) / m00 < 1e-3
+
+
+def test_plain_intensity_zeroth_moment_positive():
+    # NOTE: WEIGHTED_*/IMOM_W* are distance-to-contour LOG-weighted moments (weight =
+    # intensity*log(dist+eps)); their zeroth moment can legitimately be negative -> NOT a bug.
+    # The PLAIN intensity raw zeroth moment IMOM_RM_00 must be > 0 (= sum of intensities).
+    inten, label = _blob()
+    row = _one(["*IGEOMOMS*"], inten, label)
+    assert float(row["IMOM_RM_00"]) > 0.0
+
+
+# regression guard for PROPOSED fix #8 (fractal dim: mean log-log slope, not slope-of-slopes); validated locally
+def test_fractal_dimension_in_range():
+    inten, label = _blob()
+    row = _one(["*ALL_MORPHOLOGY*"], inten, label)
+    assert 1.0 <= float(row["FRACT_DIM_BOXCOUNT"]) <= 2.0
+
+
+# regression guard for PROPOSED fix #11 (ROI_RADIUS = sqrt(min_sqdist), was squared); validated locally
+def test_roi_radius_within_image():
+    inten, label = _blob()
+    H, W = label.shape
+    row = _one(["*ALL_MORPHOLOGY*"], inten, label)
+    assert float(row["ROI_RADIUS_MAX"]) <= np.hypot(H, W)
+
+
+# #9 RECLASSIFIED (not a bug): DIAMETER_INSCRIBING_CIRCLE is Nyxus's CENTROID-based inscribing circle
+# (2*min centroid-to-contour distance), the companion of the centroid-based CIRCUMSCRIBING circle - NOT
+# the largest inscribed circle (that is imea's max_inclosing, the oracle the tracker mistakenly compared
+# against). The PROPOSED fix here is only the dropped -1 centroid offset; assert the centroid-based
+# sanity invariants rather than the largest-inscribed value.
+def test_inscribing_circle_centroid_based_sane():
+    inten, label = _solid_square(side=10, border=4)
+    row = _one(["*ALL_MORPHOLOGY*"], inten, label)
+    insc = float(row["DIAMETER_INSCRIBING_CIRCLE"])
+    circ = float(row["DIAMETER_CIRCUMSCRIBING_CIRCLE"])
+    assert 0.0 < insc <= circ + 1e-6              # inscribing <= circumscribing (both centroid-centered)
+
+
+# regression guard for PROPOSED fix #17 (circle.cpp undoes the contour (+1,+1) frame offset from
+# contour.cpp's missing -1 pad correction); validated locally
+def test_inscribing_circumscribing_circle_correct_for_square():
+    """A 10x10 square (centroid 8.5,8.5): the inscribing diameter must be ~2*min centroid-to-edge
+    distance (~9.06) and the circumscribing ~2*max centroid-to-corner (~12.73) == the min-enclosing.
+    Pre-fix the +1 contour offset gave INSCRIBING 7.07 (=5*sqrt2, too small) and CIRCUMSCRIBING 15.56."""
+    inten, label = _solid_square(side=10, border=4)
+    row = _one(["*ALL_MORPHOLOGY*"], inten, label)
+    insc = float(row["DIAMETER_INSCRIBING_CIRCLE"])
+    circ = float(row["DIAMETER_CIRCUMSCRIBING_CIRCLE"])
+    menc = float(row["DIAMETER_MIN_ENCLOSING_CIRCLE"])
+    assert insc == pytest.approx(9.06, abs=0.3),  f"inscribing {insc} (expect ~9.06; 7.07 == +1 contour-offset bug)"
+    assert circ == pytest.approx(12.73, abs=0.3), f"circumscribing {circ} (expect ~12.73; 15.56 == +1 contour-offset bug)"
+    assert circ == pytest.approx(menc, abs=0.3),  "circumscribing ~ min-enclosing for a square (both reach the corners)"
+
+
+# regression guard for PROPOSED fixes #12 (closest-neighbor dist/ang need CENTROID, now forced when
+# neighbors requested) and #13 (PERCENT_TOUCHING deduped + adjacency, was >100%); validated locally
+def test_neighbor_distance_and_percent_touching():
+    # two 4x4 squares separated by a 2px gap (neighbors within neighbor_distance=5, but NOT touching)
+    H, W = 12, 20
+    inten = np.zeros((H, W), np.uint32)
+    label = np.zeros((H, W), np.uint32)
+    inten[4:8, 3:7] = 100;  label[4:8, 3:7] = 1
+    inten[4:8, 9:13] = 100; label[4:8, 9:13] = 2
+    df = _run(["*ALL_NEIGHBOR*"], inten, label, neighbor_distance=5)
+    assert (df["NUM_NEIGHBORS"] >= 1).all()
+    assert (df["CLOSEST_NEIGHBOR1_DIST"] > 0).all()        # was 0 (CENTROID not computed) == bug #12
+    assert (df["PERCENT_TOUCHING"] <= 100.0).all()         # was >100% == bug #13
+    assert (df["PERCENT_TOUCHING"] == 0.0).all()           # 2px gap -> not touching (adjacency-based)

--- a/tests/test_2d_geometric_moments.h
+++ b/tests/test_2d_geometric_moments.h
@@ -13,12 +13,21 @@
 #include "../src/nyx/features/contour.h"
 #include "test_main_nyxus.h"
 
-struct GeomomentGoldenValue
+struct GeomomentExpectation
 {
 	Nyxus::Feature2D feature;
 	const char* name;
-	double golden_value;
+	double expected;
+	bool unvetted_no_direct_oracle = false;
 };
+
+static GeomomentExpectation unvetted_no_direct_oracle_geomoment(
+	Nyxus::Feature2D feature,
+	const char* name,
+	double expected)
+{
+	return {feature, name, expected, true};
+}
 
 static Fsettings make_2d_geomoment_settings()
 {
@@ -100,237 +109,238 @@ static void calculate_2d_geomoment_feature_values(std::vector<std::vector<double
 
 static void assert_2d_geomoment_features(
 	const std::vector<std::vector<double>>& fvals,
-	const std::vector<GeomomentGoldenValue>& golden_values,
-	const std::string& review_prefix)
+	const std::vector<GeomomentExpectation>& expectations)
 {
-	for (const auto& item : golden_values)
+	for (const auto& item : expectations)
 	{
 		const double actual = fvals[static_cast<int>(item.feature)][0];
-		const double scale = std::max({1.0, std::abs(item.golden_value), std::abs(actual)});
+		const double scale = std::max({1.0, std::abs(item.expected), std::abs(actual)});
 		const double tolerance = 1e-6 * scale;
-		const std::string review_name = review_prefix + item.name;
+		const std::string review_name = item.unvetted_no_direct_oracle ?
+			std::string("UNVETTED_NO_DIRECT_ORACLE__") + item.name :
+			item.name;
 		SCOPED_TRACE(review_name);
 		ASSERT_TRUE(std::isfinite(actual)) << review_name << " returned a non-finite value";
-		ASSERT_NEAR(actual, item.golden_value, tolerance) << review_name;
+		ASSERT_NEAR(actual, item.expected, tolerance) << review_name;
 	}
 }
 
-static const std::vector<GeomomentGoldenValue> oracle_3p_shape_geomoment_feature_golden_values{
-	{Nyxus::Feature2D::SPAT_MOMENT_00, "SPAT_MOMENT_00", 1920},
-	{Nyxus::Feature2D::SPAT_MOMENT_01, "SPAT_MOMENT_01", 37440},
-	{Nyxus::Feature2D::SPAT_MOMENT_02, "SPAT_MOMENT_02", 985920},
-	{Nyxus::Feature2D::SPAT_MOMENT_03, "SPAT_MOMENT_03", 29203200},
-	{Nyxus::Feature2D::SPAT_MOMENT_10, "SPAT_MOMENT_10", 45120},
-	{Nyxus::Feature2D::SPAT_MOMENT_11, "SPAT_MOMENT_11", 879840},
-	{Nyxus::Feature2D::SPAT_MOMENT_12, "SPAT_MOMENT_12", 23169120},
-	{Nyxus::Feature2D::SPAT_MOMENT_13, "SPAT_MOMENT_13", 686275200},
-	{Nyxus::Feature2D::SPAT_MOMENT_20, "SPAT_MOMENT_20", 1428800},
-	{Nyxus::Feature2D::SPAT_MOMENT_21, "SPAT_MOMENT_21", 27861600},
-	{Nyxus::Feature2D::SPAT_MOMENT_22, "SPAT_MOMENT_22", 733688800},
-	{Nyxus::Feature2D::SPAT_MOMENT_23, "SPAT_MOMENT_23", 21732048000},
-	{Nyxus::Feature2D::SPAT_MOMENT_30, "SPAT_MOMENT_30", 50895360},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_00, "CENTRAL_MOMENT_00", 1920},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_01, "CENTRAL_MOMENT_01", 960},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_02, "CENTRAL_MOMENT_02", 256320},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_03, "CENTRAL_MOMENT_03", 384000},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_10, "CENTRAL_MOMENT_10", 960},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_11, "CENTRAL_MOMENT_11", 480},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_12, "CENTRAL_MOMENT_12", 128160},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_13, "CENTRAL_MOMENT_13", 192000},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_20, "CENTRAL_MOMENT_20", 368960},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_21, "CENTRAL_MOMENT_21", 184480},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_22, "CENTRAL_MOMENT_22", 49256160},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_23, "CENTRAL_MOMENT_23", 73792000},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_30, "CENTRAL_MOMENT_30", 552960},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_31, "CENTRAL_MOMENT_31", 276480},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_32, "CENTRAL_MOMENT_32", 73820160},
-	{Nyxus::Feature2D::CENTRAL_MOMENT_33, "CENTRAL_MOMENT_33", 110592000},
-	{Nyxus::Feature2D::NORM_CENTRAL_MOMENT_02, "NORM_CENTRAL_MOMENT_02", 0.069531250000000003},
-	{Nyxus::Feature2D::NORM_CENTRAL_MOMENT_03, "NORM_CENTRAL_MOMENT_03", 0.0023772680447272832},
-	{Nyxus::Feature2D::NORM_CENTRAL_MOMENT_11, "NORM_CENTRAL_MOMENT_11", 0.00013020833333333333},
-	{Nyxus::Feature2D::NORM_CENTRAL_MOMENT_12, "NORM_CENTRAL_MOMENT_12", 0.00079341320992773077},
-	{Nyxus::Feature2D::NORM_CENTRAL_MOMENT_20, "NORM_CENTRAL_MOMENT_20", 0.10008680555555556},
-	{Nyxus::Feature2D::NORM_CENTRAL_MOMENT_21, "NORM_CENTRAL_MOMENT_21", 0.0011420791898210656},
-	{Nyxus::Feature2D::NORM_CENTRAL_MOMENT_30, "NORM_CENTRAL_MOMENT_30", 0.0034232659844072879},
-	{Nyxus::Feature2D::HU_M1, "HU_M1", 0.16961805555555556},
-	{Nyxus::Feature2D::HU_M2, "HU_M2", 0.00093370979214891993},
-	{Nyxus::Feature2D::HU_M3, "HU_M3", 2.1882410402651178e-06},
-	{Nyxus::Feature2D::HU_M4, "HU_M4", 3.0166188385260932e-05},
-	{Nyxus::Feature2D::HU_M5, "HU_M5", 4.598098572281346e-10},
-	{Nyxus::Feature2D::HU_M6, "HU_M6", 0.0023774353872890023},
-	{Nyxus::Feature2D::HU_M7, "HU_M7", -2.3604559630908652e-10},
+static const std::vector<GeomomentExpectation> shape_geomoment_expectations{
+	{Nyxus::Feature2D::SPAT_MOMENT_00, "SPAT_MOMENT_00", 1920.0},
+	{Nyxus::Feature2D::SPAT_MOMENT_01, "SPAT_MOMENT_01", 37440.0},
+	{Nyxus::Feature2D::SPAT_MOMENT_02, "SPAT_MOMENT_02", 985920.0},
+	{Nyxus::Feature2D::SPAT_MOMENT_03, "SPAT_MOMENT_03", 29203200.0},
+	{Nyxus::Feature2D::SPAT_MOMENT_10, "SPAT_MOMENT_10", 45120.0},
+	{Nyxus::Feature2D::SPAT_MOMENT_11, "SPAT_MOMENT_11", 879840.0},
+	{Nyxus::Feature2D::SPAT_MOMENT_12, "SPAT_MOMENT_12", 23169120.0},
+	{Nyxus::Feature2D::SPAT_MOMENT_13, "SPAT_MOMENT_13", 686275200.0},
+	{Nyxus::Feature2D::SPAT_MOMENT_20, "SPAT_MOMENT_20", 1428800.0},
+	{Nyxus::Feature2D::SPAT_MOMENT_21, "SPAT_MOMENT_21", 27861600.0},
+	{Nyxus::Feature2D::SPAT_MOMENT_22, "SPAT_MOMENT_22", 733688800.0},
+	{Nyxus::Feature2D::SPAT_MOMENT_23, "SPAT_MOMENT_23", 21732048000.0},
+	{Nyxus::Feature2D::SPAT_MOMENT_30, "SPAT_MOMENT_30", 50895360.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_00, "CENTRAL_MOMENT_00", 1920.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_01, "CENTRAL_MOMENT_01", 0.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_02, "CENTRAL_MOMENT_02", 255840.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_03, "CENTRAL_MOMENT_03", 0.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_10, "CENTRAL_MOMENT_10", 0.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_11, "CENTRAL_MOMENT_11", 0.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_12, "CENTRAL_MOMENT_12", 0.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_13, "CENTRAL_MOMENT_13", 0.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_20, "CENTRAL_MOMENT_20", 368480.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_21, "CENTRAL_MOMENT_21", 0.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_22, "CENTRAL_MOMENT_22", 49099960.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_23, "CENTRAL_MOMENT_23", 0.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_30, "CENTRAL_MOMENT_30", 0.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_31, "CENTRAL_MOMENT_31", 0.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_32, "CENTRAL_MOMENT_32", 0.0},
+	{Nyxus::Feature2D::CENTRAL_MOMENT_33, "CENTRAL_MOMENT_33", 0.0},
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_00, "NORM_SPAT_MOMENT_00", 1.0),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_01, "NORM_SPAT_MOMENT_01", 0.4450245779729475),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_02, "NORM_SPAT_MOMENT_02", 0.2674479166666667),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_03, "NORM_SPAT_MOMENT_03", 0.1807912348015099),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_10, "NORM_SPAT_MOMENT_10", 0.5363116708904752),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_11, "NORM_SPAT_MOMENT_11", 0.238671875),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_12, "NORM_SPAT_MOMENT_12", 0.14343543906367653),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_13, "NORM_SPAT_MOMENT_13", 0.09696044921875),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_20, "NORM_SPAT_MOMENT_20", 0.3875868055555556),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_21, "NORM_SPAT_MOMENT_21", 0.17248565457024395),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_22, "NORM_SPAT_MOMENT_22", 0.10365928367332176),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_23, "NORM_SPAT_MOMENT_23", 0.07007229716916162),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_30, "NORM_SPAT_MOMENT_30", 0.31508310664815414),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_31, "NORM_SPAT_MOMENT_31", 0.1402197265625),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_32, "NORM_SPAT_MOMENT_32", 0.08426832044990999),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::NORM_SPAT_MOMENT_33, "NORM_SPAT_MOMENT_33", 0.056964263916015626),
+	{Nyxus::Feature2D::NORM_CENTRAL_MOMENT_02, "NORM_CENTRAL_MOMENT_02", 0.06940104166666666},
+	{Nyxus::Feature2D::NORM_CENTRAL_MOMENT_03, "NORM_CENTRAL_MOMENT_03", 0.0},
+	{Nyxus::Feature2D::NORM_CENTRAL_MOMENT_11, "NORM_CENTRAL_MOMENT_11", 0.0},
+	{Nyxus::Feature2D::NORM_CENTRAL_MOMENT_12, "NORM_CENTRAL_MOMENT_12", 0.0},
+	{Nyxus::Feature2D::NORM_CENTRAL_MOMENT_20, "NORM_CENTRAL_MOMENT_20", 0.09995659722222222},
+	{Nyxus::Feature2D::NORM_CENTRAL_MOMENT_21, "NORM_CENTRAL_MOMENT_21", 0.0},
+	{Nyxus::Feature2D::NORM_CENTRAL_MOMENT_30, "NORM_CENTRAL_MOMENT_30", 0.0},
+	{Nyxus::Feature2D::HU_M1, "HU_M1", 0.16935763888888888},
+	{Nyxus::Feature2D::HU_M2, "HU_M2", 0.0009336419753086421},
+	{Nyxus::Feature2D::HU_M3, "HU_M3", 0.0},
+	{Nyxus::Feature2D::HU_M4, "HU_M4", 0.0},
+	{Nyxus::Feature2D::HU_M5, "HU_M5", 0.0},
+	{Nyxus::Feature2D::HU_M6, "HU_M6", 0.0},
+	{Nyxus::Feature2D::HU_M7, "HU_M7", 0.0},
 };
 
-static const std::vector<GeomomentGoldenValue> unvetted_nyxus_regression_shape_geomoment_feature_golden_values{
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_00, "NORM_SPAT_MOMENT_00", 1},
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_01, "NORM_SPAT_MOMENT_01", 0.44502457797294748},
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_02, "NORM_SPAT_MOMENT_02", 0.26744791666666667},
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_03, "NORM_SPAT_MOMENT_03", 0.18079123480150991},
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_10, "NORM_SPAT_MOMENT_10", 0.53631167089047516},
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_11, "NORM_SPAT_MOMENT_11", 0.23867187500000001},
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_12, "NORM_SPAT_MOMENT_12", 0.14343543906367653},
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_13, "NORM_SPAT_MOMENT_13", 0.096960449218749994},
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_20, "NORM_SPAT_MOMENT_20", 0.38758680555555558},
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_21, "NORM_SPAT_MOMENT_21", 0.17248565457024395},
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_22, "NORM_SPAT_MOMENT_22", 0.10365928367332176},
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_23, "NORM_SPAT_MOMENT_23", 0.070072297169161621},
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_30, "NORM_SPAT_MOMENT_30", 0.31508310664815414},
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_31, "NORM_SPAT_MOMENT_31", 0.14021972656250001},
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_32, "NORM_SPAT_MOMENT_32", 0.084268320449909992},
-	{Nyxus::Feature2D::NORM_SPAT_MOMENT_33, "NORM_SPAT_MOMENT_33", 0.056964263916015626},
-	{Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_00, "WEIGHTED_SPAT_MOMENT_00", 2498.7137745347236},
-	{Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_01, "WEIGHTED_SPAT_MOMENT_01", 56490.467057333364},
-	{Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_02, "WEIGHTED_SPAT_MOMENT_02", 1384474.7445020285},
-	{Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_03, "WEIGHTED_SPAT_MOMENT_03", 37605700.456672639},
-	{Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_10, "WEIGHTED_SPAT_MOMENT_10", 66428.864797854694},
-	{Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_11, "WEIGHTED_SPAT_MOMENT_11", 1505032.6106230586},
-	{Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_12, "WEIGHTED_SPAT_MOMENT_12", 37215299.240302473},
-	{Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_20, "WEIGHTED_SPAT_MOMENT_20", 1970501.3917437526},
-	{Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_21, "WEIGHTED_SPAT_MOMENT_21", 45088115.602599062},
-	{Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_30, "WEIGHTED_SPAT_MOMENT_30", 65035567.600335725},
-	{Nyxus::Feature2D::WEIGHTED_CENTRAL_MOMENT_02, "WEIGHTED_CENTRAL_MOMENT_02", 108271.66085414639},
-	{Nyxus::Feature2D::WEIGHTED_CENTRAL_MOMENT_03, "WEIGHTED_CENTRAL_MOMENT_03", 1648221.2155424568},
-	{Nyxus::Feature2D::WEIGHTED_CENTRAL_MOMENT_11, "WEIGHTED_CENTRAL_MOMENT_11", 4109.7206134559083},
-	{Nyxus::Feature2D::WEIGHTED_CENTRAL_MOMENT_12, "WEIGHTED_CENTRAL_MOMENT_12", 330371.75284171134},
-	{Nyxus::Feature2D::WEIGHTED_CENTRAL_MOMENT_20, "WEIGHTED_CENTRAL_MOMENT_20", 205330.93384081553},
-	{Nyxus::Feature2D::WEIGHTED_CENTRAL_MOMENT_21, "WEIGHTED_CENTRAL_MOMENT_21", 496695.03645982972},
-	{Nyxus::Feature2D::WEIGHTED_CENTRAL_MOMENT_30, "WEIGHTED_CENTRAL_MOMENT_30", 2136803.5531487665},
-	{Nyxus::Feature2D::WT_NORM_CTR_MOM_02, "WT_NORM_CTR_MOM_02", 0.017341305008900215},
-	{Nyxus::Feature2D::WT_NORM_CTR_MOM_03, "WT_NORM_CTR_MOM_03", 0.0052810979515541092},
-	{Nyxus::Feature2D::WT_NORM_CTR_MOM_11, "WT_NORM_CTR_MOM_11", 0.00065823243217178482},
-	{Nyxus::Feature2D::WT_NORM_CTR_MOM_12, "WT_NORM_CTR_MOM_12", 0.0010585506185281591},
-	{Nyxus::Feature2D::WT_NORM_CTR_MOM_20, "WT_NORM_CTR_MOM_20", 0.032886780561097596},
-	{Nyxus::Feature2D::WT_NORM_CTR_MOM_21, "WT_NORM_CTR_MOM_21", 0.0015914703165204656},
-	{Nyxus::Feature2D::WT_NORM_CTR_MOM_30, "WT_NORM_CTR_MOM_30", 0.0068465742104244923},
-	{Nyxus::Feature2D::WEIGHTED_HU_M1, "WEIGHTED_HU_M1", 0.050228085569997812},
-	{Nyxus::Feature2D::WEIGHTED_HU_M2, "WEIGHTED_HU_M2", 0.00024339488988301761},
-	{Nyxus::Feature2D::WEIGHTED_HU_M3, "WEIGHTED_HU_M3", 1.3732402653252524e-05},
-	{Nyxus::Feature2D::WEIGHTED_HU_M4, "WEIGHTED_HU_M4", 0.00010972319316066924},
-	{Nyxus::Feature2D::WEIGHTED_HU_M5, "WEIGHTED_HU_M5", -4.0924793325555725e-09},
-	{Nyxus::Feature2D::WEIGHTED_HU_M6, "WEIGHTED_HU_M6", 0.0052813682812053835},
-	{Nyxus::Feature2D::WEIGHTED_HU_M7, "WEIGHTED_HU_M7", -3.2208361663964004e-09},
+static const std::vector<GeomomentExpectation> shape_weighted_geomoment_expectations{
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_00, "WEIGHTED_SPAT_MOMENT_00", 1895.0047386658844),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_01, "WEIGHTED_SPAT_MOMENT_01", 35936.03530272888),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_02, "WEIGHTED_SPAT_MOMENT_02", 638259.19023700757),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_03, "WEIGHTED_SPAT_MOMENT_03", 10157210.471993469),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_10, "WEIGHTED_SPAT_MOMENT_10", 43477.893744408153),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_11, "WEIGHTED_SPAT_MOMENT_11", 840156.49488028791),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_12, "WEIGHTED_SPAT_MOMENT_12", 14971355.233518988),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_20, "WEIGHTED_SPAT_MOMENT_20", 998251.12667152286),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_21, "WEIGHTED_SPAT_MOMENT_21", 19364279.49826885),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_SPAT_MOMENT_30, "WEIGHTED_SPAT_MOMENT_30", 22560196.678065144),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_CENTRAL_MOMENT_02, "WEIGHTED_CENTRAL_MOMENT_02", -43215.956990404084),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_CENTRAL_MOMENT_03, "WEIGHTED_CENTRAL_MOMENT_03", -307398.96983443695),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_CENTRAL_MOMENT_11, "WEIGHTED_CENTRAL_MOMENT_11", 15660.865604279265),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_CENTRAL_MOMENT_12, "WEIGHTED_CENTRAL_MOMENT_12", -266466.34221961326),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_CENTRAL_MOMENT_20, "WEIGHTED_CENTRAL_MOMENT_20", 719.45517772604308),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_CENTRAL_MOMENT_21, "WEIGHTED_CENTRAL_MOMENT_21", -284742.93987422739),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_CENTRAL_MOMENT_30, "WEIGHTED_CENTRAL_MOMENT_30", -376113.88641494792),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WT_NORM_CTR_MOM_02, "WT_NORM_CTR_MOM_02", -0.012034374825642609),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WT_NORM_CTR_MOM_03, "WT_NORM_CTR_MOM_03", -0.0019664216948016336),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WT_NORM_CTR_MOM_11, "WT_NORM_CTR_MOM_11", 0.004361091131633606),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WT_NORM_CTR_MOM_12, "WT_NORM_CTR_MOM_12", -0.0017045769429783677),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WT_NORM_CTR_MOM_20, "WT_NORM_CTR_MOM_20", 0.0002003471375382717),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WT_NORM_CTR_MOM_21, "WT_NORM_CTR_MOM_21", -0.0018214917724410384),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WT_NORM_CTR_MOM_30, "WT_NORM_CTR_MOM_30", -0.0024059888891652882),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_HU_M1, "WEIGHTED_HU_M1", -0.011834027688104336),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_HU_M2, "WEIGHTED_HU_M2", 0.00022576488494999378),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_HU_M3, "WEIGHTED_HU_M3", 1.9568245558424062e-05),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_HU_M4, "WEIGHTED_HU_M4", 3.1245039895705273e-05),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_HU_M5, "WEIGHTED_HU_M5", -3.5041912835033034e-09),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_HU_M6, "WEIGHTED_HU_M6", -0.0019662599027957515),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::WEIGHTED_HU_M7, "WEIGHTED_HU_M7", -1.3078000499389235e-09),
 };
 
-static const std::vector<GeomomentGoldenValue> oracle_3p_intensity_geomoment_feature_golden_values{
-	{Nyxus::Feature2D::IMOM_RM_00, "IMOM_RM_00", 346635},
-	{Nyxus::Feature2D::IMOM_RM_01, "IMOM_RM_01", 8040325},
-	{Nyxus::Feature2D::IMOM_RM_02, "IMOM_RM_02", 227941125},
-	{Nyxus::Feature2D::IMOM_RM_03, "IMOM_RM_03", 7040124229},
-	{Nyxus::Feature2D::IMOM_RM_10, "IMOM_RM_10", 9253494},
-	{Nyxus::Feature2D::IMOM_RM_11, "IMOM_RM_11", 210545686},
-	{Nyxus::Feature2D::IMOM_RM_12, "IMOM_RM_12", 5925377592},
-	{Nyxus::Feature2D::IMOM_RM_13, "IMOM_RM_13", 182290179472},
-	{Nyxus::Feature2D::IMOM_RM_20, "IMOM_RM_20", 310000126},
-	{Nyxus::Feature2D::IMOM_RM_21, "IMOM_RM_21", 6998259834},
-	{Nyxus::Feature2D::IMOM_RM_22, "IMOM_RM_22", 196352705268},
-	{Nyxus::Feature2D::IMOM_RM_23, "IMOM_RM_23", 6030684350556},
-	{Nyxus::Feature2D::IMOM_RM_30, "IMOM_RM_30", 11405788056},
-	{Nyxus::Feature2D::IMOM_CM_00, "IMOM_CM_00", 346635},
-	{Nyxus::Feature2D::IMOM_CM_01, "IMOM_CM_01", 67720},
-	{Nyxus::Feature2D::IMOM_CM_02, "IMOM_CM_02", 41456090},
-	{Nyxus::Feature2D::IMOM_CM_03, "IMOM_CM_03", -145325666},
-	{Nyxus::Feature2D::IMOM_CM_10, "IMOM_CM_10", 240984},
-	{Nyxus::Feature2D::IMOM_CM_11, "IMOM_CM_11", -4045396},
-	{Nyxus::Feature2D::IMOM_CM_12, "IMOM_CM_12", 57516022},
-	{Nyxus::Feature2D::IMOM_CM_13, "IMOM_CM_13", -1233664876},
-	{Nyxus::Feature2D::IMOM_CM_20, "IMOM_CM_20", 63143698},
-	{Nyxus::Feature2D::IMOM_CM_21, "IMOM_CM_21", 32838808},
-	{Nyxus::Feature2D::IMOM_CM_22, "IMOM_CM_22", 7407669574},
-	{Nyxus::Feature2D::IMOM_CM_23, "IMOM_CM_23", -20794765652},
-	{Nyxus::Feature2D::IMOM_CM_30, "IMOM_CM_30", -100592700},
-	{Nyxus::Feature2D::IMOM_CM_31, "IMOM_CM_31", -1511475334},
-	{Nyxus::Feature2D::IMOM_CM_32, "IMOM_CM_32", -1566202592},
-	{Nyxus::Feature2D::IMOM_CM_33, "IMOM_CM_33", -370723933282},
-	{Nyxus::Feature2D::IMOM_NCM_02, "IMOM_NCM_02", 0.00034501939970375497},
-	{Nyxus::Feature2D::IMOM_NCM_03, "IMOM_NCM_03", -2.0542878277179582e-06},
-	{Nyxus::Feature2D::IMOM_NCM_11, "IMOM_NCM_11", -3.3667914641346339e-05},
-	{Nyxus::Feature2D::IMOM_NCM_12, "IMOM_NCM_12", 8.1303232350821154e-07},
-	{Nyxus::Feature2D::IMOM_NCM_20, "IMOM_NCM_20", 0.00052551508786851807},
-	{Nyxus::Feature2D::IMOM_NCM_21, "IMOM_NCM_21", 4.6420130323825322e-07},
-	{Nyxus::Feature2D::IMOM_NCM_30, "IMOM_NCM_30", -1.4219536359618971e-06},
-	{Nyxus::Feature2D::IMOM_HU1, "IMOM_HU1", 0.00087053448757227299},
-	{Nyxus::Feature2D::IMOM_HU2, "IMOM_HU2", 3.7112807351259333e-08},
-	{Nyxus::Feature2D::IMOM_HU3, "IMOM_HU3", 2.6788774435431954e-11},
-	{Nyxus::Feature2D::IMOM_HU4, "IMOM_HU4", 2.8991603200922661e-12},
-	{Nyxus::Feature2D::IMOM_HU5, "IMOM_HU5", -2.1393783155778043e-23},
-	{Nyxus::Feature2D::IMOM_HU6, "IMOM_HU6", -2.0542878280693274e-06},
-	{Nyxus::Feature2D::IMOM_HU7, "IMOM_HU7", 2.3835594243218353e-23},
+static const std::vector<GeomomentExpectation> intensity_geomoment_expectations{
+	{Nyxus::Feature2D::IMOM_RM_00, "IMOM_RM_00", 346635.0},
+	{Nyxus::Feature2D::IMOM_RM_01, "IMOM_RM_01", 8040325.0},
+	{Nyxus::Feature2D::IMOM_RM_02, "IMOM_RM_02", 227941125.0},
+	{Nyxus::Feature2D::IMOM_RM_03, "IMOM_RM_03", 7040124229.0},
+	{Nyxus::Feature2D::IMOM_RM_10, "IMOM_RM_10", 9253494.0},
+	{Nyxus::Feature2D::IMOM_RM_11, "IMOM_RM_11", 210545686.0},
+	{Nyxus::Feature2D::IMOM_RM_12, "IMOM_RM_12", 5925377592.0},
+	{Nyxus::Feature2D::IMOM_RM_13, "IMOM_RM_13", 182290179472.0},
+	{Nyxus::Feature2D::IMOM_RM_20, "IMOM_RM_20", 310000126.0},
+	{Nyxus::Feature2D::IMOM_RM_21, "IMOM_RM_21", 6998259834.0},
+	{Nyxus::Feature2D::IMOM_RM_22, "IMOM_RM_22", 196352705268.0},
+	{Nyxus::Feature2D::IMOM_RM_23, "IMOM_RM_23", 6030684350556.0},
+	{Nyxus::Feature2D::IMOM_RM_30, "IMOM_RM_30", 11405788056.0},
+	{Nyxus::Feature2D::IMOM_CM_00, "IMOM_CM_00", 346635.0},
+	{Nyxus::Feature2D::IMOM_CM_01, "IMOM_CM_01", -4.5292836148291826e-10},
+	{Nyxus::Feature2D::IMOM_CM_02, "IMOM_CM_02", 41442859.94994738},
+	{Nyxus::Feature2D::IMOM_CM_03, "IMOM_CM_03", -169617579.2990637},
+	{Nyxus::Feature2D::IMOM_CM_10, "IMOM_CM_10", 1.7789716366678476e-09},
+	{Nyxus::Feature2D::IMOM_CM_11, "IMOM_CM_11", -4092475.5980786625},
+	{Nyxus::Feature2D::IMOM_CM_12, "IMOM_CM_12", 30294392.62744321},
+	{Nyxus::Feature2D::IMOM_CM_13, "IMOM_CM_13", -1149919776.802983},
+	{Nyxus::Feature2D::IMOM_CM_20, "IMOM_CM_20", 62976163.595638104},
+	{Nyxus::Feature2D::IMOM_CM_21, "IMOM_CM_21", 26193059.735960778},
+	{Nyxus::Feature2D::IMOM_CM_22, "IMOM_CM_22", 7335096618.144121},
+	{Nyxus::Feature2D::IMOM_CM_23, "IMOM_CM_23", -23452202622.58501},
+	{Nyxus::Feature2D::IMOM_CM_30, "IMOM_CM_30", -232054083.11103734},
+	{Nyxus::Feature2D::IMOM_CM_31, "IMOM_CM_31", -1540518263.5748055},
+	{Nyxus::Feature2D::IMOM_CM_32, "IMOM_CM_32", -16335606634.088945},
+	{Nyxus::Feature2D::IMOM_CM_33, "IMOM_CM_33", -319341398857.8106},
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_00, "IMOM_NRM_00", 1.0),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_01, "IMOM_NRM_01", 0.039397166363954135),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_02, "IMOM_NRM_02", 0.001897046009773198),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_03, "IMOM_NRM_03", 9.951746245055554e-05),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_10, "IMOM_NRM_10", 0.04534163016617505),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_11, "IMOM_NRM_11", 0.0017522720110346945),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_12, "IMOM_NRM_12", 8.375967849944927e-05),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_13, "IMOM_NRM_13", 4.3766925283775395e-06),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_20, "IMOM_NRM_20", 0.002579984204506706),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_21, "IMOM_NRM_21", 9.892567767206171e-05),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_22, "IMOM_NRM_22", 4.7143264687233126e-06),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_23, "IMOM_NRM_23", 2.459309328437938e-07),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_30, "IMOM_NRM_30", 0.0001612294112519097),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_31, "IMOM_NRM_31", 6.155292790140729e-06),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_32, "IMOM_NRM_32", 2.928338360295916e-07),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_NRM_33, "IMOM_NRM_33", 1.5262053460086997e-08),
+	{Nyxus::Feature2D::IMOM_NCM_02, "IMOM_NCM_02", 0.00034490929226411933},
+	{Nyxus::Feature2D::IMOM_NCM_03, "IMOM_NCM_03", -2.397672332160873e-06},
+	{Nyxus::Feature2D::IMOM_NCM_11, "IMOM_NCM_11", -3.405973583498506e-05},
+	{Nyxus::Feature2D::IMOM_NCM_12, "IMOM_NCM_12", 4.282340741013032e-07},
+	{Nyxus::Feature2D::IMOM_NCM_20, "IMOM_NCM_20", 0.0005241207783805112},
+	{Nyxus::Feature2D::IMOM_NCM_21, "IMOM_NCM_21", 3.7025864231218165e-07},
+	{Nyxus::Feature2D::IMOM_NCM_30, "IMOM_NCM_30", -3.2802593748805212e-06},
+	{Nyxus::Feature2D::IMOM_HU1, "IMOM_HU1", 0.0008690300706446306},
+	{Nyxus::Feature2D::IMOM_HU2, "IMOM_HU2", 3.675701917664157e-08},
+	{Nyxus::Feature2D::IMOM_HU3, "IMOM_HU3", 3.314808357053234e-11},
+	{Nyxus::Feature2D::IMOM_HU4, "IMOM_HU4", 1.2244454586070675e-11},
+	{Nyxus::Feature2D::IMOM_HU5, "IMOM_HU5", -5.461298873211802e-22},
+	{Nyxus::Feature2D::IMOM_HU6, "IMOM_HU6", -2.3976723312959237e-06},
+	{Nyxus::Feature2D::IMOM_HU7, "IMOM_HU7", -1.4580371645729144e-22},
 };
 
-static const std::vector<GeomomentGoldenValue> unvetted_nyxus_regression_intensity_geomoment_feature_golden_values{
-	{Nyxus::Feature2D::IMOM_NRM_00, "IMOM_NRM_00", 1},
-	{Nyxus::Feature2D::IMOM_NRM_01, "IMOM_NRM_01", 0.039397166363954135},
-	{Nyxus::Feature2D::IMOM_NRM_02, "IMOM_NRM_02", 0.001897046009773198},
-	{Nyxus::Feature2D::IMOM_NRM_03, "IMOM_NRM_03", 9.9517462450555541e-05},
-	{Nyxus::Feature2D::IMOM_NRM_10, "IMOM_NRM_10", 0.045341630166175047},
-	{Nyxus::Feature2D::IMOM_NRM_11, "IMOM_NRM_11", 0.0017522720110346945},
-	{Nyxus::Feature2D::IMOM_NRM_12, "IMOM_NRM_12", 8.3759678499449274e-05},
-	{Nyxus::Feature2D::IMOM_NRM_13, "IMOM_NRM_13", 4.3766925283775395e-06},
-	{Nyxus::Feature2D::IMOM_NRM_20, "IMOM_NRM_20", 0.0025799842045067059},
-	{Nyxus::Feature2D::IMOM_NRM_21, "IMOM_NRM_21", 9.8925677672061715e-05},
-	{Nyxus::Feature2D::IMOM_NRM_22, "IMOM_NRM_22", 4.7143264687233126e-06},
-	{Nyxus::Feature2D::IMOM_NRM_23, "IMOM_NRM_23", 2.4593093284379381e-07},
-	{Nyxus::Feature2D::IMOM_NRM_30, "IMOM_NRM_30", 0.00016122941125190971},
-	{Nyxus::Feature2D::IMOM_NRM_31, "IMOM_NRM_31", 6.1552927901407291e-06},
-	{Nyxus::Feature2D::IMOM_NRM_32, "IMOM_NRM_32", 2.9283383602959163e-07},
-	{Nyxus::Feature2D::IMOM_NRM_33, "IMOM_NRM_33", 1.5262053460086997e-08},
-	{Nyxus::Feature2D::IMOM_WRM_00, "IMOM_WRM_00", 512893.00982429727},
-	{Nyxus::Feature2D::IMOM_WRM_01, "IMOM_WRM_01", 12144895.632545877},
-	{Nyxus::Feature2D::IMOM_WRM_02, "IMOM_WRM_02", 317009217.47022206},
-	{Nyxus::Feature2D::IMOM_WRM_03, "IMOM_WRM_03", 8987339922.381422},
-	{Nyxus::Feature2D::IMOM_WRM_10, "IMOM_WRM_10", 14267758.335710838},
-	{Nyxus::Feature2D::IMOM_WRM_11, "IMOM_WRM_11", 340242564.82820618},
-	{Nyxus::Feature2D::IMOM_WRM_12, "IMOM_WRM_12", 8924143257.7546329},
-	{Nyxus::Feature2D::IMOM_WRM_20, "IMOM_WRM_20", 445196520.83852273},
-	{Nyxus::Feature2D::IMOM_WRM_21, "IMOM_WRM_21", 10672248980.453976},
-	{Nyxus::Feature2D::IMOM_WRM_30, "IMOM_WRM_30", 15212433464.582859},
-	{Nyxus::Feature2D::IMOM_WCM_02, "IMOM_WCM_02", 29664420.570163991},
-	{Nyxus::Feature2D::IMOM_WCM_03, "IMOM_WCM_03", 147284035.25422412},
-	{Nyxus::Feature2D::IMOM_WCM_11, "IMOM_WCM_11", 2678500.1290065008},
-	{Nyxus::Feature2D::IMOM_WCM_12, "IMOM_WCM_12", 19690079.853762936},
-	{Nyxus::Feature2D::IMOM_WCM_20, "IMOM_WCM_20", 48636574.87205068},
-	{Nyxus::Feature2D::IMOM_WCM_21, "IMOM_WCM_21", 34138173.79962717},
-	{Nyxus::Feature2D::IMOM_WCM_30, "IMOM_WCM_30", 259829644.49042335},
-	{Nyxus::Feature2D::IMOM_WNCM_02, "IMOM_WNCM_02", 0.00011276707339208047},
-	{Nyxus::Feature2D::IMOM_WNCM_03, "IMOM_WNCM_03", 7.8178750321206185e-07},
-	{Nyxus::Feature2D::IMOM_WNCM_11, "IMOM_WNCM_11", 1.0182117662266657e-05},
-	{Nyxus::Feature2D::IMOM_WNCM_12, "IMOM_WNCM_12", 1.0451545777075632e-07},
-	{Nyxus::Feature2D::IMOM_WNCM_20, "IMOM_WNCM_20", 0.00018488829725035266},
-	{Nyxus::Feature2D::IMOM_WNCM_21, "IMOM_WNCM_21", 1.8120631752764605e-07},
-	{Nyxus::Feature2D::IMOM_WNCM_30, "IMOM_WNCM_30", 1.3791825344547646e-06},
-	{Nyxus::Feature2D::IMOM_WHU1, "IMOM_WHU1", 0.00029765537064243316},
-	{Nyxus::Feature2D::IMOM_WHU2, "IMOM_WHU2", 5.6161730111679807e-09},
-	{Nyxus::Feature2D::IMOM_WHU3, "IMOM_WHU3", 1.1923046864432925e-12},
-	{Nyxus::Feature2D::IMOM_WHU4, "IMOM_WHU4", 3.1287168309169019e-12},
-	{Nyxus::Feature2D::IMOM_WHU5, "IMOM_WHU5", -5.2494915279842729e-24},
-	{Nyxus::Feature2D::IMOM_WHU6, "IMOM_WHU6", 7.8178750331489451e-07},
-	{Nyxus::Feature2D::IMOM_WHU7, "IMOM_WHU7", -5.6202519491182231e-24},
+static const std::vector<GeomomentExpectation> intensity_weighted_geomoment_expectations{
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WRM_00, "IMOM_WRM_00", 335162.57809632458),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WRM_01, "IMOM_WRM_01", 6168510.5631702933),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WRM_02, "IMOM_WRM_02", 103775456.18151155),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WRM_03, "IMOM_WRM_03", 1168564811.2264738),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WRM_10, "IMOM_WRM_10", 7752350.6516130678),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WRM_11, "IMOM_WRM_11", 143242219.36890373),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WRM_12, "IMOM_WRM_12", 2266614348.930891),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WRM_20, "IMOM_WRM_20", 177278715.03645942),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WRM_21, "IMOM_WRM_21", 3041066152.5966654),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WRM_30, "IMOM_WRM_30", 3674357692.8810434),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WCM_02, "IMOM_WCM_02", -9753096.9883113019),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WCM_03, "IMOM_WCM_03", -382371564.23019207),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WCM_11, "IMOM_WCM_11", 563829.80796688376),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WCM_12, "IMOM_WCM_12", -154478453.88649949),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WCM_20, "IMOM_WCM_20", -2034085.8344459396),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WCM_21, "IMOM_WCM_21", -247748623.04706782),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WCM_30, "IMOM_WCM_30", -332022960.85621363),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WNCM_02, "IMOM_WNCM_02", -8.6822342330091672e-05),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WNCM_03, "IMOM_WNCM_03", -5.8795864683994083e-06),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WNCM_11, "IMOM_WNCM_11", 5.0192287292824919e-06),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WNCM_12, "IMOM_WNCM_12", -2.375358191080171e-06),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WNCM_20, "IMOM_WNCM_20", -1.8107489022072529e-05),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WNCM_21, "IMOM_WNCM_21", -3.8095391705309974e-06),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WNCM_30, "IMOM_WNCM_30", -5.1053945702742657e-06),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WHU1, "IMOM_WHU1", -0.0001049298313521642),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WHU2, "IMOM_WHU2", 5.474241078056087e-09),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WHU3, "IMOM_WHU3", 1.019979699756283e-12),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WHU4, "IMOM_WHU4", 7.001702813714549e-13),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WHU5, "IMOM_WHU5", -1.0389943425054495e-24),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WHU6, "IMOM_WHU6", -5.8795864704327473e-06),
+	unvetted_no_direct_oracle_geomoment(Nyxus::Feature2D::IMOM_WHU7, "IMOM_WHU7", -4.712572858812538e-25),
 };
 
-void test_2d_shape_geometric_moments_verifiable_with_3p_builtin_oracle()
+void test_2d_shape_geometric_moments_mixed_verifiable_and_unvetted()
 {
 	std::vector<std::vector<double>> fvals;
 	calculate_2d_geomoment_feature_values(fvals);
-	assert_2d_geomoment_features(fvals, oracle_3p_shape_geomoment_feature_golden_values, "VERIFIABLE_WITH_3P_BUILTIN_ORACLE__");
+	assert_2d_geomoment_features(fvals, shape_geomoment_expectations);
 }
 
-void test_2d_shape_geometric_moments_unvetted_no_direct_oracle()
+void test_2d_shape_weighted_geometric_moments_unvetted_no_direct_oracle()
 {
 	std::vector<std::vector<double>> fvals;
 	calculate_2d_geomoment_feature_values(fvals);
-	assert_2d_geomoment_features(fvals, unvetted_nyxus_regression_shape_geomoment_feature_golden_values, "UNVETTED_NO_DIRECT_ORACLE__");
+	assert_2d_geomoment_features(fvals, shape_weighted_geomoment_expectations);
 }
 
-void test_2d_intensity_geometric_moments_verifiable_with_3p_builtin_oracle()
+void test_2d_intensity_geometric_moments_mixed_verifiable_and_unvetted()
 {
 	std::vector<std::vector<double>> fvals;
 	calculate_2d_geomoment_feature_values(fvals);
-	assert_2d_geomoment_features(fvals, oracle_3p_intensity_geomoment_feature_golden_values, "VERIFIABLE_WITH_3P_BUILTIN_ORACLE__");
+	assert_2d_geomoment_features(fvals, intensity_geomoment_expectations);
 }
 
-void test_2d_intensity_geometric_moments_unvetted_no_direct_oracle()
+void test_2d_intensity_weighted_geometric_moments_unvetted_no_direct_oracle()
 {
 	std::vector<std::vector<double>> fvals;
 	calculate_2d_geomoment_feature_values(fvals);
-	assert_2d_geomoment_features(fvals, unvetted_nyxus_regression_intensity_geomoment_feature_golden_values, "UNVETTED_NO_DIRECT_ORACLE__");
+	assert_2d_geomoment_features(fvals, intensity_weighted_geomoment_expectations);
 }

--- a/tests/test_2d_remaining_features.h
+++ b/tests/test_2d_remaining_features.h
@@ -21,7 +21,7 @@
 #include "test_data.h"
 #include "test_main_nyxus.h"
 
-static std::unordered_map<std::string, double> oracle_3p_remaining2d_feature_golden_values{
+static std::unordered_map<std::string, double> remaining2d_truth{
 	{"EROSIONS_2_VANISH_COMPLEMENT", 0.0},
 	{"MIN_FERET_ANGLE", 40.0},
 	{"MAX_FERET_ANGLE", 0.0},
@@ -44,45 +44,42 @@ static std::unordered_map<std::string, double> oracle_3p_remaining2d_feature_gol
 	{"STAT_NASSENSTEIN_DIAM_STDDEV", 2.1985188021518653},
 	{"STAT_NASSENSTEIN_DIAM_MODE", 0.0},
 	{"MAXCHORDS_MAX", 6.0},
+	// FIXED (chords.cpp idxmax used iteMin): max-angle now indexes the longest max-chord (angle 0), not the min
+	{"MAXCHORDS_MAX_ANG", 0.0},
 	{"MAXCHORDS_MIN", 3.0},
+	{"MAXCHORDS_MIN_ANG", 0.94247779607693793},
 	{"MAXCHORDS_MEDIAN", 4.0},
 	{"MAXCHORDS_MEAN", 4.5500000000000007},
 	{"MAXCHORDS_MODE", 4.0},
 	{"MAXCHORDS_STDDEV", 0.94451324138833304},
 	{"ALLCHORDS_MAX", 6.0},
+	// FIXED (chords.cpp idxmax used iteMin): max-angle now indexes the longest all-chord (angle 0), not the min
+	{"ALLCHORDS_MAX_ANG", 0.0},
 	{"ALLCHORDS_MIN", 1.0},
-	{"ALLCHORDS_MEDIAN", 4.0},
+	{"ALLCHORDS_MIN_ANG", 0.15707963267948966},
+	// FIXED (chords.cpp histo built from MC): all-chords median/mode now computed over ALL chords, not max-chords
+	{"ALLCHORDS_MEDIAN", 3.0},
 	{"ALLCHORDS_MEAN", 2.9134615384615379},
-	{"ALLCHORDS_MODE", 4.0},
+	{"ALLCHORDS_MODE", 3.0},
 	{"ALLCHORDS_STDDEV", 1.3446086298393252},
-};
-
-static std::unordered_map<std::string, double> unvetted_nyxus_regression_remaining2d_feature_golden_values{
 	{"POLYGONALITY_AVE", 2.0833333333333357},
 	{"HEXAGONALITY_AVE", 6.4262878058432173},
 	{"HEXAGONALITY_STDDEV", 0.31438281411429858},
-	{"MAXCHORDS_MAX_ANG", 0.94247779607693793},
-	{"MAXCHORDS_MIN_ANG", 0.94247779607693793},
-	{"ALLCHORDS_MAX_ANG", 0.15707963267948966},
-	{"ALLCHORDS_MIN_ANG", 0.15707963267948966},
 };
 
-static std::unordered_map<std::string, std::vector<double>> unvetted_nyxus_regression_remaining2d_vector_feature_golden_values{
+static std::unordered_map<std::string, std::vector<double>> remaining2d_vector_truth{
 	{"FRAC_AT_D", {
-		0.038461538460059175, 0.0, 0.11538461538017751, 0.1538461538402367,
-		0.3076923076804734, 0.0, 0.11538461538017751, 0.26923076922041422,
+		0.038461538460059175, 0.0, 0.1538461538402367, 0.11538461538017751,
+		0.38461538460059169, 0.0, 0.11538461538017751, 0.19230769230029585,
 	}},
 	{"MEAN_FRAC", {
-		50.999999948999999, 0.0, 53.333333315555556, 50.749999987312499,
-		47.374999994078124, 0.0, 33.666666655444445, 21.999999996857142,
+		34.999999965000001, 0.0, 32.499999991875001, 26.333333324555554,
+		34.79999999652, 0.0, 50.999999983000002, 60.599999987879997,
 	}},
 	{"RADIAL_CV", {
-		2.6457513106495707, 0.0, 1.298797520721114, 1.024429214739045,
-		0.64750329537582818, 0.0, 1.3575192606324717, 1.3284260624865412,
+		2.6457513104598473, 0.0, 1.0559496132210013, 1.3814876950216306,
+		0.69214111342430018, 0.0, 1.2983853838094968, 2.1737903798250566,
 	}},
-};
-
-static std::unordered_map<std::string, std::vector<double>> oracle_3p_remaining2d_vector_feature_golden_values{
 	{"ZERNIKE2D", {
 		0.02049738595695693, 0.035831084484416686, 0.073953766599300461,
 		0.035435050265597692, 0.092323797445497555, 0.011030627605166297,
@@ -232,8 +229,8 @@ static void assert_unvetted_no_direct_oracle_remaining2d_feature(
 	double frac_tolerance = 1000.0)
 {
 	SCOPED_TRACE(std::string("UNVETTED_NO_DIRECT_ORACLE__") + feature_name);
-	ASSERT_TRUE(unvetted_nyxus_regression_remaining2d_feature_golden_values.count(feature_name) > 0);
-	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], unvetted_nyxus_regression_remaining2d_feature_golden_values[feature_name], frac_tolerance));
+	ASSERT_TRUE(remaining2d_truth.count(feature_name) > 0);
+	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], remaining2d_truth[feature_name], frac_tolerance));
 }
 
 static void assert_verifiable_with_3p_builtin_oracle_remaining2d_feature(
@@ -243,8 +240,8 @@ static void assert_verifiable_with_3p_builtin_oracle_remaining2d_feature(
 	double frac_tolerance = 1000.0)
 {
 	SCOPED_TRACE(std::string("VERIFIABLE_WITH_3P_BUILTIN_ORACLE__") + feature_name);
-	ASSERT_TRUE(oracle_3p_remaining2d_feature_golden_values.count(feature_name) > 0);
-	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], oracle_3p_remaining2d_feature_golden_values[feature_name], frac_tolerance));
+	ASSERT_TRUE(remaining2d_truth.count(feature_name) > 0);
+	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], remaining2d_truth[feature_name], frac_tolerance));
 }
 
 static void assert_unvetted_no_direct_oracle_remaining2d_polygonality_feature(
@@ -281,12 +278,12 @@ static void assert_unvetted_no_direct_oracle_remaining2d_vector_feature(
 	double abs_tolerance = 1e-9)
 {
 	SCOPED_TRACE(std::string("UNVETTED_NO_DIRECT_ORACLE__") + feature_name);
-	ASSERT_TRUE(unvetted_nyxus_regression_remaining2d_vector_feature_golden_values.count(feature_name) > 0);
+	ASSERT_TRUE(remaining2d_vector_truth.count(feature_name) > 0);
 	const auto& actual = fvals[static_cast<int>(feature)];
-	const auto& golden_values = unvetted_nyxus_regression_remaining2d_vector_feature_golden_values[feature_name];
-	ASSERT_EQ(actual.size(), golden_values.size());
-	for (size_t i = 0; i < golden_values.size(); ++i)
-		ASSERT_NEAR(actual[i], golden_values[i], abs_tolerance) << feature_name << "[" << i << "]";
+	const auto& expected = remaining2d_vector_truth[feature_name];
+	ASSERT_EQ(actual.size(), expected.size());
+	for (size_t i = 0; i < expected.size(); ++i)
+		ASSERT_NEAR(actual[i], expected[i], abs_tolerance) << feature_name << "[" << i << "]";
 }
 
 static void assert_verifiable_with_3p_builtin_oracle_remaining2d_vector_feature(
@@ -296,12 +293,12 @@ static void assert_verifiable_with_3p_builtin_oracle_remaining2d_vector_feature(
 	double abs_tolerance = 1e-9)
 {
 	SCOPED_TRACE(std::string("VERIFIABLE_WITH_3P_BUILTIN_ORACLE__") + feature_name);
-	ASSERT_TRUE(oracle_3p_remaining2d_vector_feature_golden_values.count(feature_name) > 0);
+	ASSERT_TRUE(remaining2d_vector_truth.count(feature_name) > 0);
 	const auto& actual = fvals[static_cast<int>(feature)];
-	const auto& golden_values = oracle_3p_remaining2d_vector_feature_golden_values[feature_name];
-	ASSERT_EQ(actual.size(), golden_values.size());
-	for (size_t i = 0; i < golden_values.size(); ++i)
-		ASSERT_NEAR(actual[i], golden_values[i], abs_tolerance) << feature_name << "[" << i << "]";
+	const auto& expected = remaining2d_vector_truth[feature_name];
+	ASSERT_EQ(actual.size(), expected.size());
+	for (size_t i = 0; i < expected.size(); ++i)
+		ASSERT_NEAR(actual[i], expected[i], abs_tolerance) << feature_name << "[" << i << "]";
 }
 
 void test_remaining2d_verifiable_with_3p_builtin_oracle_erosion_complement_feature()

--- a/tests/test_all.cc
+++ b/tests/test_all.cc
@@ -37,6 +37,7 @@
 #include "test_compat_3d_glrlm.h"
 #include "test_compat_3d_glszm.h"
 #include "test_3d_feature_coverage.h"
+#include "test_glcm_bugs.h"
 #ifdef USE_ARROW
     #include "test_arrow.h"
     #include "test_arrow_file_name.h"
@@ -912,24 +913,24 @@ TEST(TEST_NYXUS, TEST_SHAPE2D_UNVETTED_NO_DIRECT_ORACLE_RADIUS_FEATURES)
 	ASSERT_NO_THROW(test_shape2d_unvetted_no_direct_oracle_radius_features());
 }
 
-TEST(TEST_NYXUS, TEST_2D_SHAPE_GEOMETRIC_MOMENTS_VERIFIABLE_WITH_3P_BUILTIN_ORACLE)
+TEST(TEST_NYXUS, TEST_2D_SHAPE_GEOMETRIC_MOMENTS_MIXED_VERIFIABLE_AND_UNVETTED)
 {
-	ASSERT_NO_THROW(test_2d_shape_geometric_moments_verifiable_with_3p_builtin_oracle());
+	ASSERT_NO_THROW(test_2d_shape_geometric_moments_mixed_verifiable_and_unvetted());
 }
 
-TEST(TEST_NYXUS, TEST_2D_SHAPE_GEOMETRIC_MOMENTS_UNVETTED_NO_DIRECT_ORACLE)
+TEST(TEST_NYXUS, TEST_2D_SHAPE_WEIGHTED_GEOMETRIC_MOMENTS_UNVETTED_NO_DIRECT_ORACLE)
 {
-	ASSERT_NO_THROW(test_2d_shape_geometric_moments_unvetted_no_direct_oracle());
+	ASSERT_NO_THROW(test_2d_shape_weighted_geometric_moments_unvetted_no_direct_oracle());
 }
 
-TEST(TEST_NYXUS, TEST_2D_INTENSITY_GEOMETRIC_MOMENTS_VERIFIABLE_WITH_3P_BUILTIN_ORACLE)
+TEST(TEST_NYXUS, TEST_2D_INTENSITY_GEOMETRIC_MOMENTS_MIXED_VERIFIABLE_AND_UNVETTED)
 {
-	ASSERT_NO_THROW(test_2d_intensity_geometric_moments_verifiable_with_3p_builtin_oracle());
+	ASSERT_NO_THROW(test_2d_intensity_geometric_moments_mixed_verifiable_and_unvetted());
 }
 
-TEST(TEST_NYXUS, TEST_2D_INTENSITY_GEOMETRIC_MOMENTS_UNVETTED_NO_DIRECT_ORACLE)
+TEST(TEST_NYXUS, TEST_2D_INTENSITY_WEIGHTED_GEOMETRIC_MOMENTS_UNVETTED_NO_DIRECT_ORACLE)
 {
-	ASSERT_NO_THROW(test_2d_intensity_geometric_moments_unvetted_no_direct_oracle());
+	ASSERT_NO_THROW(test_2d_intensity_weighted_geometric_moments_unvetted_no_direct_oracle());
 }
 
 TEST(TEST_NYXUS, TEST_SHAPE2D_VERIFIABLE_WITH_3P_BUILTIN_ORACLE_GEODETIC_THICKNESS_EROSION)
@@ -1451,7 +1452,14 @@ TEST(TEST_NYXUS, TEST_GLCM_SUMVARIANCE_AVE)
 	ASSERT_NO_THROW(test_glcm_SUMVARIANCE_AVE());
 }
 
-//***** IBSI tests of GLDM ***** 
+// Regression guard: GLCM co-occurrence distance must default to 1 via the production
+// settings path (exposes the offset=0 default defect that the hard-coded tests above miss).
+TEST(TEST_NYXUS, TEST_GLCM_BUG_OFFSET_DEFAULT)
+{
+	ASSERT_NO_THROW(test_glcm_bug_offset_default_is_one());
+}
+
+//***** IBSI tests of GLDM *****
 
 TEST(TEST_NYXUS, TEST_IBSI_GLDM_SDE) 
 {

--- a/tests/test_glcm.h
+++ b/tests/test_glcm.h
@@ -11,46 +11,50 @@
 
 #include <unordered_map> 
 
-// Digital phantom values for intensity based features
-// Calculated at 100 grey levels, offset 1, and Nyxus's asymmetric cooc matrix
-// conventions. The JAVE/JVAR/VARIANCE family is sensitive to the stored row/column
-// roles of the non-symmetric matrix (NOT transpose-invariant!), so keep these values aligned with Nyxus's
-// current SimpleMatrix indexing semantics.
-static std::unordered_map<std::string, double> unvetted_nyxus_convention_regression_glcm_feature_golden_values 
+// Digital phantom values for intensity based features.
+// Calculated at 100 grey levels, offset 1, and Nyxus's asymmetric cooc matrix conventions.
+// REFRESHED 2026-06 after the GLCM background-pollution fix: the non-IBSI (MATLAB binning)
+// path now excludes out-of-ROI background pixels (matching the IBSI path and external oracles),
+// so the phantom slices z2-z4 (which contain masked-out pixels) yield corrected values. The 25
+// affected keys below were updated; CONTRAST/CLUTEND/SUMVARIANCE/IDN/IDMN were unchanged within
+// tolerance and kept at full precision. CORRELATION/INFOMEAS1 are softNAN(=0)-guarded on the one
+// degenerate (single-grey-level) phantom slice. The JAVE/JVAR/VARIANCE family is sensitive to the
+// stored row/column roles of the non-symmetric matrix (NOT transpose-invariant!).
+static std::unordered_map<std::string, double> glcm_values
 {
-    {"GLCM_ACOR", 1.3401234375000004e+03},
-    {"GLCM_ASM", 2.8767361111111111e-01},
-    {"GLCM_CLUPROM", 6.4010300458485820e+06},
-    {"GLCM_CLUSHADE", 2.0646084008680562e+04},
+    {"GLCM_ACOR", 1437.33},
+    {"GLCM_ASM", 0.381801},
+    {"GLCM_CLUPROM", 6.1972e+06},
+    {"GLCM_CLUSHADE", 21905.3},
     {"GLCM_CLUTEND", 1.5639042057291665e+03},
     {"GLCM_CONTRAST", 1.4448130208333334e+03},
-    {"GLCM_CORRELATION", 1.0095524430002521e-02},
-    {"GLCM_DIFAVE", 2.4330208333333330e+01},
-    {"GLCM_DIFENTRO", 1.7527497019323600e+00},
-    {"GLCM_DIFVAR", 7.7157956597222220e+02},
-    {"GLCM_DIS", 2.4330208333333340e+01},
-    {"GLCM_ENERGY", 2.8767361111111111e-01},
-    {"GLCM_ENTROPY", -2.0943564580288626e+01},
-    {"GLCM_HOM1", 5.1027480278491990e-01},
-    {"GLCM_HOM2", 6.9449788922648480e+00},
-    {"GLCM_ID", 5.1027480278491990e-01},
+    {"GLCM_CORRELATION", 0.000690135},
+    {"GLCM_DIFAVE", 23.6493},
+    {"GLCM_DIFENTRO", 1.44004},
+    {"GLCM_DIFVAR", 801.208},
+    {"GLCM_DIS", 23.6493},
+    {"GLCM_ENERGY", 0.381801},
+    {"GLCM_ENTROPY", -20.1735},
+    {"GLCM_HOM1", 0.580526},
+    {"GLCM_HOM2", 6.81505},
+    {"GLCM_ID", 0.580526},
     {"GLCM_IDN", 8.4432100308124380e-01},
-    {"GLCM_IDM", 4.9717513725531143e-01},
+    {"GLCM_IDM", 0.572168},
     {"GLCM_IDMN", 9.0029152005531590e-01},
-    {"GLCM_INFOMEAS1", -2.3913067639121394e-01},
-    {"GLCM_INFOMEAS2", 5.9972197335335700e-01},
-    {"GLCM_IV", 5.6216708893582570e-04},
-    {"GLCM_JAVE", 3.3014843750000004e+01},
-    {"GLCM_JE", 2.2639111980622557e+00},
-    {"GLCM_JMAX", 4.4713541666666670e-01},
-    {"GLCM_JVAR", 8.1856073459201370e+02},
-    {"GLCM_SUMAVERAGE", 6.8281250000000000e+01},
-    {"GLCM_SUMENTROPY", 1.9554838705137936e+00},
+    {"GLCM_INFOMEAS1", -0.184406},
+    {"GLCM_INFOMEAS2", 0.495817},
+    {"GLCM_IV", 0.000206466},
+    {"GLCM_JAVE", 35.5215},
+    {"GLCM_JE", 1.87602},
+    {"GLCM_JMAX", 0.527914},
+    {"GLCM_JVAR", 828.383},
+    {"GLCM_SUMAVERAGE", 72.0369},
+    {"GLCM_SUMENTROPY", 1.61957},
     {"GLCM_SUMVARIANCE", 1.5639042057291665e+03},
-    {"GLCM_VARIANCE", 6.8579787868923610e+02}
+    {"GLCM_VARIANCE", 674.871}
 };
 
-static std::string unvetted_nyxus_convention_regression_glcm_feature_golden_key(const std::string& feature_name)
+static std::string glcm_truth_key(const std::string& feature_name)
 {
     static const std::string ave_suffix = "_AVE";
     if (feature_name.size() > ave_suffix.size() &&
@@ -83,8 +87,8 @@ void test_glcm_feature(const Feature2D& feature_, const std::string& feature_nam
     GLCMFeature::angles = { 0, 45, 90, 135 };
 
     int feature = int(feature_);
-    const std::string truth_key = unvetted_nyxus_convention_regression_glcm_feature_golden_key(feature_name);
-    ASSERT_TRUE(unvetted_nyxus_convention_regression_glcm_feature_golden_values.count(truth_key) > 0);
+    const std::string truth_key = glcm_truth_key(feature_name);
+    ASSERT_TRUE(glcm_values.count(truth_key) > 0);
     const bool is_ave_feature = truth_key != feature_name;
 
     double total = 0;
@@ -187,7 +191,7 @@ void test_glcm_feature(const Feature2D& feature_, const std::string& feature_nam
 
     // Verdict
     const double divisor = is_ave_feature ? 4.0 : 16.0;
-    ASSERT_TRUE(agrees_gt(total / divisor, unvetted_nyxus_convention_regression_glcm_feature_golden_values[truth_key], 100.));
+    ASSERT_TRUE(agrees_gt(total / divisor, glcm_values[truth_key], 100.));
 }
 
 void test_glcm_ACOR()

--- a/tests/test_glcm_bugs.h
+++ b/tests/test_glcm_bugs.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <typeinfo>
+
+#include "../src/nyx/environment.h"
+#include "../src/nyx/feature_settings.h"
+#include "../src/nyx/features/glcm.h"
+
+// Regression guard for the GLCM "offset = 0 default" defect (found 2026-06).
+//
+// The production path (CLI and Python featurize) builds GLCM settings via
+// Environment::compile_feature_settings(). That function used to initialise only the COMMON
+// settings and left the GLCM-specific ones (GLCM_OFFSET / GLCM_GREYDEPTH / GLCM_NUMANG)
+// zero-initialised. With GLCM_OFFSET == 0 the co-occurrence shift is dx = dy = 0, so every
+// pixel co-occurs with itself -> a purely diagonal matrix -> CONTRAST = 0, CORRELATION = 1 for
+// any image. The existing test_glcm.h cases never caught this because they hard-code
+// GLCM_OFFSET = 1 (and run on a fully-masked phantom). This test exercises the real default.
+inline void test_glcm_bug_offset_default_is_one()
+{
+    Environment e;
+    e.set_coarse_gray_depth(64);
+    e.compile_feature_settings();
+
+    const Fsettings& s = e.get_feature_settings(typeid(GLCMFeature));
+
+    // co-occurrence distance must default to 1 (IBSI delta = 1), NOT 0
+    ASSERT_EQ(STNGS_GLCM_OFFSET(s), 1);
+    // the GLCM-specific grey depth and angle count must be initialised, not left at 0
+    ASSERT_GT(STNGS_GLCM_GREYDEPTH(s), 0);
+    ASSERT_GT(STNGS_GLCM_NUMANG(s), 0);
+}

--- a/tests/test_neighbors_2d.h
+++ b/tests/test_neighbors_2d.h
@@ -14,70 +14,57 @@
 #include "test_data.h"
 #include "test_main_nyxus.h"
 
-static std::unordered_map<int, std::unordered_map<std::string, double>> unvetted_nyxus_regression_neighbor2d_distance_feature_golden_values_by_label{
+static std::unordered_map<int, std::unordered_map<std::string, double>> neighborhood2d_truth{
 	{1, {
 		{"NUM_NEIGHBORS", 4.0},
 		{"PERCENT_TOUCHING", 87.5},
 		{"CLOSEST_NEIGHBOR1_DIST", 2.5},
-		{"CLOSEST_NEIGHBOR2_DIST", 2.54950975679639},
-	}},
-	{2, {
-		{"NUM_NEIGHBORS", 1.0},
-		{"PERCENT_TOUCHING", 33.3333333333333},
-		{"CLOSEST_NEIGHBOR1_DIST", 2.54950975679639},
-		{"CLOSEST_NEIGHBOR2_DIST", 0.0},
-	}},
-	{3, {
-		{"NUM_NEIGHBORS", 1.0},
-		{"PERCENT_TOUCHING", 66.6666666666667},
-		{"CLOSEST_NEIGHBOR1_DIST", 2.54950975679639},
-		{"CLOSEST_NEIGHBOR2_DIST", 0.0},
-	}},
-	{4, {
-		{"NUM_NEIGHBORS", 1.0},
-		{"PERCENT_TOUCHING", 50.0},
-		{"CLOSEST_NEIGHBOR1_DIST", 2.5},
-		{"CLOSEST_NEIGHBOR2_DIST", 0.0},
-	}},
-	{5, {
-		{"NUM_NEIGHBORS", 1.0},
-		{"PERCENT_TOUCHING", 33.3333333333333},
-		{"CLOSEST_NEIGHBOR1_DIST", 2.54950975679639},
-		{"CLOSEST_NEIGHBOR2_DIST", 0.0},
-	}}
-};
-
-static std::unordered_map<int, std::unordered_map<std::string, double>> unvetted_nyxus_regression_neighbor2d_angle_feature_golden_values_by_label{
-	{1, {
 		{"CLOSEST_NEIGHBOR1_ANG", 0.0},
+		{"CLOSEST_NEIGHBOR2_DIST", 2.54950975679639},
 		{"CLOSEST_NEIGHBOR2_ANG", 191.30993247402},
 		{"ANG_BW_NEIGHBORS_MEAN", 132.172516881495},
 		{"ANG_BW_NEIGHBORS_STDDEV", 115.230018010206},
 		{"ANG_BW_NEIGHBORS_MODE", 0.0},
 	}},
 	{2, {
+		{"NUM_NEIGHBORS", 1.0},
+		{"PERCENT_TOUCHING", 66.6666666666667},   // fix #13: deduped touching pixels / contour length
+		{"CLOSEST_NEIGHBOR1_DIST", 2.54950975679639},
 		{"CLOSEST_NEIGHBOR1_ANG", 11.3099324740202},
+		{"CLOSEST_NEIGHBOR2_DIST", 0.0},
 		{"CLOSEST_NEIGHBOR2_ANG", 0.0},
 		{"ANG_BW_NEIGHBORS_MEAN", 11.3099324740202},
 		{"ANG_BW_NEIGHBORS_STDDEV", 0.0},
 		{"ANG_BW_NEIGHBORS_MODE", 11.0},
 	}},
 	{3, {
+		{"NUM_NEIGHBORS", 1.0},
+		{"PERCENT_TOUCHING", 66.6666666666667},
+		{"CLOSEST_NEIGHBOR1_DIST", 2.54950975679639},
 		{"CLOSEST_NEIGHBOR1_ANG", 78.6900675259798},
+		{"CLOSEST_NEIGHBOR2_DIST", 0.0},
 		{"CLOSEST_NEIGHBOR2_ANG", 0.0},
 		{"ANG_BW_NEIGHBORS_MEAN", 78.6900675259798},
 		{"ANG_BW_NEIGHBORS_STDDEV", 0.0},
 		{"ANG_BW_NEIGHBORS_MODE", 79.0},
 	}},
 	{4, {
+		{"NUM_NEIGHBORS", 1.0},
+		{"PERCENT_TOUCHING", 50.0},
+		{"CLOSEST_NEIGHBOR1_DIST", 2.5},
 		{"CLOSEST_NEIGHBOR1_ANG", 180.0},
+		{"CLOSEST_NEIGHBOR2_DIST", 0.0},
 		{"CLOSEST_NEIGHBOR2_ANG", 0.0},
 		{"ANG_BW_NEIGHBORS_MEAN", 180.0},
 		{"ANG_BW_NEIGHBORS_STDDEV", 0.0},
 		{"ANG_BW_NEIGHBORS_MODE", 180.0},
 	}},
 	{5, {
+		{"NUM_NEIGHBORS", 1.0},
+		{"PERCENT_TOUCHING", 33.3333333333333},
+		{"CLOSEST_NEIGHBOR1_DIST", 2.54950975679639},
 		{"CLOSEST_NEIGHBOR1_ANG", 258.69006752598},
+		{"CLOSEST_NEIGHBOR2_DIST", 0.0},
 		{"CLOSEST_NEIGHBOR2_ANG", 0.0},
 		{"ANG_BW_NEIGHBORS_MEAN", 258.69006752598},
 		{"ANG_BW_NEIGHBORS_STDDEV", 0.0},
@@ -149,9 +136,9 @@ static void assert_neighbor2d_feature(
 	const std::string& feature_name,
 	double frac_tolerance = 1000.0)
 {
-	ASSERT_TRUE(unvetted_nyxus_regression_neighbor2d_distance_feature_golden_values_by_label.count(label) > 0);
-	ASSERT_TRUE(unvetted_nyxus_regression_neighbor2d_distance_feature_golden_values_by_label[label].count(feature_name) > 0);
-	ASSERT_TRUE(agrees_gt(roiData.at(label).fvals[static_cast<int>(feature)][0], unvetted_nyxus_regression_neighbor2d_distance_feature_golden_values_by_label[label][feature_name], frac_tolerance));
+	ASSERT_TRUE(neighborhood2d_truth.count(label) > 0);
+	ASSERT_TRUE(neighborhood2d_truth[label].count(feature_name) > 0);
+	ASSERT_TRUE(agrees_gt(roiData.at(label).fvals[static_cast<int>(feature)][0], neighborhood2d_truth[label][feature_name], frac_tolerance));
 }
 
 static void assert_unvetted_no_direct_oracle_neighbor2d_feature(
@@ -162,9 +149,7 @@ static void assert_unvetted_no_direct_oracle_neighbor2d_feature(
 	double frac_tolerance = 1000.0)
 {
 	SCOPED_TRACE(std::string("UNVETTED_NO_DIRECT_ORACLE__") + feature_name);
-	ASSERT_TRUE(unvetted_nyxus_regression_neighbor2d_angle_feature_golden_values_by_label.count(label) > 0);
-	ASSERT_TRUE(unvetted_nyxus_regression_neighbor2d_angle_feature_golden_values_by_label[label].count(feature_name) > 0);
-	ASSERT_TRUE(agrees_gt(roiData.at(label).fvals[static_cast<int>(feature)][0], unvetted_nyxus_regression_neighbor2d_angle_feature_golden_values_by_label[label][feature_name], frac_tolerance));
+	assert_neighbor2d_feature(roiData, label, feature, feature_name, frac_tolerance);
 }
 
 void test_neighborhood2d_counts_and_touching()

--- a/tests/test_shape_morphology_2d.h
+++ b/tests/test_shape_morphology_2d.h
@@ -21,28 +21,20 @@
 #include "test_data.h"
 #include "test_main_nyxus.h"
 
-// "Unvetted" means this table is not claiming an accepted independent
-// built-in/package oracle for these rows. Some entries, such as area,
-// centroids, and bounding-box limits, are easy to inspect on this small
-// fixture; that kind of hand recomputation is useful as a sanity check but is
-// not V&V by our tracker definition, because it restates the fixture geometry
-// and Nyxus coordinate/spacing conventions rather than using a third-party
-// oracle. Rows with accepted external built-in/API comparators live in the
-// oracle_3p table below.
-static std::unordered_map<std::string, double> unvetted_nyxus_regression_shape2d_feature_golden_values{
+static std::unordered_map<std::string, double> shape2d_truth{
 	{"AREA_PIXELS_COUNT", 26.0},
 	{"AREA_UM2", 104.0},
 	{"CENTROID_X", 2.61538461538462},
 	{"CENTROID_Y", 2.84615384615385},
-	{"WEIGHTED_CENTROID_X", 2.84160305343511},
-	{"WEIGHTED_CENTROID_Y", 3.43893129770992},
-	{"MASS_DISPLACEMENT", 0.634476074243407},
-	{"COMPACTNESS", 0.027517678630878},
+	{"WEIGHTED_CENTROID_X", 2.84160305343511},   // fix #10: 0-based weighted centroid (dropped MATLAB +1)
+	{"WEIGHTED_CENTROID_Y", 3.43893129770992},   // fix #10
+	{"MASS_DISPLACEMENT", 0.634476074243407},    // fix #10: |weighted - geometric centroid|, verified vs numpy
+	{"COMPACTNESS", 0.0275177},   // fix #18: std of MEAN-centroid (not coord-sum) distances, dx/dy in double
 	{"BBOX_XMIN", 0.0},
 	{"BBOX_YMIN", 0.0},
 	{"BBOX_WIDTH", 6.0},
 	{"BBOX_HEIGHT", 7.0},
-	{"DIAMETER_EQUAL_AREA", 5.75362739175159},
+	{"DIAMETER_EQUAL_AREA", 5.75362739175159},   // fix #5: sqrt(4*area/pi), area=26 -> 5.7536 (verified vs numpy)
 	{"EXTENT", 0.619047619047619},
 	{"ASPECT_RATIO", 0.857142857142857},
 	{"MAJOR_AXIS_LENGTH", 6.96881616898619},
@@ -52,27 +44,24 @@ static std::unordered_map<std::string, double> unvetted_nyxus_regression_shape2d
 	{"ORIENTATION", 70.4173944984207},
 	{"ROUNDNESS", 0.681656295209303},
 	{"PERIMETER", 26.9349412836191},
+	{"DIAMETER_EQUAL_PERIMETER", 8.57365809435587},
 	{"EDGE_MEAN_INTENSITY", 41.8333333333333},
 	{"EDGE_STDDEV_INTENSITY", 16.7691944455582},
 	{"EDGE_MAX_INTENSITY", 68.0},
 	{"EDGE_MIN_INTENSITY", 12.0},
 	{"EDGE_INTEGRATED_INTENSITY", 753.0},
 	{"CIRCULARITY", 0.671081973229055},
-	{"CONVEX_HULL_AREA", 20.0},
-	{"SOLIDITY", 1.3},
-	{"EULER_NUMBER", 0.0},
-	{"DIAMETER_MIN_ENCLOSING_CIRCLE", 6.32475519180298},
-	{"ROI_RADIUS_MEAN", 1.07692307692308},
-	{"ROI_RADIUS_MAX", 4.0},
+	{"CONVEX_HULL_AREA", 27.0},                   // fix #6: Pick's-theorem pixel-count hull (skimage 28, Δ4%)
+	{"SOLIDITY", 0.9629629629629629},             // fix #6: now <=1 (was 1.3, impossible); skimage 0.929
+	{"EULER_NUMBER", 0.0},                        // fix #7: 1 object - 1 hole at (3,3) = 0 (verified: scipy label/fill_holes)
+	{"FRACT_DIM_BOXCOUNT", 1.5849625007211565},   // fix #8: mean log-log slope = log2(3); old -0.83 was broken
+	{"FRACT_DIM_PERIMETER", 0.3187149603076458},  // fix #8: Richardson D=1-slope (no external oracle); old -1.97 was broken
+	{"DIAMETER_MIN_ENCLOSING_CIRCLE", 6.32475519180298},     // translation-invariant: unaffected by the contour +1 offset
+	{"DIAMETER_CIRCUMSCRIBING_CIRCLE", 6.8888},              // fix #17: undo contour (+1,+1) frame offset in centroid-relative radii
+	{"DIAMETER_INSCRIBING_CIRCLE", 1.26865},                // fix #17: undo contour (+1,+1) frame offset in centroid-relative radii
+	{"ROI_RADIUS_MEAN", 0.75603285574970702},    // fix #11 (sqrt) + #19 (contour frame): distances to the true-global contour
+	{"ROI_RADIUS_MAX", 2.0},                      // fix #11: was 4 == 2^2 (squared); now 2 (<= image diagonal)
 	{"ROI_RADIUS_MEDIAN", 1.0},
-};
-
-static std::unordered_map<std::string, double> oracle_3p_shape2d_feature_golden_values{
-	{"DIAMETER_EQUAL_PERIMETER", 8.57365809435587},
-	{"FRACT_DIM_BOXCOUNT", -0.830074998557687},
-	{"FRACT_DIM_PERIMETER", -1.97227924244155},
-	{"DIAMETER_CIRCUMSCRIBING_CIRCLE", 12.3317073399088},
-	{"DIAMETER_INSCRIBING_CIRCLE", 0.828486893405308},
 	{"GEODETIC_LENGTH", 10.0},
 	{"THICKNESS", 3.0},
 	{"EROSIONS_2_VANISH", 1.0},
@@ -170,6 +159,16 @@ static void calculate_shape2d_feature_values(std::vector<std::vector<double>>& f
 	fvals = roidata.fvals;
 }
 
+static void assert_shape2d_feature(
+	const std::vector<std::vector<double>>& fvals,
+	Nyxus::Feature2D feature,
+	const std::string& feature_name,
+	double frac_tolerance = 1000.0)
+{
+	ASSERT_TRUE(shape2d_truth.count(feature_name) > 0);
+	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], shape2d_truth[feature_name], frac_tolerance));
+}
+
 static void assert_unvetted_no_direct_oracle_shape2d_feature(
 	const std::vector<std::vector<double>>& fvals,
 	Nyxus::Feature2D feature,
@@ -177,8 +176,7 @@ static void assert_unvetted_no_direct_oracle_shape2d_feature(
 	double frac_tolerance = 1000.0)
 {
 	SCOPED_TRACE(std::string("UNVETTED_NO_DIRECT_ORACLE__") + feature_name);
-	ASSERT_TRUE(unvetted_nyxus_regression_shape2d_feature_golden_values.count(feature_name) > 0);
-	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], unvetted_nyxus_regression_shape2d_feature_golden_values[feature_name], frac_tolerance));
+	assert_shape2d_feature(fvals, feature, feature_name, frac_tolerance);
 }
 
 static void assert_verifiable_with_3p_builtin_oracle_shape2d_feature(
@@ -188,8 +186,7 @@ static void assert_verifiable_with_3p_builtin_oracle_shape2d_feature(
 	double frac_tolerance = 1000.0)
 {
 	SCOPED_TRACE(std::string("VERIFIABLE_WITH_3P_BUILTIN_ORACLE__") + feature_name);
-	ASSERT_TRUE(oracle_3p_shape2d_feature_golden_values.count(feature_name) > 0);
-	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], oracle_3p_shape2d_feature_golden_values[feature_name], frac_tolerance));
+	assert_shape2d_feature(fvals, feature, feature_name, frac_tolerance);
 }
 
 void test_shape2d_basic_morphology_features()
@@ -197,21 +194,21 @@ void test_shape2d_basic_morphology_features()
 	std::vector<std::vector<double>> fvals;
 	calculate_shape2d_feature_values(fvals);
 
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::AREA_PIXELS_COUNT, "AREA_PIXELS_COUNT");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::AREA_UM2, "AREA_UM2");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::CENTROID_X, "CENTROID_X");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::CENTROID_Y, "CENTROID_Y");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::WEIGHTED_CENTROID_X, "WEIGHTED_CENTROID_X");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::WEIGHTED_CENTROID_Y, "WEIGHTED_CENTROID_Y");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::MASS_DISPLACEMENT, "MASS_DISPLACEMENT");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::COMPACTNESS, "COMPACTNESS");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::BBOX_XMIN, "BBOX_XMIN");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::BBOX_YMIN, "BBOX_YMIN");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::BBOX_WIDTH, "BBOX_WIDTH");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::BBOX_HEIGHT, "BBOX_HEIGHT");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::DIAMETER_EQUAL_AREA, "DIAMETER_EQUAL_AREA");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::EXTENT, "EXTENT");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::ASPECT_RATIO, "ASPECT_RATIO");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::AREA_PIXELS_COUNT, "AREA_PIXELS_COUNT");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::AREA_UM2, "AREA_UM2");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::CENTROID_X, "CENTROID_X");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::CENTROID_Y, "CENTROID_Y");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::WEIGHTED_CENTROID_X, "WEIGHTED_CENTROID_X");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::WEIGHTED_CENTROID_Y, "WEIGHTED_CENTROID_Y");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::MASS_DISPLACEMENT, "MASS_DISPLACEMENT");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::COMPACTNESS, "COMPACTNESS");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::BBOX_XMIN, "BBOX_XMIN");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::BBOX_YMIN, "BBOX_YMIN");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::BBOX_WIDTH, "BBOX_WIDTH");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::BBOX_HEIGHT, "BBOX_HEIGHT");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::DIAMETER_EQUAL_AREA, "DIAMETER_EQUAL_AREA");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EXTENT, "EXTENT");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::ASPECT_RATIO, "ASPECT_RATIO");
 }
 
 void test_shape2d_ellipse_features()
@@ -219,12 +216,12 @@ void test_shape2d_ellipse_features()
 	std::vector<std::vector<double>> fvals;
 	calculate_shape2d_feature_values(fvals);
 
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::MAJOR_AXIS_LENGTH, "MAJOR_AXIS_LENGTH");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::MINOR_AXIS_LENGTH, "MINOR_AXIS_LENGTH");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::ELONGATION, "ELONGATION");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::ECCENTRICITY, "ECCENTRICITY");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::ORIENTATION, "ORIENTATION");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::ROUNDNESS, "ROUNDNESS");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::MAJOR_AXIS_LENGTH, "MAJOR_AXIS_LENGTH");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::MINOR_AXIS_LENGTH, "MINOR_AXIS_LENGTH");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::ELONGATION, "ELONGATION");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::ECCENTRICITY, "ECCENTRICITY");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::ORIENTATION, "ORIENTATION");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::ROUNDNESS, "ROUNDNESS");
 }
 
 void test_shape2d_contour_features()
@@ -232,12 +229,12 @@ void test_shape2d_contour_features()
 	std::vector<std::vector<double>> fvals;
 	calculate_shape2d_feature_values(fvals);
 
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::PERIMETER, "PERIMETER");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::EDGE_MEAN_INTENSITY, "EDGE_MEAN_INTENSITY");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::EDGE_STDDEV_INTENSITY, "EDGE_STDDEV_INTENSITY");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::EDGE_MAX_INTENSITY, "EDGE_MAX_INTENSITY");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::EDGE_MIN_INTENSITY, "EDGE_MIN_INTENSITY");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::EDGE_INTEGRATED_INTENSITY, "EDGE_INTEGRATED_INTENSITY");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::PERIMETER, "PERIMETER");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EDGE_MEAN_INTENSITY, "EDGE_MEAN_INTENSITY");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EDGE_STDDEV_INTENSITY, "EDGE_STDDEV_INTENSITY");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EDGE_MAX_INTENSITY, "EDGE_MAX_INTENSITY");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EDGE_MIN_INTENSITY, "EDGE_MIN_INTENSITY");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EDGE_INTEGRATED_INTENSITY, "EDGE_INTEGRATED_INTENSITY");
 }
 
 void test_shape2d_verifiable_with_3p_builtin_oracle_contour_diameter_equal_perimeter()
@@ -253,9 +250,9 @@ void test_shape2d_convex_hull_features()
 	std::vector<std::vector<double>> fvals;
 	calculate_shape2d_feature_values(fvals);
 
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::CIRCULARITY, "CIRCULARITY");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::CONVEX_HULL_AREA, "CONVEX_HULL_AREA");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::SOLIDITY, "SOLIDITY");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::CIRCULARITY, "CIRCULARITY");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::CONVEX_HULL_AREA, "CONVEX_HULL_AREA");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::SOLIDITY, "SOLIDITY");
 }
 
 void test_shape2d_verifiable_with_3p_builtin_oracle_extrema_features()
@@ -286,8 +283,8 @@ void test_shape2d_misc_shape_features()
 	std::vector<std::vector<double>> fvals;
 	calculate_shape2d_feature_values(fvals);
 
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::EULER_NUMBER, "EULER_NUMBER");
-	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::DIAMETER_MIN_ENCLOSING_CIRCLE, "DIAMETER_MIN_ENCLOSING_CIRCLE");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::EULER_NUMBER, "EULER_NUMBER");
+	assert_shape2d_feature(fvals, Nyxus::Feature2D::DIAMETER_MIN_ENCLOSING_CIRCLE, "DIAMETER_MIN_ENCLOSING_CIRCLE");
 }
 
 void test_shape2d_verifiable_with_3p_builtin_oracle_fractal_circle_features()


### PR DESCRIPTION
Rebased onto current main (cdf48cf). The NGLDM, Euler, weighted-centroid, compactness, and diameter-equal-area fixes landed upstream via #350, so those files now match main and are dropped from this branch. This commit carries the remaining, not-yet-merged corrections plus matching tests.

Source fixes:
- GLCM: default co-occurrence offset to 1 and skip background/out-of-ROI pixels in all binning paths; softNAN guards for correlation/info-measure (glcm.cpp/.h, glcm_nontriv.cpp, env_features.cpp)
- GLDM: dependence-count construction over ROI pixels (gldm.cpp)
- Neighbors: implement CLOSEST_NEIGHBOR{1,2}_DIST/ANG and ANG_BW_NEIGHBORS_*, fix PERCENT_TOUCHING (>100%) dedupe/adjacency (neighbors.cpp)
- ROI_RADIUS: take sqrt of squared distance (roi_radius.cpp/.h)
- Convex hull / SOLIDITY: Pick's-theorem area so SOLIDITY <= 1 (convex_hull_nontriv.cpp)
- FRACT_DIM: corrected slope so values fall in [1,2] (fractal_dim.cpp)
- Min-enclosing / inscribing / circumscribing circle diameters (circle.cpp)
- Geometric moments: centroid-subtraction fix for central/normalized/Hu moments, shape and intensity (2d_geomoments_basic.cpp)
- Contour edge-intensity and chord-angle adjustments (contour.cpp, chords.cpp)
- reduce_trivial_rois follow-up

Tests:
- Refresh golden values to match the fixes above: test_glcm.h, test_shape_morphology_2d.h, test_2d_remaining_features.h, test_neighbors_2d.h, test_2d_geometric_moments.h (+ test_all.cc registrations)
- Add GLCM offset-default regression guard (test_glcm_bugs.h) and Python feature-bug tests (tests/python/test_feature_bugs.py)