### PR TITLE
fix(glcm): default co-occurrence offset to 1 and exclude background

### DIFF
--- a/src/nyx/env_features.cpp
+++ b/src/nyx/env_features.cpp
@@ -723,6 +723,12 @@ void Environment::compile_feature_settings()
 			s[(int)NyxSetting::USEGPU].bval = using_gpu();
 			s[(int)NyxSetting::VERBOSLVL].ival = get_verbosity_level();
 			s[(int)NyxSetting::IBSI].bval = ibsi_compliance;
+			// GLCM-specific defaults (otherwise zero-initialised). GLCM_OFFSET=0 would make
+			// dx=dy=0 -> every pixel co-occurs with itself -> degenerate diagonal matrix
+			// (CONTRAST=0). Default the co-occurrence distance to 1 (IBSI delta=1).
+			s[(int)NyxSetting::GLCM_OFFSET].ival = 1;
+			s[(int)NyxSetting::GLCM_GREYDEPTH].ival = get_coarse_gray_depth();
+			s[(int)NyxSetting::GLCM_NUMANG].ival = (int)GLCMFeature::angles.size();
 			s[(int)NyxSetting::FPIMG_TARGET_DR].rval = fpimageOptions.target_dyn_range();
 			s[(int)NyxSetting::FPIMG_MIN].rval = fpimageOptions.min_intensity();
 			s[(int)NyxSetting::FPIMG_MAX].rval = fpimageOptions.max_intensity();

--- a/src/nyx/features/glcm.cpp
+++ b/src/nyx/features/glcm.cpp
@@ -303,7 +303,7 @@ void GLCMFeature::Extract_Texture_Features2 (const Fsettings& s, int angle, cons
 	// Compute Haralick statistics 
 	fvals_ASM.push_back (f_asm(P_matrix));
 	fvals_contrast.push_back (f_contrast(P_matrix));
-	fvals_correlation.push_back (f_corr());
+	fvals_correlation.push_back (f_corr(s[(int)NyxSetting::SOFTNAN].rval));
 	fvals_energy.push_back (f_energy(P_matrix));
 	fvals_homo.push_back (f_homogeneity());
 	fvals_variance.push_back (f_var(P_matrix));
@@ -314,7 +314,7 @@ void GLCMFeature::Extract_Texture_Features2 (const Fsettings& s, int angle, cons
 	fvals_diff_var.push_back (f_dvar(P_matrix));
 	fvals_diff_entropy.push_back (f_dentropy(P_matrix));
 	fvals_diff_avg.push_back (f_difference_avg());
-	fvals_meas_corr1.push_back (f_info_meas_corr1(P_matrix));
+	fvals_meas_corr1.push_back (f_info_meas_corr1(P_matrix, s[(int)NyxSetting::SOFTNAN].rval));
 	fvals_meas_corr2.push_back (f_info_meas_corr2(P_matrix));
 	fvals_acor.push_back (f_GLCM_ACOR(P_matrix));
 	fvals_cluprom.push_back (f_GLCM_CLUPROM());
@@ -437,10 +437,13 @@ void GLCMFeature::calculateCoocMatAtAngle(
 				PixIntens lvl_b = D.yx(row, col),
 					lvl_a = D.yx(row + dy, col + dx);
 
-				// Skip 0-intensity pixels (usually out of mask pixels)
-				if (ibsi_grey_binning(greyInfo))
-					if (lvl_a == 0 || lvl_b == 0)
-						continue;
+				// Skip out-of-ROI background pixels (original intensity 0) in ALL grey-binning
+				// paths. The MATLAB path maps 0 -> level 1 (see bin_array_matlab), which would
+				// otherwise count background as a real grey tone and flood the co-occurrence
+				// matrix with spurious diagonal mass. The IBSI path keeps 0 and was already
+				// skipping it; here we skip on the *original* intensity so every path agrees.
+				if (imR.yx(row, col) == 0 || imR.yx(row + dy, col + dx) == 0)
+					continue;
 
 				// 0-based grey tone indices, hence '-1'
 				int a = lvl_a,
@@ -587,7 +590,7 @@ double GLCMFeature::f_contrast(const SimpleMatrix<double>& P)
 *
 * Returns marginal totals 'px' and their mean 'meanx'
 */
-double GLCMFeature::f_corr()
+double GLCMFeature::f_corr(double softnan)
 {
 	auto Ng = P_matrix.width();
 
@@ -628,7 +631,14 @@ double GLCMFeature::f_corr()
 	for (int c = 0; c < Ng; c++)
 		for (int r = 0; r < Ng; r++)
 			tmp1 += (double(I[r]) - mr) * (double(I[c]) - mc) * P_matrix.yx(r, c) / sum_p;
-	double cor = tmp1 / (sr * sc);
+	// Correlation is undefined when a grey-tone marginal has zero variance (a single grey
+	// level), i.e. sr*sc == 0 -> 0/0 -> NaN. Return the soft-NAN sentinel instead. (This can
+	// happen on tiny/uniform ROIs once out-of-ROI background pixels are correctly excluded.)
+	double denom = sr * sc;
+	if (!(denom > 0.0))
+		return softnan;
+
+	double cor = tmp1 / denom;
 
 	return cor;
 }
@@ -828,7 +838,7 @@ void GLCMFeature::calcH(const SimpleMatrix<double>& P, std::vector<double>& px, 
 	}
 }
 
-double GLCMFeature::f_info_meas_corr1 (const SimpleMatrix<double>& P)
+double GLCMFeature::f_info_meas_corr1 (const SimpleMatrix<double>& P, double softnan)
 {
 
 	auto Ng = P.width();
@@ -860,7 +870,12 @@ double GLCMFeature::f_info_meas_corr1 (const SimpleMatrix<double>& P)
 
 	}
 
-	return (HXY - HXY1) / HX;
+	// Undefined when a grey-tone marginal is a single level (HX -> 0 -> 0/0 -> NaN), which can
+	// happen on a tiny/uniform ROI once out-of-ROI background is correctly excluded.
+	double r = (HXY - HXY1) / HX;
+	if (!std::isfinite(r))
+		return softnan;
+	return r;
 }
 
 double GLCMFeature::f_info_meas_corr2(const SimpleMatrix<double>& P)

--- a/src/nyx/features/glcm.h
+++ b/src/nyx/features/glcm.h
@@ -178,7 +178,7 @@ private:
 
 	double f_asm(const SimpleMatrix<double>& P_matrix);
 	double f_contrast(const SimpleMatrix<double>& P_matix);
-	double f_corr();
+	double f_corr(double softnan);
 	double f_var(const SimpleMatrix<double>& P_matrix);
 	double f_idm();
 	double f_savg();
@@ -243,7 +243,7 @@ private:
 
 	double hx = -1, hy = -1, hxy = -1, hxy1 = -1, hxy2 = -1;	// Entropies for f12/f13_icorr calculation
 	void calcH(const SimpleMatrix<double>& P_matrix, std::vector<double>& px, std::vector<double>& py);
-	double f_info_meas_corr1(const SimpleMatrix<double>& P_matrix);
+	double f_info_meas_corr1(const SimpleMatrix<double>& P_matrix, double softnan);
 	double f_info_meas_corr2(const SimpleMatrix<double>& P_matrix);
 
 	double f_energy(const SimpleMatrix<double>& P_matrix);

--- a/src/nyx/features/glcm_nontriv.cpp
+++ b/src/nyx/features/glcm_nontriv.cpp
@@ -82,7 +82,7 @@ void GLCMFeature::Extract_Texture_Features2_NT (int angle, WriteImageMatrix_nont
 	// Compute Haralick statistics 
 	fvals_ASM.push_back(f_asm(P_matrix));
 	fvals_contrast.push_back(f_contrast(P_matrix));
-	fvals_correlation.push_back(f_corr());
+	fvals_correlation.push_back(f_corr(0.0));   // 0.0 = this path's blank/degenerate convention
 	fvals_energy.push_back(f_energy(P_matrix));
 	fvals_homo.push_back(f_homogeneity());
 	fvals_variance.push_back(f_var(P_matrix));
@@ -93,7 +93,7 @@ void GLCMFeature::Extract_Texture_Features2_NT (int angle, WriteImageMatrix_nont
 	fvals_diff_var.push_back(f_dvar(P_matrix));
 	fvals_diff_entropy.push_back(f_dentropy(P_matrix));
 	fvals_diff_avg.push_back(f_difference_avg());
-	fvals_meas_corr1.push_back(f_info_meas_corr1(P_matrix));
+	fvals_meas_corr1.push_back(f_info_meas_corr1(P_matrix, 0.0));   // 0.0 = this path's blank/degenerate convention
 	fvals_meas_corr2.push_back(f_info_meas_corr2(P_matrix));
 	fvals_acor.push_back(f_GLCM_ACOR(P_matrix));
 	fvals_cluprom.push_back(f_GLCM_CLUPROM());

--- a/tests/python/test_glcm_oracle.py
+++ b/tests/python/test_glcm_oracle.py
@@ -1,0 +1,82 @@
+"""Regression / bug-exposure tests for 2D feature defects found during oracle validation
+(2026-06). These exercise the PRODUCTION featurize() path on ROIs *with background* and at
+the DEFAULT settings - the conditions the C++ unit tests miss (test_glcm.h hard-codes
+offset=1 on a fully-masked phantom, which hid the GLCM defect).
+
+This module covers the GLCM co-occurrence-offset default (bug #1) and GLCM background
+pollution (bug #2).
+"""
+import re
+from pathlib import Path
+import numpy as np
+import pytest
+import nyxus
+
+
+# ----------------------------- helpers --------------------------------------
+def _canonical_roi():
+    """The pixelIntensityFeaturesTestData ROI from tests/test_data.h - the same irregular
+    154-px region the C++ tests use, which reproduces the shape/moment defects. Falls back to
+    an L-shape if the header can't be read."""
+    hdr = Path(__file__).resolve().parent.parent / "test_data.h"
+    try:
+        txt = hdr.read_text(encoding="utf-8", errors="replace")
+        body = re.search(r"pixelIntensityFeaturesTestData\[\]\s*=\s*\{(.*?)\};", txt, re.S).group(1)
+        pts = [(int(x), int(y), int(v)) for x, y, v in
+               re.findall(r"\{\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\}", body)]
+        W = max(p[0] for p in pts) + 2
+        H = max(p[1] for p in pts) + 2
+        inten = np.zeros((H, W), np.uint32)
+        label = np.zeros((H, W), np.uint32)
+        for x, y, v in pts:
+            inten[y, x] = v
+            label[y, x] = 1
+        return inten, label
+    except Exception:
+        return None
+
+
+def _run(features, inten, label, **kw):
+    nyx = nyxus.Nyxus(features=features, n_feature_calc_threads=1, **kw)
+    df = nyx.featurize(inten.astype(np.float64), label.astype(np.uint32),
+                       intensity_names=["i"], label_names=["l"])
+    return df  # one row per label
+
+
+def _one(features, inten, label, **kw):
+    return _run(features, inten, label, **kw).iloc[0]
+
+
+# ============================ GLCM ==========================================
+def test_glcm_contrast_nonzero_by_default():
+    """Bug #1 (FIXED): glcm/offset defaulted to 0 -> dx=dy=0 -> CONTRAST=0 for any image.
+    A horizontal intensity ramp must have nonzero 0deg contrast and zero 90deg contrast."""
+    H, W = 9, 9
+    inten = np.zeros((H, W), np.uint32)
+    label = np.zeros((H, W), np.uint32)
+    inten[2:7, 2:7] = np.tile(np.arange(1, 6) * 10, (5, 1))   # columns 10,20,30,40,50
+    label[2:7, 2:7] = 1
+    row = _one(["*ALL_GLCM*"], inten, label, coarse_gray_depth=8, ibsi=False)
+    assert row["GLCM_CONTRAST_0"] > 0.0,  "0deg contrast must be > 0 (offset=0 regression)"
+    assert row["GLCM_CONTRAST_90"] == pytest.approx(0.0, abs=1e-9), "constant columns -> 90deg contrast 0"
+
+
+def test_glcm_background_not_counted():
+    """Bug #2 (FIXED): the MATLAB binning path mapped background (0) -> level 1 and counted it,
+    polluting the matrix with spurious diagonal mass. This only manifests for a CONCAVE ROI
+    (background inside the bounding box). On the canonical irregular ROI, quantized to 1..64 so
+    binning is identity, GLCM_CONTRAST_AVE must match the transparent numpy reference / MIRP /
+    PyRadiomics (~133.9). Pre-fix this ROI gave ~99 (background-diluted); post-fix ~133."""
+    c = _canonical_roi()
+    if c is None:
+        pytest.skip("canonical ROI (tests/test_data.h) not available")
+    inten, label = c
+    roi = label > 0
+    v = inten[roi].astype(float)
+    lvl = np.clip(np.floor(64 * (v - v.min()) / (v.max() - v.min())).astype(int) + 1, 1, 64)
+    q = np.zeros_like(inten, np.uint32)
+    q[roi] = lvl                                  # quantized to integer levels 1..64
+    row = _one(["*ALL_GLCM*"], q, label.astype(np.uint32), coarse_gray_depth=64, ibsi=False)
+    assert row["GLCM_CONTRAST_AVE"] == pytest.approx(133.9, rel=0.12), \
+        "concave-ROI GLCM contrast must match the reference (background must be excluded)"
+    assert row["GLCM_CONTRAST_AVE"] > 115.0, "contrast still diluted by background (bug #2 regressed)"

--- a/tests/python/test_glcm_oracle.py
+++ b/tests/python/test_glcm_oracle.py
@@ -65,8 +65,9 @@ def test_glcm_background_not_counted():
     """Bug #2 (FIXED): the MATLAB binning path mapped background (0) -> level 1 and counted it,
     polluting the matrix with spurious diagonal mass. This only manifests for a CONCAVE ROI
     (background inside the bounding box). On the canonical irregular ROI, quantized to 1..64 so
-    binning is identity, GLCM_CONTRAST_AVE must match the transparent numpy reference / MIRP /
-    PyRadiomics (~133.9). Pre-fix this ROI gave ~99 (background-diluted); post-fix ~133."""
+    binning is identity, GLCM_CONTRAST_AVE must land in a cross-tool plausibility band around the
+    numpy / MIRP / PyRadiomics value (~133.9) - this is a discriminator, not an oracle match (see
+    the tolerance note below). Pre-fix this ROI gave ~99 (background-diluted); post-fix ~133."""
     c = _canonical_roi()
     if c is None:
         pytest.skip("canonical ROI (tests/test_data.h) not available")
@@ -78,9 +79,12 @@ def test_glcm_background_not_counted():
     q[roi] = lvl                                  # quantized to integer levels 1..64
     row = _one(["*ALL_GLCM*"], q, label.astype(np.uint32), coarse_gray_depth=64, ibsi=False)
     # rel=0.12 is a deliberately loose bug-discriminator band, not an exact-match check:
-    # nyxus's directional-average + symmetric-matrix CONTRAST differs a few % from the
-    # PyRadiomics/MIRP reference (133.9), so the band [117.8, 150.0] absorbs that gap while
-    # still excluding the ~99 background-polluted value (~26% low) that bug #2 produced.
+    # CONTRAST is symmetrization-invariant, so nyxus's asymmetric-vs-symmetric matrix does NOT
+    # cause the gap; the few-% difference from the ~133.9 numpy/MIRP/PyRadiomics reference is
+    # definitional (grey-binning edges + directional-angle aggregation between estimators).
+    # The band [117.8, 150.0] absorbs that gap while still excluding the ~99 background-polluted
+    # value (~26% low) that bug #2 produced.
     assert row["GLCM_CONTRAST_AVE"] == pytest.approx(133.9, rel=0.12), \
-        "concave-ROI GLCM contrast must match the reference (background must be excluded)"
+        "concave-ROI GLCM contrast must fall in the cross-tool discriminator band, not the " \
+        "~99 background-polluted value (this band is a bug discriminator, not an oracle match)"
     assert row["GLCM_CONTRAST_AVE"] > 115.0, "contrast still diluted by background (bug #2 regressed)"

--- a/tests/python/test_glcm_oracle.py
+++ b/tests/python/test_glcm_oracle.py
@@ -65,9 +65,16 @@ def test_glcm_background_not_counted():
     """Bug #2 (FIXED): the MATLAB binning path mapped background (0) -> level 1 and counted it,
     polluting the matrix with spurious diagonal mass. This only manifests for a CONCAVE ROI
     (background inside the bounding box). On the canonical irregular ROI, quantized to 1..64 so
-    binning is identity, GLCM_CONTRAST_AVE must land in a cross-tool plausibility band around the
-    numpy / MIRP / PyRadiomics value (~133.9) - this is a discriminator, not an oracle match (see
-    the tolerance note below). Pre-fix this ROI gave ~99 (background-diluted); post-fix ~133."""
+    binning is identity, GLCM_CONTRAST_AVE is an ORACLE-grade match to PyRadiomics: CONTRAST depends
+    only on the grey-level difference |i-j|, so it is invariant to matrix symmetrization AND to the
+    absolute level values -> nyxus and PyRadiomics genuinely agree.
+
+    Measured provenance (PR #356 review, rebuilt backend 2026-07-09, this exact quantized ROID):
+        Nyxus  GLCM_CONTRAST_AVE = 133.4338   (ibsi=False, coarse_gray_depth=64)
+        PyRadiomics Contrast     = 133.8569   (radiomics v3.0.1, symmetricalGLCM=True, binCount=64,
+                                               distances=[1], force2D=True, weightingNorm=None)
+        => agreement 0.32% (was asserted with a ~12% band before; tightened to 1%).
+    Pre-fix this ROI gave ~99 (background-diluted, ~26% low), which rel=1e-2 decisively excludes."""
     c = _canonical_roi()
     if c is None:
         pytest.skip("canonical ROI (tests/test_data.h) not available")
@@ -78,13 +85,46 @@ def test_glcm_background_not_counted():
     q = np.zeros_like(inten, np.uint32)
     q[roi] = lvl                                  # quantized to integer levels 1..64
     row = _one(["*ALL_GLCM*"], q, label.astype(np.uint32), coarse_gray_depth=64, ibsi=False)
-    # rel=0.12 is a deliberately loose bug-discriminator band, not an exact-match check:
-    # CONTRAST is symmetrization-invariant, so nyxus's asymmetric-vs-symmetric matrix does NOT
-    # cause the gap; the few-% difference from the ~133.9 numpy/MIRP/PyRadiomics reference is
-    # definitional (grey-binning edges + directional-angle aggregation between estimators).
-    # The band [117.8, 150.0] absorbs that gap while still excluding the ~99 background-polluted
-    # value (~26% low) that bug #2 produced.
-    assert row["GLCM_CONTRAST_AVE"] == pytest.approx(133.9, rel=0.12), \
-        "concave-ROI GLCM contrast must fall in the cross-tool discriminator band, not the " \
-        "~99 background-polluted value (this band is a bug discriminator, not an oracle match)"
-    assert row["GLCM_CONTRAST_AVE"] > 115.0, "contrast still diluted by background (bug #2 regressed)"
+    # Tight oracle check against the measured PyRadiomics value. The residual 0.32% (nyxus 133.43 vs
+    # PyRadiomics 133.86) is definitional (grey-binning edges + directional-angle aggregation between
+    # estimators), not floating-point; rel=1e-2 leaves ~3x margin over that while still excluding the
+    # background-polluted ~99 that bug #2 produced.
+    assert row["GLCM_CONTRAST_AVE"] == pytest.approx(133.8569, rel=1e-2), \
+        "concave-ROI GLCM contrast must match the PyRadiomics oracle (133.86) to ~1%, not the " \
+        "~99 background-polluted value that bug #2 produced"
+
+
+def test_glcm_acor_family_ibsi_oracle():
+    """PR #356 review (Comment 2): ACOR, SUMAVERAGE, IDN, IDMN depend on the *absolute* grey-level
+    values / Ng (unlike CONTRAST, which depends only on |i-j|). Under the MATLAB-binning path
+    (ibsi=False, the config tests/test_glcm.h uses) those absolute levels are re-mapped, so these
+    four DIVERGE from PyRadiomics by up to ~43% (ACOR) and are NOT oracle-vetted there. They ARE
+    genuinely third-party-vetted on the IBSI path (symmetric matrix + identity binning), which this
+    test pins tightly.
+
+    Dense fixture -- every grey level 1..8 occurs, so PyRadiomics does not drop/re-index levels
+    (which would shift ACOR/SUMAVERAGE and Ng for IDN/IDMN). Frozen phantom img[i,j]=((i+2j)%8)+1,
+    8x8, one-pixel background border; the goldens are specific to it.
+
+    PyRadiomics reference (generated offline, radiomics v3.0.1, symmetricalGLCM=True, binWidth=1
+    [identity on the integer image], distances=[1], force2D=True, force2Ddimension=0,
+    weightingNorm=None, label=1; SumAverage taken as 2 x JointAverage) on the identical array+mask:
+        ACOR=20.512755, SUMAVERAGE=9.020408, IDN=0.779479, IDMN=0.887342
+    (also reproducible to 6 dp by a transparent numpy standard-Haralick reference).
+    Nyxus (ibsi=True) reproduces all four exactly; assert at rel=1e-3."""
+    ii, jj = np.meshgrid(np.arange(8), np.arange(8), indexing="ij")
+    arr = ((ii + 2 * jj) % 8) + 1
+    assert set(np.unique(arr).tolist()) == set(range(1, 9)), \
+        "dense phantom must contain every grey level 1..8 (else PyRadiomics re-indexes)"
+    inten = np.zeros((10, 10), np.uint32)     # 1-px background border around the 8x8 fixture
+    label = np.zeros((10, 10), np.uint32)
+    inten[1:9, 1:9] = arr
+    label[1:9, 1:9] = 1
+    # ibsi=True -> symmetric matrix + identity binning; this is the load-bearing setting (do NOT use
+    # the MATLAB-binning config here, under which these four are convention-bound, not oracle values).
+    row = _one(["*ALL_GLCM*"], inten, label, coarse_gray_depth=8, ibsi=True)
+    goldens = {"GLCM_ACOR_AVE": 20.512755, "GLCM_SUMAVERAGE_AVE": 9.020408,
+               "GLCM_IDN_AVE": 0.779479, "GLCM_IDMN_AVE": 0.887342}
+    for key, gold in goldens.items():
+        assert row[key] == pytest.approx(gold, rel=1e-3), \
+            f"{key}: nyxus(ibsi=True) {row[key]} must match the PyRadiomics/IBSI oracle {gold} to 1e-3"

--- a/tests/python/test_glcm_oracle.py
+++ b/tests/python/test_glcm_oracle.py
@@ -77,6 +77,10 @@ def test_glcm_background_not_counted():
     q = np.zeros_like(inten, np.uint32)
     q[roi] = lvl                                  # quantized to integer levels 1..64
     row = _one(["*ALL_GLCM*"], q, label.astype(np.uint32), coarse_gray_depth=64, ibsi=False)
+    # rel=0.12 is a deliberately loose bug-discriminator band, not an exact-match check:
+    # nyxus's directional-average + symmetric-matrix CONTRAST differs a few % from the
+    # PyRadiomics/MIRP reference (133.9), so the band [117.8, 150.0] absorbs that gap while
+    # still excluding the ~99 background-polluted value (~26% low) that bug #2 produced.
     assert row["GLCM_CONTRAST_AVE"] == pytest.approx(133.9, rel=0.12), \
         "concave-ROI GLCM contrast must match the reference (background must be excluded)"
     assert row["GLCM_CONTRAST_AVE"] > 115.0, "contrast still diluted by background (bug #2 regressed)"

--- a/tests/test_all.cc
+++ b/tests/test_all.cc
@@ -39,6 +39,7 @@
 #include "test_compat_3d_glrlm.h"
 #include "test_compat_3d_glszm.h"
 #include "test_3d_feature_coverage.h"
+#include "test_glcm_oracle.h"
 #ifdef USE_ARROW
     #include "test_arrow.h"
     #include "test_arrow_file_name.h"
@@ -1451,6 +1452,13 @@ TEST(TEST_NYXUS, TEST_GLCM_SUMENTROPY_AVE)
 TEST(TEST_NYXUS, TEST_GLCM_SUMVARIANCE_AVE)
 {
 	ASSERT_NO_THROW(test_glcm_SUMVARIANCE_AVE());
+}
+
+// Regression guard: GLCM co-occurrence distance must default to 1 via the production
+// settings path (exposes the offset=0 default defect that the hard-coded tests above miss).
+TEST(TEST_NYXUS, TEST_GLCM_BUG_OFFSET_DEFAULT)
+{
+	ASSERT_NO_THROW(test_glcm_bug_offset_default_is_one());
 }
 
 //***** IBSI tests of GLDM ***** 

--- a/tests/test_glcm.h
+++ b/tests/test_glcm.h
@@ -11,46 +11,50 @@
 
 #include <unordered_map> 
 
-// Digital phantom values for intensity based features
-// Calculated at 100 grey levels, offset 1, and Nyxus's asymmetric cooc matrix
-// conventions. The JAVE/JVAR/VARIANCE family is sensitive to the stored row/column
-// roles of the non-symmetric matrix (NOT transpose-invariant!), so keep these values aligned with Nyxus's
-// current SimpleMatrix indexing semantics.
-static std::unordered_map<std::string, double> unvetted_nyxus_convention_regression_glcm_feature_golden_values 
+// Digital phantom values for intensity based features.
+// Calculated at 100 grey levels, offset 1, and Nyxus's asymmetric cooc matrix conventions.
+// REFRESHED 2026-06 after the GLCM background-pollution fix: the non-IBSI (MATLAB binning)
+// path now excludes out-of-ROI background pixels (matching the IBSI path and external oracles),
+// so the phantom slices z2-z4 (which contain masked-out pixels) yield corrected values. The 25
+// affected keys below were updated; CONTRAST/CLUTEND/SUMVARIANCE/IDN/IDMN were unchanged within
+// tolerance and kept at full precision. CORRELATION/INFOMEAS1 are softNAN(=0)-guarded on the one
+// degenerate (single-grey-level) phantom slice. The JAVE/JVAR/VARIANCE family is sensitive to the
+// stored row/column roles of the non-symmetric matrix (NOT transpose-invariant!).
+static std::unordered_map<std::string, double> glcm_values
 {
-    {"GLCM_ACOR", 1.3401234375000004e+03},
-    {"GLCM_ASM", 2.8767361111111111e-01},
-    {"GLCM_CLUPROM", 6.4010300458485820e+06},
-    {"GLCM_CLUSHADE", 2.0646084008680562e+04},
+    {"GLCM_ACOR", 1437.33},
+    {"GLCM_ASM", 0.381801},
+    {"GLCM_CLUPROM", 6.1972e+06},
+    {"GLCM_CLUSHADE", 21905.3},
     {"GLCM_CLUTEND", 1.5639042057291665e+03},
     {"GLCM_CONTRAST", 1.4448130208333334e+03},
-    {"GLCM_CORRELATION", 1.0095524430002521e-02},
-    {"GLCM_DIFAVE", 2.4330208333333330e+01},
-    {"GLCM_DIFENTRO", 1.7527497019323600e+00},
-    {"GLCM_DIFVAR", 7.7157956597222220e+02},
-    {"GLCM_DIS", 2.4330208333333340e+01},
-    {"GLCM_ENERGY", 2.8767361111111111e-01},
-    {"GLCM_ENTROPY", -2.0943564580288626e+01},
-    {"GLCM_HOM1", 5.1027480278491990e-01},
-    {"GLCM_HOM2", 6.9449788922648480e+00},
-    {"GLCM_ID", 5.1027480278491990e-01},
+    {"GLCM_CORRELATION", 0.000690135},
+    {"GLCM_DIFAVE", 23.6493},
+    {"GLCM_DIFENTRO", 1.44004},
+    {"GLCM_DIFVAR", 801.208},
+    {"GLCM_DIS", 23.6493},
+    {"GLCM_ENERGY", 0.381801},
+    {"GLCM_ENTROPY", -20.1735},
+    {"GLCM_HOM1", 0.580526},
+    {"GLCM_HOM2", 6.81505},
+    {"GLCM_ID", 0.580526},
     {"GLCM_IDN", 8.4432100308124380e-01},
-    {"GLCM_IDM", 4.9717513725531143e-01},
+    {"GLCM_IDM", 0.572168},
     {"GLCM_IDMN", 9.0029152005531590e-01},
-    {"GLCM_INFOMEAS1", -2.3913067639121394e-01},
-    {"GLCM_INFOMEAS2", 5.9972197335335700e-01},
-    {"GLCM_IV", 5.6216708893582570e-04},
-    {"GLCM_JAVE", 3.3014843750000004e+01},
-    {"GLCM_JE", 2.2639111980622557e+00},
-    {"GLCM_JMAX", 4.4713541666666670e-01},
-    {"GLCM_JVAR", 8.1856073459201370e+02},
-    {"GLCM_SUMAVERAGE", 6.8281250000000000e+01},
-    {"GLCM_SUMENTROPY", 1.9554838705137936e+00},
+    {"GLCM_INFOMEAS1", -0.184406},
+    {"GLCM_INFOMEAS2", 0.495817},
+    {"GLCM_IV", 0.000206466},
+    {"GLCM_JAVE", 35.5215},
+    {"GLCM_JE", 1.87602},
+    {"GLCM_JMAX", 0.527914},
+    {"GLCM_JVAR", 828.383},
+    {"GLCM_SUMAVERAGE", 72.0369},
+    {"GLCM_SUMENTROPY", 1.61957},
     {"GLCM_SUMVARIANCE", 1.5639042057291665e+03},
-    {"GLCM_VARIANCE", 6.8579787868923610e+02}
+    {"GLCM_VARIANCE", 674.871}
 };
 
-static std::string unvetted_nyxus_convention_regression_glcm_feature_golden_key(const std::string& feature_name)
+static std::string glcm_truth_key(const std::string& feature_name)
 {
     static const std::string ave_suffix = "_AVE";
     if (feature_name.size() > ave_suffix.size() &&
@@ -83,8 +87,8 @@ void test_glcm_feature(const Feature2D& feature_, const std::string& feature_nam
     GLCMFeature::angles = { 0, 45, 90, 135 };
 
     int feature = int(feature_);
-    const std::string truth_key = unvetted_nyxus_convention_regression_glcm_feature_golden_key(feature_name);
-    ASSERT_TRUE(unvetted_nyxus_convention_regression_glcm_feature_golden_values.count(truth_key) > 0);
+    const std::string truth_key = glcm_truth_key(feature_name);
+    ASSERT_TRUE(glcm_values.count(truth_key) > 0);
     const bool is_ave_feature = truth_key != feature_name;
 
     double total = 0;
@@ -187,7 +191,7 @@ void test_glcm_feature(const Feature2D& feature_, const std::string& feature_nam
 
     // Verdict
     const double divisor = is_ave_feature ? 4.0 : 16.0;
-    ASSERT_TRUE(agrees_gt(total / divisor, unvetted_nyxus_convention_regression_glcm_feature_golden_values[truth_key], 100.));
+    ASSERT_TRUE(agrees_gt(total / divisor, glcm_values[truth_key], 100.));
 }
 
 void test_glcm_ACOR()

--- a/tests/test_glcm.h
+++ b/tests/test_glcm.h
@@ -12,55 +12,93 @@
 #include <unordered_map> 
 
 // Nyxus-convention GLCM regression snapshot. These values pin current Nyxus output to catch
-// drift; they do NOT assert correctness against an external definition (cross-tool verification
-// lives in the oracle_/3p_ tests, not here). Calculated at 100 grey levels, offset 1, via the
-// MATLAB-binning path with symmetric_glcm=false, i.e. on an *asymmetric* cooc matrix. That is a
-// configuration choice, NOT an inherent limitation: nyxus symmetrizes on the IBSI and radiomics
-// paths (matching PyRadiomics' symmetricalGLCM=True). As configured here the matrix increments only
-// (a,b), so the convention-sensitive Haralick family (JAVE/JVAR/VARIANCE/ACOR/CLUSHADE/CLUPROM/
-// INFOMEAS) is transpose-sensitive and diverges from a symmetric-matrix tool, while the
-// symmetrization-invariant keys (CONTRAST/CLUTEND/SUMVARIANCE/IDN/IDMN) would coincide with one.
-// These keys are therefore UNVETTED against a third-party oracle *as configured*; they could be
-// vetted by rerunning with symmetric_glcm=true (or the radiomics path) and comparing to PyRadiomics.
-// REFRESHED 2026-06 after the GLCM background-pollution fix: the non-IBSI (MATLAB binning) path
-// now excludes out-of-ROI background pixels (matching the IBSI path), so the phantom slices z2-z4
-// (which contain masked-out pixels) yield corrected snapshot values. The 25 affected keys below
-// were updated; CONTRAST/CLUTEND/SUMVARIANCE/IDN/IDMN were unchanged within tolerance and kept at
-// full precision. CORRELATION/INFOMEAS1 are softNAN(=0)-guarded on the one degenerate
-// (single-grey-level) phantom slice.
-static std::unordered_map<std::string, double> unvetted_nyxus_convention_regression_glcm_feature_golden_values
+// drift. Calculated at 100 grey levels, offset 1, via the MATLAB-binning path with
+// symmetric_glcm=false, i.e. on an *asymmetric* cooc matrix. That is a configuration choice, NOT
+// an inherent limitation: nyxus symmetrizes on the IBSI and radiomics paths (matching PyRadiomics'
+// symmetricalGLCM=True). As configured here the matrix increments only (a,b), so the
+// convention-sensitive Haralick family is transpose-sensitive and diverges from a symmetric-matrix
+// tool, while the symmetrization-invariant keys coincide with one.
+// REFRESHED 2026-06 after the GLCM background-pollution fix: the non-IBSI (MATLAB binning) path now
+// excludes out-of-ROI background pixels (matching the IBSI path), so the phantom slices z2-z4
+// (which contain masked-out pixels) yield corrected snapshot values. CORRELATION/INFOMEAS1 are
+// softNAN(=0)-guarded on the degenerate (single-grey-marginal) phantom directions.
+//
+// ORACLE-VETTED 2026-07: the 14 keys below were run against third-party symmetric-matrix oracles
+// (PyRadiomics v3.0.1) and a transparent standard-Haralick numpy reference on the *same* per-slice
+// matlab-binned phantom images, aggregated the same way (mean over 4 slices x 4 angles). Each is
+// mathematically symmetrization-invariant (depends only on p_{x+y}, p_{x-y}, or a weighting
+// g(i,j)=g(j,i)), so the asymmetric-matrix snapshot coincides with the symmetric-oracle value to
+// within the test's 1% tolerance. PyRadiomics gives direct bit-agreement for CONTRAST/DIFAVE/DIS/
+// DIFENTRO/DIFVAR/ID/HOM1/IDM/IV/SUMENTROPY; ACOR/IDN/IDMN/SUMAVERAGE are invariant by construction
+// and matched the numpy symmetric reference (PyRadiomics differs on them only by its level-origin /
+// Ng-normalization conventions, not by definition). These are therefore VETTED against an external
+// definition, not merely pinned.
+static std::unordered_map<std::string, double> vetted_nyxus_convention_regression_glcm_feature_golden_values
 {
     {"GLCM_ACOR", 1437.33},
-    {"GLCM_ASM", 0.381801},
-    {"GLCM_CLUPROM", 6.1972e+06},
-    {"GLCM_CLUSHADE", 21905.3},
-    {"GLCM_CLUTEND", 1.5639042057291665e+03},
     {"GLCM_CONTRAST", 1.4448130208333334e+03},
-    {"GLCM_CORRELATION", 0.000690135},
     {"GLCM_DIFAVE", 23.6493},
     {"GLCM_DIFENTRO", 1.44004},
     {"GLCM_DIFVAR", 801.208},
     {"GLCM_DIS", 23.6493},
-    {"GLCM_ENERGY", 0.381801},
-    {"GLCM_ENTROPY", -20.1735},
     {"GLCM_HOM1", 0.580526},
-    {"GLCM_HOM2", 6.81505},
     {"GLCM_ID", 0.580526},
-    {"GLCM_IDN", 8.4432100308124380e-01},
     {"GLCM_IDM", 0.572168},
     {"GLCM_IDMN", 9.0029152005531590e-01},
+    {"GLCM_IDN", 8.4432100308124380e-01},
+    {"GLCM_IV", 0.000206466},
+    {"GLCM_SUMAVERAGE", 72.0369},
+    {"GLCM_SUMENTROPY", 1.61957}
+};
+
+// The remaining keys are transpose-sensitive: they depend on individual matrix entries or on the
+// grey-tone marginal means (mu_x/mu_y), which differ between the asymmetric matrix used here and a
+// symmetric one. As configured (symmetric_glcm=false) they genuinely diverge from any symmetric
+// oracle by >1% (verified: ASM/ENERGY 3.7%, CLUSHADE 46%, CLUTEND/SUMVARIANCE 3.2%, JE 9.3%,
+// JVAR/VARIANCE ~10%, ...), and ENTROPY/HOM2 are computed from raw counts (un-normalized), so they
+// have no probability-normalized oracle counterpart. They remain UNVETTED snapshots and could be
+// vetted only by rerunning with symmetric_glcm=true (or the radiomics/IBSI path) and comparing to
+// PyRadiomics. (Note: CLUTEND/SUMVARIANCE are NOT symmetrization-invariant in Nyxus because they
+// use the single row-marginal mean by_row_mean; the earlier comment listing them as invariant was
+// inaccurate.)
+static std::unordered_map<std::string, double> unvetted_nyxus_convention_regression_glcm_feature_golden_values
+{
+    {"GLCM_ASM", 0.381801},
+    {"GLCM_CLUPROM", 6.1972e+06},
+    {"GLCM_CLUSHADE", 21905.3},
+    {"GLCM_CLUTEND", 1.5639042057291665e+03},
+    {"GLCM_CORRELATION", 0.000690135},
+    {"GLCM_ENERGY", 0.381801},
+    {"GLCM_ENTROPY", -20.1735},
+    {"GLCM_HOM2", 6.81505},
     {"GLCM_INFOMEAS1", -0.184406},
     {"GLCM_INFOMEAS2", 0.495817},
-    {"GLCM_IV", 0.000206466},
     {"GLCM_JAVE", 35.5215},
     {"GLCM_JE", 1.87602},
     {"GLCM_JMAX", 0.527914},
     {"GLCM_JVAR", 828.383},
-    {"GLCM_SUMAVERAGE", 72.0369},
-    {"GLCM_SUMENTROPY", 1.61957},
     {"GLCM_SUMVARIANCE", 1.5639042057291665e+03},
     {"GLCM_VARIANCE", 674.871}
 };
+
+// A GLCM golden value now lives in exactly one of the two snapshots above. Look it up wherever it is.
+static double glcm_golden_value(const std::string& golden_key, bool& found)
+{
+    auto itv = vetted_nyxus_convention_regression_glcm_feature_golden_values.find(golden_key);
+    if (itv != vetted_nyxus_convention_regression_glcm_feature_golden_values.end())
+    {
+        found = true;
+        return itv->second;
+    }
+    auto itu = unvetted_nyxus_convention_regression_glcm_feature_golden_values.find(golden_key);
+    if (itu != unvetted_nyxus_convention_regression_glcm_feature_golden_values.end())
+    {
+        found = true;
+        return itu->second;
+    }
+    found = false;
+    return 0.0;
+}
 
 static std::string glcm_golden_key(const std::string& feature_name)
 {
@@ -96,7 +134,10 @@ void test_glcm_feature(const Feature2D& feature_, const std::string& feature_nam
 
     int feature = int(feature_);
     const std::string golden_key = glcm_golden_key(feature_name);
-    ASSERT_TRUE(unvetted_nyxus_convention_regression_glcm_feature_golden_values.count(golden_key) > 0);
+    // Golden lives in either the vetted or the (remaining) unvetted snapshot; require it in one.
+    bool golden_found = false;
+    const double golden = glcm_golden_value(golden_key, golden_found);
+    ASSERT_TRUE(golden_found);
     const bool is_ave_feature = golden_key != feature_name;
 
     double total = 0;
@@ -199,7 +240,7 @@ void test_glcm_feature(const Feature2D& feature_, const std::string& feature_nam
 
     // Verdict
     const double divisor = is_ave_feature ? 4.0 : 16.0;
-    ASSERT_TRUE(agrees_gt(total / divisor, unvetted_nyxus_convention_regression_glcm_feature_golden_values[golden_key], 100.));
+    ASSERT_TRUE(agrees_gt(total / divisor, golden, 100.));
 }
 
 void test_glcm_ACOR()

--- a/tests/test_glcm.h
+++ b/tests/test_glcm.h
@@ -11,16 +11,24 @@
 
 #include <unordered_map> 
 
-// Digital phantom values for intensity based features.
-// Calculated at 100 grey levels, offset 1, and Nyxus's asymmetric cooc matrix conventions.
-// REFRESHED 2026-06 after the GLCM background-pollution fix: the non-IBSI (MATLAB binning)
-// path now excludes out-of-ROI background pixels (matching the IBSI path and external oracles),
-// so the phantom slices z2-z4 (which contain masked-out pixels) yield corrected values. The 25
-// affected keys below were updated; CONTRAST/CLUTEND/SUMVARIANCE/IDN/IDMN were unchanged within
-// tolerance and kept at full precision. CORRELATION/INFOMEAS1 are softNAN(=0)-guarded on the one
-// degenerate (single-grey-level) phantom slice. The JAVE/JVAR/VARIANCE family is sensitive to the
-// stored row/column roles of the non-symmetric matrix (NOT transpose-invariant!).
-static std::unordered_map<std::string, double> glcm_values
+// Nyxus-convention GLCM regression snapshot. These values pin current Nyxus output to catch
+// drift; they do NOT assert correctness against an external definition (cross-tool verification
+// lives in the oracle_/3p_ tests, not here). Calculated at 100 grey levels, offset 1, via the
+// MATLAB-binning path with symmetric_glcm=false, i.e. on an *asymmetric* cooc matrix. That is a
+// configuration choice, NOT an inherent limitation: nyxus symmetrizes on the IBSI and radiomics
+// paths (matching PyRadiomics' symmetricalGLCM=True). As configured here the matrix increments only
+// (a,b), so the convention-sensitive Haralick family (JAVE/JVAR/VARIANCE/ACOR/CLUSHADE/CLUPROM/
+// INFOMEAS) is transpose-sensitive and diverges from a symmetric-matrix tool, while the
+// symmetrization-invariant keys (CONTRAST/CLUTEND/SUMVARIANCE/IDN/IDMN) would coincide with one.
+// These keys are therefore UNVETTED against a third-party oracle *as configured*; they could be
+// vetted by rerunning with symmetric_glcm=true (or the radiomics path) and comparing to PyRadiomics.
+// REFRESHED 2026-06 after the GLCM background-pollution fix: the non-IBSI (MATLAB binning) path
+// now excludes out-of-ROI background pixels (matching the IBSI path), so the phantom slices z2-z4
+// (which contain masked-out pixels) yield corrected snapshot values. The 25 affected keys below
+// were updated; CONTRAST/CLUTEND/SUMVARIANCE/IDN/IDMN were unchanged within tolerance and kept at
+// full precision. CORRELATION/INFOMEAS1 are softNAN(=0)-guarded on the one degenerate
+// (single-grey-level) phantom slice.
+static std::unordered_map<std::string, double> unvetted_nyxus_convention_regression_glcm_feature_golden_values
 {
     {"GLCM_ACOR", 1437.33},
     {"GLCM_ASM", 0.381801},
@@ -54,7 +62,7 @@ static std::unordered_map<std::string, double> glcm_values
     {"GLCM_VARIANCE", 674.871}
 };
 
-static std::string glcm_truth_key(const std::string& feature_name)
+static std::string glcm_golden_key(const std::string& feature_name)
 {
     static const std::string ave_suffix = "_AVE";
     if (feature_name.size() > ave_suffix.size() &&
@@ -87,9 +95,9 @@ void test_glcm_feature(const Feature2D& feature_, const std::string& feature_nam
     GLCMFeature::angles = { 0, 45, 90, 135 };
 
     int feature = int(feature_);
-    const std::string truth_key = glcm_truth_key(feature_name);
-    ASSERT_TRUE(glcm_values.count(truth_key) > 0);
-    const bool is_ave_feature = truth_key != feature_name;
+    const std::string golden_key = glcm_golden_key(feature_name);
+    ASSERT_TRUE(unvetted_nyxus_convention_regression_glcm_feature_golden_values.count(golden_key) > 0);
+    const bool is_ave_feature = golden_key != feature_name;
 
     double total = 0;
 
@@ -191,7 +199,7 @@ void test_glcm_feature(const Feature2D& feature_, const std::string& feature_nam
 
     // Verdict
     const double divisor = is_ave_feature ? 4.0 : 16.0;
-    ASSERT_TRUE(agrees_gt(total / divisor, glcm_values[truth_key], 100.));
+    ASSERT_TRUE(agrees_gt(total / divisor, unvetted_nyxus_convention_regression_glcm_feature_golden_values[golden_key], 100.));
 }
 
 void test_glcm_ACOR()

--- a/tests/test_glcm.h
+++ b/tests/test_glcm.h
@@ -23,19 +23,23 @@
 // (which contain masked-out pixels) yield corrected snapshot values. CORRELATION/INFOMEAS1 are
 // softNAN(=0)-guarded on the degenerate (single-grey-marginal) phantom directions.
 //
-// ORACLE-VETTED 2026-07: the 14 keys below were run against third-party symmetric-matrix oracles
-// (PyRadiomics v3.0.1) and a transparent standard-Haralick numpy reference on the *same* per-slice
-// matlab-binned phantom images, aggregated the same way (mean over 4 slices x 4 angles). Each is
-// mathematically symmetrization-invariant (depends only on p_{x+y}, p_{x-y}, or a weighting
-// g(i,j)=g(j,i)), so the asymmetric-matrix snapshot coincides with the symmetric-oracle value to
-// within the test's 1% tolerance. PyRadiomics gives direct bit-agreement for CONTRAST/DIFAVE/DIS/
-// DIFENTRO/DIFVAR/ID/HOM1/IDM/IV/SUMENTROPY; ACOR/IDN/IDMN/SUMAVERAGE are invariant by construction
-// and matched the numpy symmetric reference (PyRadiomics differs on them only by its level-origin /
-// Ng-normalization conventions, not by definition). These are therefore VETTED against an external
+// ORACLE-VETTED 2026-07 (corrected 2026-07-09): the 10 keys below were run against a third-party
+// symmetric-matrix oracle (PyRadiomics v3.0.1) on the *same* per-slice matlab-binned phantom images,
+// aggregated the same way (mean over 4 slices x 4 angles). Each depends only on the grey-level
+// DIFFERENCE p_{x-y} / |i-j| (CONTRAST/DIFAVE/DIS/DIFENTRO/DIFVAR/ID/HOM1/IDM/IV/SUMENTROPY), so it is
+// invariant to BOTH matrix symmetrization AND the absolute level values that matlab binning re-maps
+// -> PyRadiomics agrees within the test's 1% tolerance. These are VETTED against an external
 // definition, not merely pinned.
+// CORRECTION (2026-07-09, PR #356 review): ACOR/IDN/IDMN/SUMAVERAGE were previously listed here as
+// oracle-vetted -- that was WRONG for this ibsi=False / matlab-binning config. They depend on the
+// absolute grey-level values / Ng, which matlab binning re-maps, so under this config they diverge
+// from PyRadiomics by up to ~43% (ACOR; measured on a dense 8-level phantom: Nyxus ibsi=False ACOR
+// 29.25 vs oracle 20.51). They were therefore MOVED to the unvetted snapshot below. They ARE
+// genuinely third-party-vetted on the IBSI path (symmetric matrix, identity binning), where Nyxus
+// ibsi=True == PyRadiomics exactly (ACOR 20.512755, SUMAVERAGE 9.020408, IDN 0.779479, IDMN
+// 0.887342) -- covered by the dense-phantom oracle test in tests/python/test_glcm_oracle.py.
 static std::unordered_map<std::string, double> vetted_nyxus_convention_regression_glcm_feature_golden_values
 {
-    {"GLCM_ACOR", 1437.33},
     {"GLCM_CONTRAST", 1.4448130208333334e+03},
     {"GLCM_DIFAVE", 23.6493},
     {"GLCM_DIFENTRO", 1.44004},
@@ -44,25 +48,32 @@ static std::unordered_map<std::string, double> vetted_nyxus_convention_regressio
     {"GLCM_HOM1", 0.580526},
     {"GLCM_ID", 0.580526},
     {"GLCM_IDM", 0.572168},
-    {"GLCM_IDMN", 9.0029152005531590e-01},
-    {"GLCM_IDN", 8.4432100308124380e-01},
     {"GLCM_IV", 0.000206466},
-    {"GLCM_SUMAVERAGE", 72.0369},
     {"GLCM_SUMENTROPY", 1.61957}
 };
 
-// The remaining keys are transpose-sensitive: they depend on individual matrix entries or on the
-// grey-tone marginal means (mu_x/mu_y), which differ between the asymmetric matrix used here and a
-// symmetric one. As configured (symmetric_glcm=false) they genuinely diverge from any symmetric
-// oracle by >1% (verified: ASM/ENERGY 3.7%, CLUSHADE 46%, CLUTEND/SUMVARIANCE 3.2%, JE 9.3%,
-// JVAR/VARIANCE ~10%, ...), and ENTROPY/HOM2 are computed from raw counts (un-normalized), so they
-// have no probability-normalized oracle counterpart. They remain UNVETTED snapshots and could be
-// vetted only by rerunning with symmetric_glcm=true (or the radiomics/IBSI path) and comparing to
-// PyRadiomics. (Note: CLUTEND/SUMVARIANCE are NOT symmetrization-invariant in Nyxus because they
-// use the single row-marginal mean by_row_mean; the earlier comment listing them as invariant was
-// inaccurate.)
+// These keys are NOT oracle-matched under this config, for one of two reasons.
+// (a) Transpose-sensitive: they depend on individual matrix entries or on the grey-tone marginal
+//     means (mu_x/mu_y), which differ between the asymmetric matrix used here and a symmetric one.
+//     As configured (symmetric_glcm=false) they diverge from any symmetric oracle by >1% (verified:
+//     ASM/ENERGY 3.7%, CLUSHADE 46%, CLUTEND/SUMVARIANCE 3.2%, JE 9.3%, JVAR/VARIANCE ~10%, ...), and
+//     ENTROPY/HOM2 are computed from raw counts (un-normalized), so they have no probability-
+//     normalized oracle counterpart.
+// (b) Absolute-level / Ng-dependent (ACOR/IDN/IDMN/SUMAVERAGE, moved here from the vetted map on
+//     2026-07-09 per PR #356 review): matlab binning re-maps the absolute grey levels and Ng, so on
+//     this ibsi=False config they diverge from PyRadiomics (up to ~43% for ACOR). They ARE genuinely
+//     oracle-vetted on the IBSI path (symmetric matrix, identity binning) -- see the dense-phantom
+//     test in tests/python/test_glcm_oracle.py, which pins them tightly against PyRadiomics.
+// All of the above remain UNVETTED snapshots on this config; the transpose-sensitive group could be
+// vetted by rerunning with symmetric_glcm=true (or the radiomics/IBSI path). (Note: CLUTEND/
+// SUMVARIANCE are NOT symmetrization-invariant in Nyxus because they use the single row-marginal mean
+// by_row_mean; the earlier comment listing them as invariant was inaccurate.)
 static std::unordered_map<std::string, double> unvetted_nyxus_convention_regression_glcm_feature_golden_values
 {
+    {"GLCM_ACOR", 1437.33},                 // moved from vetted 2026-07-09: absolute-level-dependent, ibsi=False != oracle (IBSI-path vetted)
+    {"GLCM_IDMN", 9.0029152005531590e-01},  // moved from vetted 2026-07-09: Ng-dependent, ibsi=False != oracle (IBSI-path vetted)
+    {"GLCM_IDN", 8.4432100308124380e-01},   // moved from vetted 2026-07-09: Ng-dependent, ibsi=False != oracle (IBSI-path vetted)
+    {"GLCM_SUMAVERAGE", 72.0369},           // moved from vetted 2026-07-09: absolute-level-dependent, ibsi=False != oracle (IBSI-path vetted)
     {"GLCM_ASM", 0.381801},
     {"GLCM_CLUPROM", 6.1972e+06},
     {"GLCM_CLUSHADE", 21905.3},

--- a/tests/test_glcm_oracle.h
+++ b/tests/test_glcm_oracle.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <gtest/gtest.h>
+#include <typeinfo>
+
+#include "../src/nyx/environment.h"
+#include "../src/nyx/feature_settings.h"
+#include "../src/nyx/features/glcm.h"
+
+// Regression guard for the GLCM "offset = 0 default" defect (found 2026-06).
+//
+// The production path (CLI and Python featurize) builds GLCM settings via
+// Environment::compile_feature_settings(). That function used to initialise only the COMMON
+// settings and left the GLCM-specific ones (GLCM_OFFSET / GLCM_GREYDEPTH / GLCM_NUMANG)
+// zero-initialised. With GLCM_OFFSET == 0 the co-occurrence shift is dx = dy = 0, so every
+// pixel co-occurs with itself -> a purely diagonal matrix -> CONTRAST = 0, CORRELATION = 1 for
+// any image. The existing test_glcm.h cases never caught this because they hard-code
+// GLCM_OFFSET = 1 (and run on a fully-masked phantom). This test exercises the real default.
+inline void test_glcm_bug_offset_default_is_one()
+{
+    Environment e;
+    e.set_coarse_gray_depth(64);
+    e.compile_feature_settings();
+
+    const Fsettings& s = e.get_feature_settings(typeid(GLCMFeature));
+
+    // co-occurrence distance must default to 1 (IBSI delta = 1), NOT 0
+    ASSERT_EQ(STNGS_GLCM_OFFSET(s), 1);
+    // the GLCM-specific grey depth and angle count must be initialised, not left at 0
+    ASSERT_GT(STNGS_GLCM_GREYDEPTH(s), 0);
+    ASSERT_GT(STNGS_GLCM_NUMANG(s), 0);
+}


### PR DESCRIPTION
Two production-path defects the hard-coded phantom tests missed:

- GLCM_OFFSET was zero-initialised when settings are compiled from the production path, so dx=dy=0 -> every pixel co-occurs with itself -> CONTRAST=0 for any image. Default GLCM_OFFSET=1 (IBSI delta=1) in env_features.cpp (plus GLCM_GREYDEPTH/GLCM_NUMANG).
- The MATLAB grey-binning path maps off-ROI background (0) to level 1; the old zero-skip guard only ran on the IBSI path, so background inside a concave ROI flooded the co-occurrence matrix and diluted CONTRAST. Skip on the ORIGINAL intensity (imR==0) in all binning paths (glcm.cpp).
- Soft-NAN guard CORRELATION/INFOMEAS1 for the degenerate single-grey-level case that a correctly-masked tiny ROI can produce (glcm.cpp/.h, glcm_nontriv.cpp).

Refresh the 25 background-sensitive phantom goldens in test_glcm.h (the background-insensitive keys are unchanged), add test_glcm_bugs.h with a production-path offset-default regression guard (registered in test_all.cc), and add GLCM contrast/background Python tests validated against PyRadiomics/MIRP.