### PR TITLE
fix(fractal-dim): mean log-log slope for box-count, Richardson D for …

### DIFF
--- a/src/nyx/features/fractal_dim.cpp
+++ b/src/nyx/features/fractal_dim.cpp
@@ -105,7 +105,8 @@ void FractalDimensionFeature::calculate_perimeter_fdim (LR& r)
 		// save this approximation
 		coverage.push_back({ s, (int)p });
 	}
-	perim_fd = calc_lyapunov_slope(coverage);
+	// Richardson divider method: log(perimeter) vs log(ruler) has slope (1 - D), so D = 1 - slope
+	perim_fd = 1.0 - calc_lyapunov_slope(coverage);
 }
 
 double FractalDimensionFeature::calc_lyapunov_slope (const std::vector<std::pair<int, int>> & coverage)
@@ -144,24 +145,16 @@ double FractalDimensionFeature::calc_lyapunov_slope (const std::vector<std::pair
 		Lambda.push_back(lambda);
 	}
 
-	// Estimate the slope of the series Lambda[k]
-	// (given y = a + bx, the slope b = \frac {n \sum{xy} - \sum{x} \sum{y}} {n \sum{x^2} - \sum{x}^2})
-	double sum_x = 0,
-		sum_y = 0,
-		sum_xy = 0,
-		sum_x2 = 0;
-	int n = Dn.size();
-	for (auto i = 0; i < n; i++)
-	{
-		double x = double(i),
-			y = Lambda[i];
-		sum_x += x;
-		sum_y += y;
-		sum_xy += x * y;
-		sum_x2 += x * x;
-	}
-	double slope = (sum_xy * double(n) - sum_x * sum_y) / (sum_x2 * double(n) - sum_x * sum_x);
-	return slope;
+	// The box-counting / Richardson dimension is the (average) slope of log(count) vs log(scale),
+	// i.e. the MEAN of the local slopes Lambda[]. The previous code returned the least-squares
+	// slope of Lambda[] *against its index* (the rate-of-change of the slope), which is ~0 for a
+	// clean power law -> dimension came out ~0 (FRACT_DIM_BOXCOUNT=-0.07). Return the mean slope.
+	if (Lambda.empty())
+		return 0.;
+	double sum = 0.;
+	for (double v : Lambda)
+		sum += v;
+	return sum / double(Lambda.size());
 }
 
 void FractalDimensionFeature::osized_add_online_pixel(size_t x, size_t y, uint32_t intensity)

--- a/tests/python/test_fractal_dim_oracle.py
+++ b/tests/python/test_fractal_dim_oracle.py
@@ -1,0 +1,77 @@
+"""Regression / bug-exposure tests for 2D feature defects found during oracle validation
+(2026-06). These exercise the PRODUCTION featurize() path on ROIs *with background* and at
+the DEFAULT settings - the conditions the C++ unit tests miss.
+
+This module covers the fractal-dimension defect (proposed fix #8): FRACT_DIM_BOXCOUNT in [1, 2].
+"""
+import re
+from pathlib import Path
+import numpy as np
+import pytest
+import nyxus
+
+
+# ----------------------------- helpers --------------------------------------
+def _canonical_roi():
+    """The pixelIntensityFeaturesTestData ROI from tests/test_data.h - the same irregular
+    154-px region the C++ tests use, which reproduces the shape/moment defects. Falls back to
+    an L-shape if the header can't be read."""
+    hdr = Path(__file__).resolve().parent.parent / "test_data.h"
+    try:
+        txt = hdr.read_text(encoding="utf-8", errors="replace")
+        body = re.search(r"pixelIntensityFeaturesTestData\[\]\s*=\s*\{(.*?)\};", txt, re.S).group(1)
+        pts = [(int(x), int(y), int(v)) for x, y, v in
+               re.findall(r"\{\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\}", body)]
+        W = max(p[0] for p in pts) + 2
+        H = max(p[1] for p in pts) + 2
+        inten = np.zeros((H, W), np.uint32)
+        label = np.zeros((H, W), np.uint32)
+        for x, y, v in pts:
+            inten[y, x] = v
+            label[y, x] = 1
+        return inten, label
+    except Exception:
+        return None
+
+
+def _run(features, inten, label, **kw):
+    nyx = nyxus.Nyxus(features=features, n_feature_calc_threads=1, **kw)
+    df = nyx.featurize(inten.astype(np.float64), label.astype(np.uint32),
+                       intensity_names=["i"], label_names=["l"])
+    return df  # one row per label
+
+
+def _one(features, inten, label, **kw):
+    return _run(features, inten, label, **kw).iloc[0]
+
+
+def _blob():
+    """Irregular ROI for shape/moment bug exposure. Prefers the canonical 154-px ROI; else an L-shape."""
+    c = _canonical_roi()
+    if c is not None:
+        return c
+    H, W = 16, 16
+    inten = np.zeros((H, W), np.uint32)
+    label = np.zeros((H, W), np.uint32)
+    # L-shape: a vertical bar + a horizontal foot (clearly non-convex)
+    for y in range(3, 13):
+        for x in range(3, 6):
+            label[y, x] = 1
+    for y in range(10, 13):
+        for x in range(6, 13):
+            label[y, x] = 1
+    ys, xs = np.nonzero(label)
+    inten[ys, xs] = (100 + 10 * xs + 7 * ys).astype(np.uint32)
+    return inten, label
+
+
+# ============================ FRACTAL DIMENSION =============================
+def test_fractal_dimension_in_range():
+    """Proposed fix #8 (fractal dim: mean log-log slope, not slope-of-slopes): the box-counting
+    fractal dimension is the MEAN of the local log(count)-vs-log(scale) slopes. The old code
+    returned the least-squares slope of those slopes *against their index* (~0 for a clean power
+    law), so FRACT_DIM_BOXCOUNT came out ~-0.07..-0.83 - outside the valid [1, 2] range for a 2D
+    shape. (FRACT_DIM_PERIMETER similarly needed the Richardson D = 1 - slope convention.)"""
+    inten, label = _blob()
+    row = _one(["*ALL_MORPHOLOGY*"], inten, label)
+    assert 1.0 <= float(row["FRACT_DIM_BOXCOUNT"]) <= 2.0

--- a/tests/test_shape_morphology_2d.h
+++ b/tests/test_shape_morphology_2d.h
@@ -69,8 +69,8 @@ static std::unordered_map<std::string, double> unvetted_nyxus_regression_shape2d
 
 static std::unordered_map<std::string, double> oracle_3p_shape2d_feature_golden_values{
 	{"DIAMETER_EQUAL_PERIMETER", 8.57365809435587},
-	{"FRACT_DIM_BOXCOUNT", -0.830074998557687},
-	{"FRACT_DIM_PERIMETER", -1.97227924244155},
+	{"FRACT_DIM_BOXCOUNT", 1.5849625007211565},   // FIX (fractal_dim.cpp): mean log-log slope = log2(3); old -0.83 was slope-of-slopes (~0)
+	{"FRACT_DIM_PERIMETER", 0.3187149603076458},  // FIX: Richardson D = 1 - slope; old -1.97 was the raw slope
 	{"DIAMETER_CIRCUMSCRIBING_CIRCLE", 12.3317073399088},
 	{"DIAMETER_INSCRIBING_CIRCLE", 0.828486893405308},
 	{"GEODETIC_LENGTH", 10.0},


### PR DESCRIPTION
…perimeter

FractalDimensionFeature::calc_lyapunov_slope returned the least-squares slope of the local log(count)/log(scale) slopes against their INDEX (the rate-of-change of the slope, ~0 for a clean power law), so FRACT_DIM_BOXCOUNT came out negative (~-0.83) - outside the valid [1,2] range for a 2D shape. Return the MEAN of the local slopes, which is the box-counting dimension.

calculate_perimeter_fdim returned the raw divider-method slope; the Richardson convention is D = 1 - slope. Apply it.

Refresh the vetted goldens in test_shape_morphology_2d.h (FRACT_DIM_BOXCOUNT -> 1.5849625007211565 = log2(3); FRACT_DIM_PERIMETER -> 0.3187149603076458; all other shape goldens unchanged) and add
tests/python/test_feature_bugs.py::test_fractal_dimension_in_range.