### PR TITLE
perf(omezarr): open the z5 dataset once, not per tile

### DIFF
--- a/src/nyx/omezarr.h
+++ b/src/nyx/omezarr.h
@@ -8,6 +8,8 @@
 
 // factory functions to create files, groups and datasets
 #include "z5/factory.hxx"
+// dataset type (cached handle member)
+#include "z5/dataset.hxx"
 // handles for z5 filesystem objects
 #include "z5/filesystem/handle.hxx"
 // z5 multiarray API (ArrayView-based, no xtensor)
@@ -64,11 +66,17 @@ public:
         else if (dtype_str == "<f4") {data_format_=9;} //float
         else if (dtype_str == "<f8") {data_format_=10;} //double
         else {data_format_=2;} //uint16_t
+
+        // Open the dataset once and cache the handle. The dataset metadata is
+        // immutable for the lifetime of this loader, so there is no need to
+        // re-open (and re-parse the .zarray metadata) on every tile read.
+        ds_ = z5::openDataset(*zarr_ptr_, ds_name_);
     }
 
     /// @brief NyxusOmeZarrLoader destructor
-    ~NyxusOmeZarrLoader() override 
+    ~NyxusOmeZarrLoader() override
     {
+        ds_ = nullptr;
         zarr_ptr_ = nullptr;
     }
 
@@ -130,8 +138,6 @@ public:
     template<typename FileType>
     void loadTile(std::shared_ptr<std::vector<DataType>> &dest, size_t pixel_row_index, 
                   size_t pixel_col_index, size_t pixel_layer_index) {
-        auto ds = z5::openDataset(*zarr_ptr_, ds_name_);
-        
         size_t data_height = tile_height_, data_width = tile_width_;
         if (pixel_row_index + data_height > full_height_) {
             data_height = full_height_ - pixel_row_index;
@@ -148,8 +154,8 @@ public:
         auto view = z5::multiarray::makeView(buffer.data(), shape);
         z5::types::ShapeType offset = {0, 0, pixel_layer_index, pixel_row_index, pixel_col_index};
         
-        // Read subarray from z5 dataset
-        z5::multiarray::readSubarray<FileType>(*ds, view, offset.begin());
+        // Read subarray from the cached z5 dataset
+        z5::multiarray::readSubarray<FileType>(*ds_, view, offset.begin());
         
         // Copy from buffer to destination tile, handling partial tiles
         for (size_t k = 0; k < data_height; ++k) {
@@ -205,5 +211,6 @@ private:
     short data_format_ = 0;
     std::unique_ptr<z5::filesystem::handle::File> zarr_ptr_;
     std::string ds_name_;
+    std::unique_ptr<z5::Dataset> ds_;   ///< Cached dataset handle (opened once)
 };
 #endif //OMEZARR_SUPPORT

--- a/src/nyx/raw_omezarr.h
+++ b/src/nyx/raw_omezarr.h
@@ -7,6 +7,8 @@
 
 // factory functions to create files, groups and datasets
 #include "z5/factory.hxx"
+// dataset type (cached handle member)
+#include "z5/dataset.hxx"
 // handles for z5 filesystem objects
 #include "z5/filesystem/handle.hxx"
 // z5 multiarray API (ArrayView-based, no xtensor)
@@ -59,10 +61,16 @@ public:
 
         // allocate the buffer
         dest = std::vector<uint32_t> (tile_height_ * tile_width_);
+
+        // Open the dataset once and cache the handle. The dataset metadata is
+        // immutable for the lifetime of this loader, so there is no need to
+        // re-open (and re-parse the .zarray metadata) on every tile read.
+        ds_ = z5::openDataset(*zarr_ptr_, ds_name_);
     }
 
     ~RawOmezarrLoader() override
     {
+        ds_ = nullptr;
         zarr_ptr_ = nullptr;
     }
 
@@ -133,8 +141,6 @@ public:
     template<typename FileType>
     void loadTile(size_t pixel_row_index, size_t pixel_col_index, size_t pixel_layer_index)
     {
-        auto ds = z5::openDataset(*zarr_ptr_, ds_name_);
-        
         size_t data_height = tile_height_, data_width = tile_width_;
         if (pixel_row_index + data_height > full_height_) {
             data_height = full_height_ - pixel_row_index;
@@ -151,8 +157,8 @@ public:
         auto view = z5::multiarray::makeView(buffer.data(), shape);
         z5::types::ShapeType offset = {0, 0, pixel_layer_index, pixel_row_index, pixel_col_index};
         
-        // Read subarray from z5 dataset
-        z5::multiarray::readSubarray<FileType>(*ds, view, offset.begin());
+        // Read subarray from the cached z5 dataset
+        z5::multiarray::readSubarray<FileType>(*ds_, view, offset.begin());
         
         // zero-fill the buffer foreseeing its partial filling at incomplete (tail) tiles
         std::fill(dest.begin(), dest.end(), 0);
@@ -211,6 +217,7 @@ private:
     short data_format_ = 0;
     std::unique_ptr<z5::filesystem::handle::File> zarr_ptr_;
     std::string ds_name_;
+    std::unique_ptr<z5::Dataset> ds_;   ///< Cached dataset handle (opened once)
 
     std::vector<uint32_t> dest;
 };


### PR DESCRIPTION
## Summary

Follow-up to the z5 3.0.1 upgrade (#360). Both OME-Zarr loaders opened the dataset **on every tile read**:

```cpp
void loadTile(...) {
    auto ds = z5::openDataset(*zarr_ptr_, ds_name_);  // re-parses .zarray every call
    ...
    z5::multiarray::readSubarray<FileType>(*ds, view, offset.begin());
}
```

`z5::openDataset` re-stats and re-parses the dataset's `.zarray` metadata (shape, chunks, dtype, compressor) from disk each time. On a whole-slide image that's thousands of redundant parses of an immutable dataset.

This opens the dataset **once in the constructor**, caches the returned `std::unique_ptr<z5::Dataset>`, and reads every tile through the cached handle.

## Why it's safe

- `readSubarray` takes a `const Dataset&`, so a single cached handle is safe to share across all tile reads, including the multithreaded tile-loader path (reads don't mutate the handle).
- The constructor already opens the store and throws on a bad dataset, so opening the handle there keeps the same failure semantics.
- Pure optimization: no change to what's read or returned.

## Testing

Verified both readers (`NyxusOmeZarrLoader` and `RawOmezarrLoader`) still return exact pixel values and full-image checksums against the committed `tests/data/omezarr` datasets, **including the multi-tile / partial-tile cases** — those now read all tiles through the single cached handle, which exercises the reuse path directly. The existing `test_omezarr.h` GTest suite covers this; all assertions pass.

## Scope

Two files, +23/-9, no behavior change. This is item 1 from the #360 review follow-ups (the highest-value, zero-risk one). The remaining follow-ups (8-bit/float16 dtype-string matching, float→uint32 truncation, added dtype test fixtures) change what inputs the reader accepts and will come as a separate PR with their own test data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)