### PR TITLE
fix: upgrade Docker build to CUDA 12.6 and Python 3.11

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Copy 3rd-party libraries to staging directory
       working-directory: ${{github.workspace}}
       run: |
-        bash ci-utils/docker_copy_3rd_party_libs.sh ${{github.workspace}}/miniconda-for-nyxus/envs/nyxus-3.9
+        bash ci-utils/docker_copy_3rd_party_libs.sh ${{github.workspace}}/miniconda-for-nyxus/envs/nyxus-3.11
 
     - name: Set version from .version file
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.5.2-runtime-ubuntu20.04
+FROM nvidia/cuda:12.6.0-runtime-ubuntu22.04
 
 COPY VERSION /
 

--- a/ci-utils/build_conda.sh
+++ b/ci-utils/build_conda.sh
@@ -17,7 +17,7 @@ MINICONDA=$PWD/miniconda-for-nyxus # Modify this to your preferred location for 
 CPP_BUILD_DIR=$PWD
 SRC_ROOT=$1 #source dir location
 NYXUS_ROOT=$SRC_ROOT
-PYTHON=3.9
+PYTHON=3.11
 
 git config --global --add safe.directory $NYXUS_ROOT
 
@@ -66,6 +66,7 @@ mkdir -p $CPP_BUILD_DIR
 pushd $CPP_BUILD_DIR
 cmake -DCMAKE_PREFIX_PATH=$CONDA_PREFIX \
       -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
+      -DCMAKE_CUDA_COMPILER=$CONDA_PREFIX/bin/nvcc \
       -DBUILD_CLI=ON \
       -DUSEGPU=ON \
       -DALLEXTRAS=ON \

--- a/ci-utils/envs/conda_linux_gpu.txt
+++ b/ci-utils/envs/conda_linux_gpu.txt
@@ -1,2 +1,4 @@
-cudatoolkit=11.5.0
-cudatoolkit-dev=11.5.0
+cuda-version=12.6
+cuda-nvcc=12.6
+cuda-cudart-dev=12.6
+libcufft-dev


### PR DESCRIPTION
## Summary

Upgrades the GPU Docker build to CUDA 12.6 and Python 3.11:

- Dockerfile base image `nvidia/cuda:11.5.2-runtime-ubuntu20.04` → `nvidia/cuda:12.6.0-runtime-ubuntu22.04`
- `conda_linux_gpu.txt`: replace `cudatoolkit=11.5` / `cudatoolkit-dev=11.5` with the CUDA 12.6 conda-forge packages that actually ship `nvcc` (`cuda-version=12.6`, `cuda-nvcc=12.6`, `cuda-cudart-dev=12.6`, `libcufft-dev`)
- `build_conda.sh`: add `-DCMAKE_CUDA_COMPILER=$CONDA_PREFIX/bin/nvcc` so CMake doesn't rely on `check_language(CUDA)` discovery, and bump `PYTHON=3.9` → `3.11` (3.9 is EOL)
- `publish_docker.yml`: update the hardcoded `nyxus-3.9` env path to `nyxus-3.11`

## Root cause (the CUDA fix)

`cudatoolkit-dev=11.5.0` installs headers/libs but doesn't place `nvcc` where CMake's `check_language(CUDA)` looks, so CMake reported `CMAKE_CUDA_COMPILER=NOTFOUND` and hit the fatal error in `CMakeLists.txt`. The CUDA 12.6 conda-forge packages ship `nvcc`, and passing `-DCMAKE_CUDA_COMPILER` explicitly makes discovery deterministic.

## Rebased onto the z5 3.0.1 upgrade

This branch previously carried two extra commits that worked around the old z5 2.0.20 + xtensor stack in the Docker build:
- "check for `z5/multiarray/xtensor_access.hxx` instead of `z5/z5.hxx`"
- "install z5 2.0.20 C++ headers in Docker build script"

Both are **moot** now that the z5 3.0.1 upgrade is merged into `main`: CMake looks for `z5/z5.hxx` again, and the z5 C++ headers come from the `z5py >=3.0.1` conda package in `conda_cpp.txt` (no manual header install needed). The branch has been rebased onto the current `main` and those two commits dropped, leaving only the Docker/CUDA/Python change.

Note the Python 3.11 bump is now also **required** for the GPU build to solve, not just a nicety: z5py 3.0.x has no Python 3.10/3.9 build (3.11+ only), and `build_conda.sh` pulls z5 via `conda_cpp.txt` (`z5py >=3.0.1`).

## Test plan

- [ ] Trigger the `Publish Docker image` workflow on this branch and confirm the "Run Build Script" step passes (CUDA build + z5 3.0.1 via z5py on Python 3.11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)