### PR TITLE
Fix heap overrun / data corruption reading 32-bit unsigned TIFFs

### DIFF
--- a/src/nyx/grayscale_tiff.h
+++ b/src/nyx/grayscale_tiff.h
@@ -464,7 +464,7 @@ public:
                         break;
                     case 16:copyRow<uint16_t>(buf, tileDataVec, layer - startLayer, row - startRow, startCol, endCol);
                         break;
-                    case 32:copyRow<size_t>(buf, tileDataVec, layer - startLayer, row - startRow, startCol, endCol);
+                    case 32:copyRow<uint32_t>(buf, tileDataVec, layer - startLayer, row - startRow, startCol, endCol); // FIX: was copyRow<size_t> (8 bytes on Win64) for a 4-byte sample -> reads 2x past the scanline buffer (AV / heap corruption) and yields wrong pixels; uint32_t matches the 32-bit sample (cf. signed int32_t below, tile-loader uint32_t, raw_tiff.h uint32_t)
                         break;
                     case 64:copyRow<uint64_t>(buf, tileDataVec, layer - startLayer, row - startRow, startCol, endCol);
                         break;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TEST_SRC
 	test_initialization.h
 	test_3d_nifti.h
 	test_omezarr.h
+	test_tiff_loader.h
 	${TEST_SOURCE_FILES}
 )
 add_executable(runAllTests ${TEST_SRC})

--- a/tests/python/test_tiff_loader.py
+++ b/tests/python/test_tiff_loader.py
@@ -1,0 +1,104 @@
+"""Regression tests for the TIFF tile/strip loader.
+
+Guards the fix in src/nyx/grayscale_tiff.h where the 32-bit *unsigned* sample
+case of NyxusGrayscaleTiffStripLoader::loadTileFromFile used copyRow<size_t>
+instead of copyRow<uint32_t>. size_t is 8 bytes on LP64/Win64 while a 32-bit
+sample is 4 bytes, so copyRow read ((size_t*)buf)[col] -- 2x past the libtiff
+scanline buffer. That corrupted pixel values (columns shifted / garbage) and
+could crash (heap over-read), for ANY uint32 TIFF read from disk.
+
+This must go through a *file-based* API (featurize_files / featurize_directory)
+because the in-memory Nyxus.featurize(numpy, ...) path never touches the tile
+loader and so cannot exercise the bug. tifffile writes strip-based TIFFs by
+default (no tile=), which selects the strip loader that carried the bug.
+"""
+
+import numpy as np
+import pytest
+
+import nyxus
+
+# tifffile is only needed to synthesize the on-disk uint32 TIFF; skip cleanly if
+# it is not available in the test environment.
+tifffile = pytest.importorskip("tifffile")
+
+
+# Intensities deliberately span past the 16-bit range, including a value above
+# 2**31, so any wrong element size / truncation / column shift in the loader
+# produces a detectably wrong MAX and INTEGRATED_INTENSITY (or a crash).
+_INTENSITY = np.array(
+    [
+        [100,        70_000,      300_000,       16_777_216],
+        [4_000_000,  5,           123_456_789,   3_000_000_000],
+        [65_535,     65_536,      2_147_483_648, 1],
+    ],
+    dtype=np.uint32,
+)
+
+
+def _write_strip_tiff(path, arr):
+    # No tile= -> strip-based TIFF -> NyxusGrayscaleTiffStripLoader (the fixed path).
+    tifffile.imwrite(str(path), arr)
+
+
+def test_uint32_strip_tiff_pixels_read_correctly(tmp_path):
+    """A uint32 strip TIFF loaded from disk yields the exact input statistics."""
+    int_dir = tmp_path / "int"
+    seg_dir = tmp_path / "seg"
+    int_dir.mkdir()
+    seg_dir.mkdir()
+
+    inten = _INTENSITY
+    mask = np.ones_like(inten, dtype=np.uint32)  # single ROI covering the whole image
+    _write_strip_tiff(int_dir / "img.tif", inten)
+    _write_strip_tiff(seg_dir / "img.tif", mask)
+
+    nyx = nyxus.Nyxus(
+        features=["MAX", "MIN", "INTEGRATED_INTENSITY", "MEAN"],
+        n_feature_calc_threads=1,
+    )
+    f = nyx.featurize_files(
+        intensity_files=[str(int_dir / "img.tif")],
+        mask_files=[str(seg_dir / "img.tif")],
+        single_roi=False,
+    )
+
+    assert f.shape[0] == 1, "expected exactly one ROI"
+    # With the old copyRow<size_t> these fail (shuffled/garbage pixels) or crash.
+    assert f.at[0, "MAX"] == float(inten.max())          # 3_000_000_000
+    assert f.at[0, "MIN"] == float(inten.min())          # 1
+    assert np.isclose(f.at[0, "INTEGRATED_INTENSITY"], float(inten.sum()), rtol=0, atol=0.5)
+    assert np.isclose(f.at[0, "MEAN"], float(inten.mean()), rtol=1e-9)
+
+
+def test_uint32_tiff_from_disk_matches_in_memory(tmp_path):
+    """The file loader must read the same values as the in-memory numpy path.
+
+    Nyxus.featurize(numpy) never uses the tile loader, so it is a correct oracle:
+    if the on-disk read matches it for a uint32 image, the loader typing is right.
+    """
+    int_dir = tmp_path / "int"
+    seg_dir = tmp_path / "seg"
+    int_dir.mkdir()
+    seg_dir.mkdir()
+
+    inten = _INTENSITY
+    mask = np.ones_like(inten, dtype=np.uint32)
+    _write_strip_tiff(int_dir / "img.tif", inten)
+    _write_strip_tiff(seg_dir / "img.tif", mask)
+
+    feats = ["MAX", "MIN", "INTEGRATED_INTENSITY", "MEAN", "MEDIAN", "RANGE"]
+
+    from_disk = nyxus.Nyxus(features=feats, n_feature_calc_threads=1).featurize_files(
+        intensity_files=[str(int_dir / "img.tif")],
+        mask_files=[str(seg_dir / "img.tif")],
+        single_roi=False,
+    )
+    in_memory = nyxus.Nyxus(features=feats, n_feature_calc_threads=1).featurize(
+        inten, mask
+    )
+
+    for col in feats:
+        assert np.isclose(
+            from_disk.at[0, col], in_memory.at[0, col], rtol=1e-9, atol=1e-6
+        ), f"disk vs in-memory mismatch for {col}"

--- a/tests/test_all.cc
+++ b/tests/test_all.cc
@@ -26,6 +26,7 @@
 #include "test_glszm.h"
 #include "test_ngtdm.h"
 #include "test_roi_blacklist.h"
+#include "test_tiff_loader.h"
 #include "test_image_quality.h"
 #include "test_3d_nifti.h"
 #include "test_omezarr.h"
@@ -685,6 +686,11 @@ TEST(TEST_NYXUS, TEST_UNVETTED_NO_DIRECT_ORACLE_GABOR){
 TEST(TEST_NYXUS, TEST_ROI_BLACKLISTING)
 {
 	ASSERT_NO_THROW(test_roi_blacklist());
+}
+
+TEST(TEST_NYXUS, TEST_TIFF_UINT32_STRIP_LOADER)
+{
+	ASSERT_NO_THROW(test_uint32_strip_tiff_loader());
 }
 
 TEST(TEST_NYXUS, TEST_INITIALIZATION) {

--- a/tests/test_tiff_loader.h
+++ b/tests/test_tiff_loader.h
@@ -1,0 +1,108 @@
+#pragma once
+//
+// Regression test for the TIFF strip loader fix in src/nyx/grayscale_tiff.h:
+// the 32-bit unsigned sample case used copyRow<size_t> (8 bytes on LP64/Win64)
+// for a 4-byte sample, so copyRow read ((size_t*)buf)[col] -- 2x past the libtiff
+// scanline buffer -> corrupted/garbage pixels or a heap over-read (crash). The
+// fix is copyRow<uint32_t>.
+//
+// This drives the exact loader that carried the bug: it writes a uint32 strip
+// TIFF to disk with libtiff and reads it back through
+// NyxusGrayscaleTiffStripLoader<uint32_t>, asserting every pixel round-trips.
+// The intensities span past the 16-bit range and past 2^31 (up to UINT32_MAX) so
+// a wrong element size / truncation / column shift is detectable.
+//
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <tiffio.h>
+
+#include "../src/nyx/grayscale_tiff.h"
+
+// Write a strip-based (non-tiled), single-channel uint32 grayscale TIFF.
+static inline void nyxus_ut_write_uint32_strip_tiff(
+    const std::string& path, const std::vector<uint32_t>& px, uint32_t w, uint32_t h)
+{
+    TIFF* t = TIFFOpen(path.c_str(), "w");
+    if (t == nullptr)
+        throw std::runtime_error("could not create TIFF: " + path);
+
+    TIFFSetField(t, TIFFTAG_IMAGEWIDTH, w);
+    TIFFSetField(t, TIFFTAG_IMAGELENGTH, h);
+    TIFFSetField(t, TIFFTAG_BITSPERSAMPLE, 32);
+    TIFFSetField(t, TIFFTAG_SAMPLESPERPIXEL, 1);
+    TIFFSetField(t, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_UINT);   // -> loader sampleFormat_ == 1
+    TIFFSetField(t, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+    TIFFSetField(t, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_MINISBLACK);
+    TIFFSetField(t, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
+    TIFFSetField(t, TIFFTAG_ROWSPERSTRIP, 1);                   // strip (scanline) layout, not tiled
+
+    std::vector<uint32_t> row(w);
+    for (uint32_t y = 0; y < h; ++y)
+    {
+        std::copy(px.begin() + static_cast<size_t>(y) * w,
+                  px.begin() + static_cast<size_t>(y + 1) * w, row.begin());
+        if (TIFFWriteScanline(t, row.data(), y, 0) < 0)
+        {
+            TIFFClose(t);
+            throw std::runtime_error("TIFFWriteScanline failed");
+        }
+    }
+    TIFFClose(t);
+}
+
+inline void test_uint32_strip_tiff_loader()
+{
+    const uint32_t w = 5, h = 3;
+    // Values past 16-bit and past 2^31 (incl. UINT32_MAX) so a mis-typed read shows up.
+    const std::vector<uint32_t> expected = {
+        100u,         70000u,       300000u,       16777216u,   4000000000u,
+        5u,           123456789u,   3000000000u,   65535u,      65536u,
+        2147483648u,  1u,           4294967295u,   2u,          268435456u
+    };
+
+    const auto path =
+        (std::filesystem::temp_directory_path() / "nyxus_ut_uint32_strip.tif").string();
+    nyxus_ut_write_uint32_strip_tiff(path, expected, w, h);
+
+    try
+    {
+        NyxusGrayscaleTiffStripLoader<uint32_t> loader(1, path);
+
+        if (loader.fullWidth(0) != w || loader.fullHeight(0) != h)
+            throw std::runtime_error("TIFF header dimensions mismatch");
+
+        const size_t tw = loader.tileWidth(0),
+                     th = loader.tileHeight(0),
+                     td = loader.tileDepth(0);
+        auto tile = std::make_shared<std::vector<uint32_t>>(tw * th * td);
+
+        // Single tile at (row,col,layer,level) = (0,0,0,0) covers this small image.
+        loader.loadTileFromFile(tile, 0, 0, 0, 0);
+
+        for (uint32_t y = 0; y < h; ++y)
+            for (uint32_t x = 0; x < w; ++x)
+            {
+                const uint32_t got = (*tile)[static_cast<size_t>(y) * tw + x];
+                const uint32_t exp = expected[static_cast<size_t>(y) * w + x];
+                if (got != exp)
+                    throw std::runtime_error(
+                        "pixel (" + std::to_string(x) + "," + std::to_string(y) +
+                        ") = " + std::to_string(got) + ", expected " + std::to_string(exp));
+            }
+    }
+    catch (...)
+    {
+        std::error_code ec;
+        std::filesystem::remove(path, ec);   // best-effort cleanup, then rethrow
+        throw;
+    }
+
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+}


### PR DESCRIPTION
NyxusGrayscaleTiffStripLoader mapped the 32-bit unsigned sample case to copyRow<size_t>; size_t is 8 bytes on LP64/Win64 while the sample is 4 bytes, so copyRow reads 2x past the scanline buffer -- intermittent AV/heap corruption (heap-layout dependent) and wrong pixels otherwise. Affects any uint32 TIFF via the tile loader; uint8/uint16 and the pybind path were unaffected. Fix: copyRow<uint32_t>, matching the signed int32_t case, the tile-based loader, and raw_tiff.h.