### PR TITLE
test(glcm,convex-hull): precise vetted-comment wording; pin convex-hull oracle to offset_coordinates=False

### DIFF
--- a/tests/test_glcm.h
+++ b/tests/test_glcm.h
@@ -25,11 +25,14 @@
 //
 // ORACLE-VETTED 2026-07 (corrected 2026-07-09): the 10 keys below were run against a third-party
 // symmetric-matrix oracle (PyRadiomics v3.0.1) on the *same* per-slice matlab-binned phantom images,
-// aggregated the same way (mean over 4 slices x 4 angles). Each depends only on the grey-level
-// DIFFERENCE p_{x-y} / |i-j| (CONTRAST/DIFAVE/DIS/DIFENTRO/DIFVAR/ID/HOM1/IDM/IV/SUMENTROPY), so it is
-// invariant to BOTH matrix symmetrization AND the absolute level values that matlab binning re-maps
-// -> PyRadiomics agrees within the test's 1% tolerance. These are VETTED against an external
-// definition, not merely pinned.
+// aggregated the same way (mean over 4 slices x 4 angles). Nine of them depend only on the grey-level
+// DIFFERENCE p_{x-y} / |i-j| (CONTRAST/DIFAVE/DIS/DIFENTRO/DIFVAR/ID/HOM1/IDM/IV); SUMENTROPY is the
+// dimensionless entropy of the SUM distribution p_{x+y}. Both kinds are invariant to matrix
+// symmetrization and to a level RELABELING (origin shift) -- and this phantom's binning relabels
+// levels without RESCALING them, so they coincide with the symmetric-matrix oracle -> PyRadiomics
+// agrees within the test's 1% tolerance. (Difference-based features are NOT invariant to level
+// *scaling*; that only holds here because the binning does not rescale.) These are VETTED against an
+// external definition, not merely pinned.
 // CORRECTION (2026-07-09, PR #356 review): ACOR/IDN/IDMN/SUMAVERAGE were previously listed here as
 // oracle-vetted -- that was WRONG for this ibsi=False / matlab-binning config. They depend on the
 // absolute grey-level values / Ng, which matlab binning re-maps, so under this config they diverge

--- a/tests/test_shape_morphology_2d.h
+++ b/tests/test_shape_morphology_2d.h
@@ -66,18 +66,20 @@ static std::unordered_map<std::string, double> unvetted_nyxus_regression_shape2d
 };
 
 static std::unordered_map<std::string, double> oracle_3p_shape2d_feature_golden_values{
-	// CONVEX_HULL_AREA / SOLIDITY are cross-checked against scikit-image regionprops on this exact
-	// ROI (skimage 0.26: area_convex=28, solidity=26/28=0.9285714). Nyxus computes a Pick's-theorem
-	// pixel-count hull area (convex_hull_nontriv.cpp) = 27, solidity 26/27 = 0.9629630. The ~1 px /
-	// ~3.6% gap is a pure boundary CONVENTION, not an error: Nyxus hulls through pixel CENTRES, which
-	// reproduces skimage's convex_hull_image(offset_coordinates=False) == 27 EXACTLY; skimage's
-	// regionprops default (offset_coordinates=True) first expands every pixel to its +/-0.5 corners,
-	// so its hull rasterises to 28. We assert against skimage's default (28 / 0.9286) with a tolerance
-	// (frac_tolerance=10 => 10%) that comfortably covers this corner-expansion gap while still catching
-	// a real regression. This makes SOLIDITY a real skimage-vetted check (both <= 1, unlike the old
-	// impossible 1.3) rather than a self-referential snapshot of Nyxus's own output.
-	{"CONVEX_HULL_AREA", 28.0},
-	{"SOLIDITY", 0.9285714285714286},
+	// CONVEX_HULL_AREA / SOLIDITY are cross-checked against scikit-image on this exact ROI. Nyxus
+	// computes a Pick's-theorem pixel-count hull area (convex_hull_nontriv.cpp) = 27, solidity
+	// 26/27 = 0.9629630. Because Nyxus hulls through pixel CENTRES, this reproduces skimage's
+	// convex_hull_image(offset_coordinates=False) == 27 EXACTLY, so we vet against THAT convention
+	// (27 / 0.9629630) with a tight 1% tolerance (frac_tolerance=100). The hull area is a
+	// provably-exact integer lattice count, so 1% is float/platform slack -- not a convention fudge --
+	// and it still catches a >=1 px regression. (skimage's regionprops DEFAULT uses
+	// offset_coordinates=True, which first expands every pixel to its +/-0.5 corners and rasterises
+	// the hull to 28 / 0.9285714; that +1 px is a corner-expansion convention, not an error, and is
+	// why we pin the offset_coordinates=False value rather than the default.) SOLIDITY is thus a real
+	// skimage-vetted <= 1 check (unlike the old impossible 1.3), matched exactly rather than within a
+	// loose band.
+	{"CONVEX_HULL_AREA", 27.0},
+	{"SOLIDITY", 0.9629629629629629},
 	{"DIAMETER_EQUAL_PERIMETER", 8.57365809435587},
 	{"FRACT_DIM_BOXCOUNT", -0.830074998557687},
 	{"FRACT_DIM_PERIMETER", -1.97227924244155},
@@ -264,10 +266,10 @@ void test_shape2d_convex_hull_features()
 	calculate_shape2d_feature_values(fvals);
 
 	assert_unvetted_no_direct_oracle_shape2d_feature(fvals, Nyxus::Feature2D::CIRCULARITY, "CIRCULARITY");
-	// CONVEX_HULL_AREA / SOLIDITY are verifiable against scikit-image regionprops (see the oracle_3p
-	// table); 10% tolerance covers the Pick's-vs-rasterisation boundary-convention gap (~1 px).
-	assert_verifiable_with_3p_builtin_oracle_shape2d_feature(fvals, Nyxus::Feature2D::CONVEX_HULL_AREA, "CONVEX_HULL_AREA", 10.0);
-	assert_verifiable_with_3p_builtin_oracle_shape2d_feature(fvals, Nyxus::Feature2D::SOLIDITY, "SOLIDITY", 10.0);
+	// CONVEX_HULL_AREA / SOLIDITY are verifiable against scikit-image convex_hull_image(offset_coordinates=False)
+	// (see the oracle_3p table); Nyxus reproduces that convention exactly, so a tight 1% tolerance suffices.
+	assert_verifiable_with_3p_builtin_oracle_shape2d_feature(fvals, Nyxus::Feature2D::CONVEX_HULL_AREA, "CONVEX_HULL_AREA", 100.0);
+	assert_verifiable_with_3p_builtin_oracle_shape2d_feature(fvals, Nyxus::Feature2D::SOLIDITY, "SOLIDITY", 100.0);
 }
 
 void test_shape2d_verifiable_with_3p_builtin_oracle_extrema_features()


### PR DESCRIPTION
Follow-up to the reviews on #356 and #357 (both merged). Test-only.

## #356 comment precision (`tests/test_glcm.h`)
Two wording corrections in the vetted-map comment, **no value changes**:
- **SUMENTROPY** was grouped as "depends only on the grey-level DIFFERENCE `|i−j|`". It doesn't — it's the dimensionless entropy of the SUM distribution `p_{x+y}`. It's still correctly vetted (a dimensionless entropy is level-value-invariant), but the stated reason didn't apply to it.
- "invariant to the absolute level values that matlab binning re-maps" overstated it. Difference-based features are invariant to a level **relabeling / origin shift**, not to level **scaling** — they coincide with the symmetric-matrix oracle only because this phantom's binning relabels without rescaling. Clarified, with the scaling caveat called out.

## #357 tighter convex-hull oracle (`tests/test_shape_morphology_2d.h`)
The merged test vets `CONVEX_HULL_AREA` / `SOLIDITY` against skimage regionprops' **default** (`28` / `0.9286`) at a 10% tolerance. Since Nyxus hulls through pixel centres, it reproduces skimage `convex_hull_image(offset_coordinates=False)` == **27** exactly (SOLIDITY `26/27`). This PR pins to that convention and tightens the tolerance **10% → 1%** (`frac_tolerance` 10 → 100).

Rationale: the hull area is a provably-exact integer lattice count, so 1% is float/platform slack rather than a convention fudge, and the check now catches a ≥1 px regression (the old 10% band accepted ±2.8 px). The +1 px regionprops-default (`offset_coordinates=True` corner expansion → 28) is documented in the comment as the reason we pin the `offset_coordinates=False` value instead.

The new goldens equal Nyxus's actual output for these fixtures (they were the pre-#357 regression-snapshot values), so no runtime behavior changes and both C++ tests pass unchanged.