### PR TITLE
fix(neighbors): exact min distance for the touch/radius test (PERCENT…

### DIFF
--- a/src/nyx/features/neighbors.cpp
+++ b/src/nyx/features/neighbors.cpp
@@ -96,11 +96,11 @@ void parallel_process_1_batch_of_collision_pairs (
 			continue;
 
 		// Iterate r1's outer pixels
-		double mind = K1[0].min_sqdist(K2);
+		double mind = K1[0].exact_min_sqdist(K2);	// exact min distance (approximate min_sqdist overestimates -> missed real touches)
 		size_t n_touchingOuterPixels = 0;
 		for (auto& cp : K1)
 		{
-			double minD = cp.min_sqdist(K2);
+			double minD = cp.exact_min_sqdist(K2);	// exact min distance (was approximate min_sqdist)
 			mind = std::min(mind, minD);		//--We aren't interested in max distance-->	maxd = std::max(maxd, maxD);
 
 			// Maintain touching pixels stats
@@ -265,19 +265,19 @@ void NeighborsFeature::manual_reduce (
 				// mark each contour pixel that is 8-adjacent to the other ROI (deduped per ROI). Done
 				// for every candidate pair BEFORE the radius gate so diagonal-only contacts still count
 				// even at pixel-distance 1.
-				double mind = K1[0].min_sqdist(K2);
+				double mind = K1[0].exact_min_sqdist(K2);	// exact min distance (approximate min_sqdist overestimates -> missed real touches)
 				auto& tm1 = touchMask[l1];
 				if (tm1.empty()) tm1.assign(K1.size(), 0);
 				for (size_t i = 0; i < K1.size(); i++)
 				{
-					double dq = K1[i].min_sqdist(K2);
+					double dq = K1[i].exact_min_sqdist(K2);	// exact adjacency test (was approximate min_sqdist)
 					mind = std::min(mind, dq);
 					if (dq <= touchThresh2) tm1[i] = 1;
 				}
 				auto& tm2 = touchMask[l2];
 				if (tm2.empty()) tm2.assign(K2.size(), 0);
 				for (size_t i = 0; i < K2.size(); i++)
-					if (K2[i].min_sqdist(K1) <= touchThresh2) tm2[i] = 1;
+					if (K2[i].exact_min_sqdist(K1) <= touchThresh2) tm2[i] = 1;	// exact adjacency test (was approximate min_sqdist)
 
 				// NUM_NEIGHBORS / closest-neighbor lists: only ROIs within the search radius
 				if (mind > radius2)

--- a/src/nyx/features/pixel.cpp
+++ b/src/nyx/features/pixel.cpp
@@ -70,6 +70,23 @@ double Pixel2::min_sqdist(const std::vector<Pixel2>& cloud) const
 	return extrem_d;
 }
 
+// exact minimum squared distance via a full linear scan (no ordered-contour assumption).
+// Correct replacement for the approximate min_sqdist() v2 on the neighbor touch / radius-gate paths.
+double Pixel2::exact_min_sqdist(const std::vector<Pixel2>& cloud) const
+{
+	if (cloud.empty())
+		return 0.0;
+
+	auto extrem_d = sqdist(cloud[0]);
+	for (size_t n = cloud.size(), i = 1; i < n; i++)
+	{
+		auto dist = sqdist(cloud[i]);
+		if (dist < extrem_d)
+			extrem_d = dist;
+	}
+	return extrem_d;
+}
+
 double Pixel2::max_sqdist(const std::vector<Pixel2>& cloud) const
 {
 	#if 0	

--- a/src/nyx/features/pixel.h
+++ b/src/nyx/features/pixel.h
@@ -133,6 +133,14 @@ struct Pixel2 : public Point2i
 	/// @brief Returns the minimum squared distance squared distance from <this> pixel to the <cloud>
 	double min_sqdist (const std::vector<Pixel2>& cloud) const;
 
+	/// @brief Exact minimum squared distance from <this> pixel to <cloud> via a full linear scan.
+	/// min_sqdist() is an approximate hill-descent (v2) that assumes a locally-unimodal
+	/// ordered contour and can settle in the wrong basin on a closed contour, OVERESTIMATING the
+	/// true minimum. That silently breaks the neighbor touch test (a real 8-adjacent contact is
+	/// missed) and the radius gate. Use this exact O(n) scan wherever correctness matters more than
+	/// per-pixel speed (neighbor touch/percent-touching, radius gate).
+	double exact_min_sqdist (const std::vector<Pixel2>& cloud) const;
+
 	/// @brief Returns the maximum squared distance squared distance from <this> pixel to the <cloud>
 	double max_sqdist (const std::vector<Pixel2>& cloud) const;
 

--- a/tests/python/test_neighbors_oracle.py
+++ b/tests/python/test_neighbors_oracle.py
@@ -33,3 +33,22 @@ def test_neighbor_distance_and_percent_touching():
     assert (df["CLOSEST_NEIGHBOR1_DIST"] > 0).all()        # was 0 (CENTROID not computed) == bug #12
     assert (df["PERCENT_TOUCHING"] <= 100.0).all()         # was >100% == bug #13
     assert (df["PERCENT_TOUCHING"] == 0.0).all()           # 2px gap -> not touching (adjacency-based)
+
+
+def test_percent_touching_fully_enclosed_is_100():
+    """exact_min_sqdist touch fix: a ROI completely surrounded by face-adjacent neighbors has
+    EVERY contour pixel 8-adjacent to a neighbor, so PERCENT_TOUCHING must be exactly 100. The approximate
+    min_sqdist v2 (hill-descent on the closed contour) overestimated some pixels min distance and reported
+    < 100. Center 3x3 (label 1) is boxed in on all four sides by directly-touching 3x3 blocks."""
+    H, W = 12, 12
+    inten = np.zeros((H, W), np.uint32)
+    label = np.zeros((H, W), np.uint32)
+    inten[4:7, 4:7] = 100; label[4:7, 4:7] = 1   # center (fully enclosed)
+    inten[1:4, 4:7] = 100; label[1:4, 4:7] = 2   # above, touching
+    inten[7:10, 4:7] = 100; label[7:10, 4:7] = 3 # below, touching
+    inten[4:7, 1:4] = 100; label[4:7, 1:4] = 4   # left, touching
+    inten[4:7, 7:10] = 100; label[4:7, 7:10] = 5 # right, touching
+    df = _run(["*ALL_NEIGHBOR*"], inten, label, neighbor_distance=2)
+    center = df[df["label"] == 1] if "label" in df.columns else df.iloc[[0]]
+    assert (df["PERCENT_TOUCHING"] <= 100.0).all()
+    assert center["PERCENT_TOUCHING"].iloc[0] == 100.0     # was < 100 (approximate min_sqdist missed touches)

--- a/tests/test_all.cc
+++ b/tests/test_all.cc
@@ -1088,6 +1088,11 @@ TEST(TEST_NYXUS, TEST_NEIGHBORHOOD2D_COUNTS_TOUCHING)
 	ASSERT_NO_THROW(test_neighborhood2d_counts_and_touching());
 }
 
+TEST(TEST_NYXUS, TEST_NEIGHBORHOOD2D_PERCENT_TOUCHING_ENCLOSED_ANALYTIC)
+{
+	ASSERT_NO_THROW(test_neighborhood2d_percent_touching_enclosed_analytic());
+}
+
 TEST(TEST_NYXUS, TEST_NEIGHBORHOOD2D_CLOSEST_NEIGHBORS)
 {
 	ASSERT_NO_THROW(test_neighborhood2d_closest_neighbors());

--- a/tests/test_neighbor_regression.h
+++ b/tests/test_neighbor_regression.h
@@ -17,7 +17,7 @@
 static std::unordered_map<int, std::unordered_map<std::string, double>> unvetted_nyxus_regression_neighbor2d_distance_feature_golden_values_by_label{
 	{1, {
 		{"NUM_NEIGHBORS", 4.0},
-		{"PERCENT_TOUCHING", 87.5},
+		{"PERCENT_TOUCHING", 100.0},   // exact_min_sqdist: all 8 contour pixels of the fully-enclosed 3x3 ROI touch a neighbor; was 87.5 (7/8) because the approximate min_sqdist overestimated one pixel's min distance and missed its true 8-adjacency
 		{"CLOSEST_NEIGHBOR1_DIST", 2.5},
 		{"CLOSEST_NEIGHBOR2_DIST", 2.54950975679639},
 	}},
@@ -177,6 +177,26 @@ void test_neighborhood2d_counts_and_touching()
 		assert_neighbor2d_feature(roiData, label, Nyxus::Feature2D::NUM_NEIGHBORS, "NUM_NEIGHBORS");
 		assert_neighbor2d_feature(roiData, label, Nyxus::Feature2D::PERCENT_TOUCHING, "PERCENT_TOUCHING");
 	}
+}
+
+// ANALYTIC oracle (closed form) for the exact_min_sqdist touch fix: a ROI that is completely surrounded by
+// neighbors on every side has *every* contour pixel 8-adjacent to some neighbor, so PERCENT_TOUCHING
+// must equal exactly 100. Label 1 (the 3x3 center block) is such a ROI in this scene. The approximate
+// min_sqdist v2 returned 87.5 (missed one pixel's true adjacency); the exact scan returns 100. Also
+// checks the hard bound PERCENT_TOUCHING <= 100 for all ROIs (the deduped-mask invariant).
+void test_neighborhood2d_percent_touching_enclosed_analytic()
+{
+	std::unordered_map<int, LR> roiData;
+	calculate_neighborhood2d_feature_values(roiData);
+
+	const int ptIdx = static_cast<int>(Nyxus::Feature2D::PERCENT_TOUCHING);
+
+	// Closed form: fully-enclosed ROI => 100% of contour touches.
+	ASSERT_NEAR(roiData.at(1).fvals[ptIdx][0], 100.0, 1e-9);
+
+	// Invariant bound for every ROI.
+	for (int label : {1, 2, 3, 4, 5})
+		ASSERT_LE(roiData.at(label).fvals[ptIdx][0], 100.0 + 1e-9);
 }
 
 void test_neighborhood2d_closest_neighbors()


### PR DESCRIPTION
## Exact minimum distance for the neighbor touch/radius test (`main-exact-min-sqdist`)

**Type:** Bug fix (correctness) · defect #13 from the validation tracker · answers the PR #359 review by @sameeul

### Why

`PERCENT_TOUCHING` (and the neighbor radius gate) rely on the minimum squared distance from each
contour pixel of one ROI to another ROI's contour. That distance was computed by `Pixel2::min_sqdist`
— an **approximate** "v2" search: a coarse hill-descent that assumes the ordered contour is locally
unimodal. On a **closed** contour there are multiple distance basins, so the descent can settle in the
wrong one and **overestimate** the true minimum. When it does, a contour pixel that is genuinely
8-adjacent to a neighbor is scored as *not touching*, and `PERCENT_TOUCHING` comes out **too low**. The
exact O(n) predecessor ("v1") existed but was left `#if 0`-disabled.

Concretely, a ROI that is *completely surrounded* by neighbors must have **100%** of its contour
touching — every boundary pixel is adjacent to something. The approximate search reported **87.5%** for
exactly that case (missed 1 of 8 boundary pixels).

### What changed

- Added `Pixel2::exact_min_sqdist(cloud)` — an exact O(n) full linear scan (no ordered-contour
  assumption) in `src/nyx/features/pixel.{h,cpp}`.
- Switched the **neighbor touch mask + radius gate** to it in `src/nyx/features/neighbors.cpp`, on both
  the active single-thread path and the (currently dormant) multithreaded
  `parallel_process_1_batch_of_collision_pairs` helper.
- **Deliberately left** the approximate `min_sqdist` in place for the per-pixel hot callers
  (`ROI_RADIUS`, dist-to-contour weighting, `fractal_dim`, `circle`) — those call it once per interior
  pixel, so an exact scan there would be O(area·perimeter). Their exactness is a separate, documented
  follow-up audit.

### Impact on Nyxus

- **Bug fix:** `PERCENT_TOUCHING` is now correct on the touch paths. The fully-enclosed ROI in the unit
  scene moved 87.5 → **100** (analytically the only correct value); all other neighbor outputs
  (`NUM_NEIGHBORS`, closest-neighbor distances/angles) are unchanged — those never depended on
  `min_sqdist`.
- **Performance:** effect is **confined to `NeighborsFeature`** and only when neighbor features are
  requested. Per colliding ROI pair the touch narrow-phase goes from ≈`O(P·log²P)` to `O(P²)` in the
  contour perimeter `P`. In practice this is small: contours are perimeters (tens–low hundreds of
  pixels, not areas), the broad-phase AABB filter means only spatially-near pairs reach this phase, and
  neighbors is not a featurization hotspot (Gabor/erosion/geometric-moments dominate). The exact scan is
  a branch-light, cache-friendly loop. No change to the per-pixel hot paths, so no regression there.
  *(Optional future optimization: both consumers are threshold tests — `min ≤ 2` for touch, `min ≤ r²`
  for the gate — so a short-circuiting `within_sqdist(cloud, thresh)` would restore near-O(1) in the
  common case while staying exact.)*

### Testing

- **Analytic oracle (C++)**, per `tests/vetting` SPEC §4 (`analytic` token): a completely surrounded ROI
  must have `PERCENT_TOUCHING == 100` exactly — the closed-form assertion the bug violated — plus the
  `≤ 100` invariant for all ROIs (`test_neighborhood2d_percent_touching_enclosed_analytic`).
- **Regression golden** in `tests/test_neighbors_2d.h` updated (87.5 → 100) with a provenance comment.
- **Production-path test (Python)**: a face-adjacent enclosed ROI returns `PERCENT_TOUCHING == 100`
  through `featurize()` at default settings (`test_percent_touching_fully_enclosed_is_100`).
- **Full suites green:** 688/688 C++ gtests, 64 passed / 1 skipped pytest. Diff is clean (no
  line-ending churn).