### PR TITLE
ci(release-please): minor (0.12.0) not major — honor bump-minor-pre-major + Release-As

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,8 +20,12 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         id: release
         with:
-          release-type: python
-          package-name: nyxus
+          # Use the manifest config so release-please honors bump-minor-pre-major
+          # (0.x breaking changes -> minor, not a jump to 1.0.0). release-type/
+          # package-name live in release-please-config.json; passing them inline put
+          # v4 on the non-manifest path and silently ignored the config.
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
 
       - name: Checkout code
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Makes the next release **0.12.0** (minor) instead of **1.0.0** (major), and fixes why it was major.

## Root cause
`release-please-config.json` sets `bump-minor-pre-major: true` (0.x breaking changes bump the minor, not jump to 1.0.0), but it was being ignored: `.github/workflows/release-please.yml` drove `release-please-action@v4` with inline `release-type`/`package-name`, which puts v4 on the non-manifest path and skips the config file. So the omezarr z5/C++20 breaking change bumped `0.11.0 → 1.0.0`.

## What this does
- Switches the action to `config-file: release-please-config.json` + `manifest-file: .release-please-manifest.json` (drops the inline inputs — they already live in the config). Now `bump-minor-pre-major` is honored → future 0.x breaking changes stay minor.
- Carries `Release-As: 0.12.0` in the commit footer to pin **this** release to 0.12.0 regardless.

Release-As: 0.12.0

## Note
This supersedes #376, whose empty commit was dropped by rebase-merge (empty commits don't survive rebase) so its `Release-As` never reached `main`. This commit has a real diff, so the footer survives any merge strategy.

On merge, the Release Please workflow re-runs and rewrites **#344** to `0.12.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)