### PR TITLE
test(vetting): a golden reference table is `const`, and read with `.at()`

### DIFF
--- a/tests/python/test_vetting_mechanics.py
+++ b/tests/python/test_vetting_mechanics.py
@@ -124,7 +124,7 @@ def test_vetting_tree_names_conform_to_spec_mechanics():
 
 def test_vetting_name_checker_rejects_bad_names_mechanics(tmp_path):
     """The checker must actually fail on each defect class - a lint that cannot fail is not a lint.
-    Plants one of each and requires all thirteen to be reported. Each planted file isolates a single
+    Plants one of each and requires all fourteen to be reported. Each planted file isolates a single
     defect, so an assertion failing here names the rule that stopped being enforced."""
     (tmp_path / "tests" / "python").mkdir(parents=True)
     # a TEST body with two callees: case = UPPER(function) has no single function to mirror
@@ -190,6 +190,14 @@ def test_vetting_name_checker_rejects_bad_names_mechanics(tmp_path):
         '    {"NGLDM_LDE", 1.0},\n};\n'
         'void test_2d_ngldm_lde_regression() {}', encoding="utf-8")
 
+    # a table whose name, location and type all conform, declared without const. Only its
+    # mutability makes it a defect -- which is what a mutable table costs: operator[] compiles, so a
+    # missing key is default-inserted as 0 instead of failing the lookup.
+    (tmp_path / "tests" / "test_2d_glszm_ibsi.h").write_text(
+        'static ref_vals_map<double> glszm_2d_ibsi_ref_vals = {\n'
+        '    {"GLSZM_SZE", 1.0},\n};\n'
+        'void test_2d_glszm_sze_ibsi() {}', encoding="utf-8")
+
     # one family reaching into another family's fixture header. Both file names conform and the
     # header holds no values, so only the include makes it a defect (SPEC 6.3.1).
     (tmp_path / "tests" / "test_2d_glszm_common.h").write_text(
@@ -221,3 +229,9 @@ def test_vetting_name_checker_rejects_bad_names_mechanics(tmp_path):
                for e in errs)                                                # conforming name, raw type
     assert any("test_2d_gldzm_regression.h" in e and "test_2d_glszm_common.h" in e
                and "SPEC 6.3.1" in e for e in errs)                          # includes another family
+    assert any("glszm_2d_ibsi_ref_vals" in e and "without const" in e
+               for e in errs)                                                # conforming name+type, mutable
+    # and it must not fire on a const-qualified table -- a rule that flags everything is as useless
+    # as one that flags nothing. ngldm_2d_regression_ref_vals above is const, so it earns the raw
+    # container error and only that one.
+    assert not any("ngldm_2d_regression_ref_vals" in e and "without const" in e for e in errs)

--- a/tests/test_2d_firstorder_ibsi.h
+++ b/tests/test_2d_firstorder_ibsi.h
@@ -4,7 +4,7 @@
 #include "test_ref_vals.h"
 
 // dig. phantom values for intensity based features
-static ref_vals_map<double> firstorder_2d_ibsi_ref_vals {
+static const ref_vals_map<double> firstorder_2d_ibsi_ref_vals {
     {"MEAN", 2.15},
     {"VARIANCE", 3.05},
     {"SKEWNESS", 1.08},
@@ -74,7 +74,7 @@ void assert_firstorder_feature_ibsi(const Feature2D& feature, const std::string&
 
     if (round) total = std::round(total);
 
-    ASSERT_TRUE(agrees_gt(total, firstorder_2d_ibsi_ref_vals[feature_name], 100.));
+    ASSERT_TRUE(agrees_gt(total, firstorder_2d_ibsi_ref_vals.at(feature_name), 100.));
 }
 
 void test_2d_firstorder_mean_ibsi()

--- a/tests/test_2d_firstorder_matlab.h
+++ b/tests/test_2d_firstorder_matlab.h
@@ -7,7 +7,7 @@
 #include "test_2d_firstorder_common.h"
 #include "test_ref_vals.h"
 
-static ref_vals_map<double> firstorder_2d_matlab_ref_vals {
+static const ref_vals_map<double> firstorder_2d_matlab_ref_vals {
     {"HYPERSKEWNESS",                 1.978293086605381},
     {"HYPERFLATNESS",                 5.126659243028459},
     {"UNIFORMITY",                    0.0647664},
@@ -49,7 +49,7 @@ void assert_firstorder_feature_matlab(const Feature2D& feature, const std::strin
     calculate_pixel_intensity_feature_values(fvals, s, slide_idx, slide_min, slide_max);
 
     ASSERT_TRUE(agrees_gt(fvals[(int)feature][0],
-                          firstorder_2d_matlab_ref_vals[feature_name],
+                          firstorder_2d_matlab_ref_vals.at(feature_name),
                           frac_tolerance));
 }
 

--- a/tests/test_2d_firstorder_regression.h
+++ b/tests/test_2d_firstorder_regression.h
@@ -6,7 +6,7 @@
 #include "test_2d_firstorder_common.h"
 #include "test_ref_vals.h"
 
-static ref_vals_map<double> firstorder_2d_regression_ref_vals {
+static const ref_vals_map<double> firstorder_2d_regression_ref_vals {
     {"ENTROPY",     4.12733},
     {"P01",         1.189536940000000e+04},
     {"P25",         1.907482583333333e+04},
@@ -25,7 +25,7 @@ void assert_firstorder_feature_regression(const Feature2D& feature, const std::s
     calculate_pixel_intensity_feature_values(fvals, s);
 
     ASSERT_TRUE(agrees_gt(fvals[(int)feature][0],
-                          firstorder_2d_regression_ref_vals[feature_name],
+                          firstorder_2d_regression_ref_vals.at(feature_name),
                           frac_tolerance));
 }
 

--- a/tests/test_2d_glcm_ibsi.h
+++ b/tests/test_2d_glcm_ibsi.h
@@ -14,7 +14,7 @@
 
 // Digital phantom values for intensity based features
 // (Reference: IBSI Documentation, Release 0.0.1dev Dec 13, 2021. Dataset: dig phantom. Aggr. method: 2D, averaged)
-static ref_vals_map<double> glcm_2d_ibsi_ref_vals {
+static const ref_vals_map<double> glcm_2d_ibsi_ref_vals {
     {"GLCM_ACOR", 5.09},    // p. 76, consensus: very strong
     {"GLCM_ASM", 0.368},    // p. 68, consensus: very strong
     {"GLCM_CLUPROM", 79.1}, // p. 79, consensus: very strong

--- a/tests/test_2d_glcm_mirp.h
+++ b/tests/test_2d_glcm_mirp.h
@@ -18,7 +18,7 @@
 // MIRP is the IBSI reference implementation, so it reports the two quantities PyRadiomics dropped
 // as duplicates - dissimilarity and sum variance - in their own right, and GLCM_DIS and
 // GLCM_SUMVARIANCE are vetted here against those rather than through an equality argument.
-static ref_vals_map<double> glcm_2d_mirp_ref_vals
+static const ref_vals_map<double> glcm_2d_mirp_ref_vals
 {
     {"GLCM_ACOR", 20.512755102040813},   // cm_auto_corr
     {"GLCM_ACOR_AVE", 20.512755102040813},   // cm_auto_corr

--- a/tests/test_2d_glcm_pyradiomics.h
+++ b/tests/test_2d_glcm_pyradiomics.h
@@ -25,7 +25,7 @@
 // Dissimilarity and SumVariance as duplicates of DifferenceAverage and ClusterTendency, which is
 // where the goldens for GLCM_DIS and GLCM_SUMVARIANCE come from; MIRP reports those two as
 // quantities of their own and test_2d_glcm_mirp.h pins them there.
-static ref_vals_map<double> glcm_2d_pyradiomics_ref_vals
+static const ref_vals_map<double> glcm_2d_pyradiomics_ref_vals
 {
     {"GLCM_ACOR", 20.512755102040817},   // Autocorrelation
     {"GLCM_ACOR_AVE", 20.512755102040817},   // Autocorrelation

--- a/tests/test_2d_glcm_regression.h
+++ b/tests/test_2d_glcm_regression.h
@@ -26,7 +26,7 @@
 //
 // CORRELATION/INFOMEAS1 are softNAN(=0)-guarded on the degenerate (single-grey-marginal) phantom
 // directions. An _AVE key shares its base feature's golden: it is the mean of the same 4 angles.
-static ref_vals_map<double> glcm_2d_regression_ref_vals
+static const ref_vals_map<double> glcm_2d_regression_ref_vals
 {
     {"GLCM_ACOR", 1437.33},                 // absolute-level-dependent: matlab binning re-maps levels, so ibsi=False diverges from a symmetric oracle by ~43%. Vetted on the IBSI path instead -- see below.
     {"GLCM_ASM", 0.381801},

--- a/tests/test_2d_glrlm_ibsi.h
+++ b/tests/test_2d_glrlm_ibsi.h
@@ -12,7 +12,7 @@
 // (Reference: IBSI Documentation, Release 0.0.1dev Dec 13, 2021. Dataset: dig phantom.)
 // Verified against fresh PyRadiomics and MIRP runs on the phantom pixels checked into test_data.h -
 // see tests/vetting/audit/glrlm_2d_ibsi_vetting_report.md.
-static ref_vals_map<double> glrlm_2d_ibsi_ref_vals {
+static const ref_vals_map<double> glrlm_2d_ibsi_ref_vals {
     {"GLRLM_SRE", 0.641},
     {"GLRLM_LRE", 3.78},
     {"GLRLM_LGLRE", 0.604},

--- a/tests/test_2d_glrlm_mirp.h
+++ b/tests/test_2d_glrlm_mirp.h
@@ -20,7 +20,7 @@
 // Each quantity is pinned twice: once for the per-direction feature, once for its _AVE twin. The
 // tool reports one value over the 4 in-slice directions, which is what _AVE holds and what
 // averaging the 4 directional values of the base feature produces.
-static ref_vals_map<double> glrlm_2d_mirp_ref_vals
+static const ref_vals_map<double> glrlm_2d_mirp_ref_vals
 {
     {"GLRLM_GLV", 3.3530283911078764},   // rlm_gl_var
     {"GLRLM_GLV_AVE", 3.3530283911078764},   // rlm_gl_var

--- a/tests/test_2d_glrlm_pyradiomics.h
+++ b/tests/test_2d_glrlm_pyradiomics.h
@@ -20,7 +20,7 @@
 // Each quantity is pinned twice: once for the per-direction feature, once for its _AVE twin. The
 // tool reports one value over the 4 in-slice directions, which is what _AVE holds and what
 // averaging the 4 directional values of the base feature produces.
-static ref_vals_map<double> glrlm_2d_pyradiomics_ref_vals
+static const ref_vals_map<double> glrlm_2d_pyradiomics_ref_vals
 {
     {"GLRLM_GLN", 5.1970624045072578},   // GrayLevelNonUniformity
     {"GLRLM_GLN_AVE", 5.1970624045072578},   // GrayLevelNonUniformity

--- a/tests/test_2d_glrlm_regression.h
+++ b/tests/test_2d_glrlm_regression.h
@@ -14,7 +14,7 @@
 
 // dig. phantom values for intensity based features
 // Calculated at 100 grey levels
-static ref_vals_map<double> glrlm_2d_regression_ref_vals {
+static const ref_vals_map<double> glrlm_2d_regression_ref_vals {
     {"GLRLM_SRE", 0.677679}, 
     {"GLRLM_LRE", 3.41805}, 
     {"GLRLM_LGLRE", 0.11546}, 
@@ -164,7 +164,7 @@ void assert_glrlm_feature_regression(const Nyxus::Feature2D& feature_, const std
 
     // Verdict
     const double divisor = is_ave_feature ? 4.0 : 16.0;
-    ASSERT_TRUE(Nyxus::agrees_gt(total / divisor, glrlm_2d_regression_ref_vals[truth_key], 100.));
+    ASSERT_TRUE(Nyxus::agrees_gt(total / divisor, glrlm_2d_regression_ref_vals.at(truth_key), 100.));
 }
 
 void test_2d_glrlm_sre_regression()

--- a/tests/test_2d_intensity_histogram_analytic.h
+++ b/tests/test_2d_intensity_histogram_analytic.h
@@ -145,7 +145,7 @@ void test_2d_intensity_histogram_bin_counts_analytic()
 // evaluates each closed form from the published definitions rather than from
 // intensity_histogram.cpp. Evidence:
 // tests/vetting/audit/intensity_histogram_2d_analytic_vetting_report.md.
-static ref_vals_map<double> intensity_histogram_2d_analytic_phantom_ref_vals
+static const ref_vals_map<double> intensity_histogram_2d_analytic_phantom_ref_vals
 {
     {"IH_BIN_SIZE", 0.83333333333333337},
     {"IH_COEFFICIENT_OF_VARIATION_VAL", 0.61261603178456026},

--- a/tests/test_2d_intensity_histogram_mirp.h
+++ b/tests/test_2d_intensity_histogram_mirp.h
@@ -20,7 +20,7 @@
 // family has no MIRP counterpart and is vetted analytically in
 // test_2d_intensity_histogram_analytic.h; the conventions are set out in
 // tests/vetting/audit/intensity_histogram_2d_analytic_vetting_report.md.
-static ref_vals_map<double> intensity_histogram_2d_mirp_ref_vals
+static const ref_vals_map<double> intensity_histogram_2d_mirp_ref_vals
 {
     {"IH_COEFFICIENT_OF_VARIATION_IDX", 0.81219785849173143},   // ih_cov
     {"IH_ENTROPY_IDX", 1.2656115555865246},   // ih_entropy

--- a/tests/test_2d_morphology_cellprofiler.h
+++ b/tests/test_2d_morphology_cellprofiler.h
@@ -25,7 +25,7 @@
 // whether these numbers came from CellProfiler or from Nyxus cannot be told from the tree. The split
 // preserves the registry's claim and makes the gap local instead of hiding it behind a shared table;
 // closing it means a gen_morphology_cellprofiler.py run. Tracked in not_covered.md section C.
-static ref_vals_map<double> morphology_2d_cellprofiler_ref_vals
+static const ref_vals_map<double> morphology_2d_cellprofiler_ref_vals
 {
 	{"MASS_DISPLACEMENT", 0.634476074243407},
 	{"EDGE_MEAN_INTENSITY", 41.8333333333333},
@@ -42,7 +42,7 @@ static void assert_morphology_feature_cellprofiler(
 {
 	SCOPED_TRACE(std::string("CELLPROFILER__") + feature_name);
 	ASSERT_TRUE(morphology_2d_cellprofiler_ref_vals.count(feature_name) > 0) << feature_name;
-	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_cellprofiler_ref_vals[feature_name], 1000.0));
+	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_cellprofiler_ref_vals.at(feature_name), 1000.0));
 }
 
 void test_2d_morphology_edge_intensity_cellprofiler()

--- a/tests/test_2d_morphology_fraclac.h
+++ b/tests/test_2d_morphology_fraclac.h
@@ -9,7 +9,7 @@
 // Provenance (SPEC 6.4): tool=ImageJ FracLac (box counting); recipe=morphology.fractal_blob512,
 // i.e. the 512x512 mask tests/data/fractal_blob512_seg.ome.tif as a single ROI;
 // generators=tests/vetting/oracles/fraclac/{shiftgrid_boxcount.ijm,ref_boxcount.py}.
-static ref_vals_map<double> morphology_2d_fraclac_ref_vals{
+static const ref_vals_map<double> morphology_2d_fraclac_ref_vals{
 	{"FRACT_DIM_BOXCOUNT", 1.8706},   // vetted by ImageJ/FracLac: an independent implementation of the same box-count method
 	{"FRACT_DIM_PERIMETER", 1.0493},  // vetted by ImageJ/FracLac edge box-count: cross-method vs Nyxus' divider
 };
@@ -23,7 +23,7 @@ void test_2d_morphology_fractal_dimension_blob512_fraclac()
 	// FRACT_DIM_PERIMETER: cross-method (Nyxus divider vs box-count-of-edge) -> 3% tolerance.
 	SCOPED_TRACE("FRACT_DIM_BLOB512_ORACLE");
 	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(Nyxus::Feature2D::FRACT_DIM_BOXCOUNT)][0],
-		morphology_2d_fraclac_ref_vals["FRACT_DIM_BOXCOUNT"], 100.0));    // 1% (same method)
+		morphology_2d_fraclac_ref_vals.at("FRACT_DIM_BOXCOUNT"), 100.0));    // 1% (same method)
 	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(Nyxus::Feature2D::FRACT_DIM_PERIMETER)][0],
-		morphology_2d_fraclac_ref_vals["FRACT_DIM_PERIMETER"], 33.0));    // ~3% (cross method)
+		morphology_2d_fraclac_ref_vals.at("FRACT_DIM_PERIMETER"), 33.0));    // ~3% (cross method)
 }

--- a/tests/test_2d_morphology_imea.h
+++ b/tests/test_2d_morphology_imea.h
@@ -19,7 +19,7 @@
 // differ from Nyxus by 3.9-79.3%, too coarse for the hull-vs-raster conventions to converge -- so
 // they are regression snapshots in test_2d_morphology_regression.h and the diameters are vetted
 // against imea on the clean ellipse below. Measured in audit/morphology_2d_imea_vetting_report.md.
-static ref_vals_map<double> morphology_2d_imea_shape2d_ref_vals{
+static const ref_vals_map<double> morphology_2d_imea_shape2d_ref_vals{
 	{"DIAMETER_EQUAL_PERIMETER", 8.573658094355881},
 	{"GEODETIC_LENGTH", 11.13182483477333},
 	{"THICKNESS", 2.3356458070362205}
@@ -36,7 +36,7 @@ static ref_vals_map<double> morphology_2d_imea_shape2d_ref_vals{
 // (rot_angle_increment = 10 degrees, caliper.h), so the two sample the same angles. Every value here
 // comes from one run at that step; mixing steps inflates the tolerance
 // (audit/morphology_2d_imea_vetting_report.md). Worst residual 4.99%.
-static ref_vals_map<double> morphology_2d_imea_ellipse_ref_vals{
+static const ref_vals_map<double> morphology_2d_imea_ellipse_ref_vals{
 	{"STAT_MARTIN_DIAM_MIN", 19.0},
 	{"STAT_MARTIN_DIAM_MAX", 41.0},
 	{"STAT_MARTIN_DIAM_MEAN", 27.5},
@@ -68,7 +68,7 @@ static void assert_iso_transform_imea(const std::vector<std::vector<double>>& fv
 {
 	SCOPED_TRACE(std::string("IMEA_ORACLE__") + feature_name);
 	ASSERT_TRUE(morphology_2d_imea_shape2d_ref_vals.count(feature_name) > 0) << feature_name;
-	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_imea_shape2d_ref_vals[feature_name], frac_tolerance));
+	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_imea_shape2d_ref_vals.at(feature_name), frac_tolerance));
 }
 
 static void assert_caliper_close_to_imea(
@@ -84,7 +84,7 @@ static void assert_caliper_close_to_imea(
 {
 	SCOPED_TRACE(std::string("CALIPER_VS_IMEA__") + feature_name);
 	ASSERT_TRUE(morphology_2d_imea_ellipse_ref_vals.count(feature_name) > 0);
-	const double imea_ref = morphology_2d_imea_ellipse_ref_vals[feature_name];
+	const double imea_ref = morphology_2d_imea_ellipse_ref_vals.at(feature_name);
 	const double actual = fvals[static_cast<int>(feature)][0];
 	const double denom = std::max(std::abs(imea_ref), 1e-9);
 	ASSERT_LE(std::abs(actual - imea_ref) / denom, reltol)

--- a/tests/test_2d_morphology_matlab.h
+++ b/tests/test_2d_morphology_matlab.h
@@ -24,7 +24,7 @@
 // Nyxus does, so MAJOR_AXIS_LENGTH / MINOR_AXIS_LENGTH / ECCENTRICITY agree to ~1e-15 here, while
 // skimage (which omits it) differs ~1.4% and is left unvetted for them in
 // test_2d_morphology_skimage.h.
-static ref_vals_map<double> morphology_2d_matlab_regionprops_ref_vals{
+static const ref_vals_map<double> morphology_2d_matlab_regionprops_ref_vals{
 	{"AREA_PIXELS_COUNT", 26.0},
 	{"AREA_UM2", 104.0},
 	{"CENTROID_X", 2.6153846153846163},
@@ -53,7 +53,7 @@ static void assert_morphology_regionprops_matlab(const std::vector<std::vector<d
 {
 	SCOPED_TRACE(std::string("MATLAB_ORACLE__") + feature_name);
 	ASSERT_TRUE(morphology_2d_matlab_regionprops_ref_vals.count(feature_name) > 0) << feature_name;
-	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_matlab_regionprops_ref_vals[feature_name], frac_tolerance));
+	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_matlab_regionprops_ref_vals.at(feature_name), frac_tolerance));
 }
 
 void test_2d_morphology_basic_matlab()
@@ -101,7 +101,7 @@ void test_2d_morphology_euler_matlab()
 	assert_morphology_regionprops_matlab(fvals, Nyxus::Feature2D::EULER_NUMBER, "EULER_NUMBER");
 }
 
-static ref_vals_map<double> morphology_2d_matlab_extrema_ref_vals{
+static const ref_vals_map<double> morphology_2d_matlab_extrema_ref_vals{
 	// EXTREMA P1..P8 (X,Y) match MATLAB/Octave regionprops('Extrema') EXACTLY under the documented
 	// coordinate convention: MATLAB returns 1-based sub-pixel *corner* coords, Nyxus returns 0-based
 	// pixel *centers*. The corner is direction-specific -> the offset is per-point: left/top coords
@@ -133,7 +133,7 @@ static void assert_morphology_extrema_matlab(const std::vector<std::vector<doubl
 {
 	SCOPED_TRACE(std::string("MATLAB_ORACLE__") + feature_name);
 	ASSERT_TRUE(morphology_2d_matlab_extrema_ref_vals.count(feature_name) > 0) << feature_name;
-	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_matlab_extrema_ref_vals[feature_name], frac_tolerance));
+	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_matlab_extrema_ref_vals.at(feature_name), frac_tolerance));
 }
 
 void test_2d_morphology_extrema_matlab()

--- a/tests/test_2d_morphology_regression.h
+++ b/tests/test_2d_morphology_regression.h
@@ -13,7 +13,7 @@
 // hull-vs-raster conventions to converge), so they lived in an imea-named table read by an
 // imea-named helper without ever having been compared to imea. The diameters themselves
 // are vetted against imea on the clean ellipse in test_2d_morphology_imea.h.
-static ref_vals_map<double> morphology_2d_regression_caliper_shape2d_ref_vals{
+static const ref_vals_map<double> morphology_2d_regression_caliper_shape2d_ref_vals{
 	{"STAT_FERET_DIAM_MIN", 4.47301},
 	{"STAT_FERET_DIAM_MAX", 6.3222},
 	{"STAT_FERET_DIAM_MEAN", 5.40848},
@@ -40,7 +40,7 @@ static void assert_morphology_caliper_shape2d_regression(const std::vector<std::
 {
 	SCOPED_TRACE(std::string("REGRESSION__") + feature_name);
 	ASSERT_TRUE(morphology_2d_regression_caliper_shape2d_ref_vals.count(feature_name) > 0) << feature_name;
-	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_regression_caliper_shape2d_ref_vals[feature_name], frac_tolerance));
+	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_regression_caliper_shape2d_ref_vals.at(feature_name), frac_tolerance));
 }
 
 void test_2d_morphology_caliper_shape2d_regression()
@@ -69,7 +69,7 @@ void test_2d_morphology_caliper_shape2d_regression()
 	assert_morphology_caliper_shape2d_regression(fvals, Nyxus::Feature2D::ALLCHORDS_MIN, "ALLCHORDS_MIN");
 }
 
-static ref_vals_map<double> morphology_2d_regression_caliper_chords_ref_vals{
+static const ref_vals_map<double> morphology_2d_regression_caliper_chords_ref_vals{
 	{"EROSIONS_2_VANISH_COMPLEMENT", 0.0},
 	{"MIN_FERET_ANGLE", 40.0},
 	// The Feret angles are a Nyxus-frame convention with no comparable imea output, so they are
@@ -91,7 +91,7 @@ static ref_vals_map<double> morphology_2d_regression_caliper_chords_ref_vals{
 	{"ALLCHORDS_STDDEV", 1.3446086298393252},
 };
 
-static ref_vals_map<double> morphology_2d_regression_polygonality_chords_ref_vals{
+static const ref_vals_map<double> morphology_2d_regression_polygonality_chords_ref_vals{
 	// Polus-specific scores with no external oracle, so these are self-referential snapshots.
 	// POLYGONALITY_AVE depends only on neighbors/area/perimeter. HEXAGONALITY_AVE and
 	// HEXAGONALITY_STDDEV read CONVEX_HULL_AREA through area_hull (hexagonality_polygonality.cpp),
@@ -116,7 +116,7 @@ static void assert_morphology_polygonality_chords_regression(
 {
 	SCOPED_TRACE(std::string("REGRESSION__") + feature_name);
 	ASSERT_TRUE(morphology_2d_regression_polygonality_chords_ref_vals.count(feature_name) > 0);
-	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_regression_polygonality_chords_ref_vals[feature_name], frac_tolerance));
+	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_regression_polygonality_chords_ref_vals.at(feature_name), frac_tolerance));
 }
 
 static void assert_morphology_caliper_chords_regression(
@@ -127,7 +127,7 @@ static void assert_morphology_caliper_chords_regression(
 {
 	SCOPED_TRACE(std::string("REGRESSION__") + feature_name);
 	ASSERT_TRUE(morphology_2d_regression_caliper_chords_ref_vals.count(feature_name) > 0) << feature_name;
-	const double ref_val = morphology_2d_regression_caliper_chords_ref_vals[feature_name];
+	const double ref_val = morphology_2d_regression_caliper_chords_ref_vals.at(feature_name);
 	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], ref_val, frac_tolerance));
 }
 
@@ -144,7 +144,7 @@ static void assert_morphology_polygonality_regression(
 	ASSERT_TRUE(morphology_2d_regression_polygonality_chords_ref_vals.count(feature_name) > 0);
 	const double actual = roiData.at(1).fvals[static_cast<int>(feature)][0];
 	ASSERT_GT(actual, 0.0);
-	ASSERT_TRUE(agrees_gt(actual, morphology_2d_regression_polygonality_chords_ref_vals[feature_name], frac_tolerance));
+	ASSERT_TRUE(agrees_gt(actual, morphology_2d_regression_polygonality_chords_ref_vals.at(feature_name), frac_tolerance));
 }
 
 static void assert_morphology_polygonality_score_regression(
@@ -170,7 +170,7 @@ static void assert_morphology_polygonality_no_value_for_sparse_neighbors(
 
 // Pinned Nyxus output for the shape-2D features with no external reference. Establishes no vetting
 // (SPEC 1), which is why nothing outside this file compares against it any more.
-static ref_vals_map<double> morphology_2d_regression_ref_vals
+static const ref_vals_map<double> morphology_2d_regression_ref_vals
 {
 	{"AREA_PIXELS_COUNT", 26.0},
 	{"AREA_UM2", 104.0},
@@ -201,7 +201,7 @@ static ref_vals_map<double> morphology_2d_regression_ref_vals
 	{"ROI_RADIUS_MEDIAN", 1.0}
 };
 
-static ref_vals_map<double> morphology_2d_regression_diameters_ref_vals{
+static const ref_vals_map<double> morphology_2d_regression_diameters_ref_vals{
 	{"DIAMETER_CIRCUMSCRIBING_CIRCLE", 12.3317073399088},
 	{"DIAMETER_INSCRIBING_CIRCLE", 0.828486893405308},
 };
@@ -211,7 +211,7 @@ static void assert_morphology_feature_regression(const std::vector<std::vector<d
 {
 	SCOPED_TRACE(std::string("REGRESSION__") + feature_name);
 	ASSERT_TRUE(morphology_2d_regression_ref_vals.count(feature_name) > 0) << feature_name;
-	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_regression_ref_vals[feature_name], frac_tolerance));
+	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_regression_ref_vals.at(feature_name), frac_tolerance));
 }
 
 static void assert_morphology_diameter_regression(const std::vector<std::vector<double>>& fvals,
@@ -219,7 +219,7 @@ static void assert_morphology_diameter_regression(const std::vector<std::vector<
 {
 	SCOPED_TRACE(std::string("REGRESSION__") + feature_name);
 	ASSERT_TRUE(morphology_2d_regression_diameters_ref_vals.count(feature_name) > 0) << feature_name;
-	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_regression_diameters_ref_vals[feature_name], frac_tolerance));
+	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_regression_diameters_ref_vals.at(feature_name), frac_tolerance));
 }
 
 void test_2d_morphology_basic_regression()

--- a/tests/test_2d_morphology_skimage.h
+++ b/tests/test_2d_morphology_skimage.h
@@ -7,7 +7,7 @@
 
 #include "test_ref_vals.h"
 
-static ref_vals_map<double> morphology_2d_skimage_shape2d_ref_vals{
+static const ref_vals_map<double> morphology_2d_skimage_shape2d_ref_vals{
 	// CONVEX_HULL_AREA / SOLIDITY are cross-checked against scikit-image on this exact ROI. Nyxus
 	// computes a Pick's-theorem pixel-count hull area (convex_hull_nontriv.cpp) = 27, solidity
 	// 26/27 = 0.9629630. Because Nyxus hulls through pixel CENTRES, this reproduces skimage's
@@ -42,7 +42,7 @@ static ref_vals_map<double> morphology_2d_skimage_shape2d_ref_vals{
 // The two do NOT agree on the small shape2d mask (skimage 12.657 vs Nyxus 26.935): there the object
 // is 26 pixels with a 1-pixel hole, and the two contour conventions have nothing to converge to.
 // PERIMETER is therefore vetted on this benchmark only, and stays a regression row on shape2d.
-static ref_vals_map<double> morphology_2d_skimage_circles_ref_vals{
+static const ref_vals_map<double> morphology_2d_skimage_circles_ref_vals{
 	{"PERIMETER", 999.25901807804496},
 };
 
@@ -51,7 +51,7 @@ static void assert_morphology_shape2d_skimage(const std::vector<std::vector<doub
 {
 	SCOPED_TRACE(std::string("SKIMAGE_ORACLE__") + feature_name);
 	ASSERT_TRUE(morphology_2d_skimage_shape2d_ref_vals.count(feature_name) > 0) << feature_name;
-	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_skimage_shape2d_ref_vals[feature_name], frac_tolerance));
+	ASSERT_TRUE(agrees_gt(fvals[static_cast<int>(feature)][0], morphology_2d_skimage_shape2d_ref_vals.at(feature_name), frac_tolerance));
 }
 
 void test_2d_morphology_convex_hull_skimage()
@@ -125,5 +125,5 @@ void test_2d_morphology_perimeter_skimage()
 	SCOPED_TRACE("SKIMAGE_ORACLE__PERIMETER");
 	ASSERT_TRUE(morphology_2d_skimage_circles_ref_vals.count("PERIMETER") > 0);
 	ASSERT_TRUE(agrees_gt(roidata.fvals[(int)Nyxus::Feature2D::PERIMETER][0],
-		morphology_2d_skimage_circles_ref_vals["PERIMETER"]));
+		morphology_2d_skimage_circles_ref_vals.at("PERIMETER")));
 }

--- a/tests/test_2d_ngldm_ibsi.h
+++ b/tests/test_2d_ngldm_ibsi.h
@@ -13,7 +13,7 @@
 //
 // These are published to three significant figures, which is what sets this file's rel=1e-2
 // tolerance. The full-precision digits are pinned against mirp in test_2d_ngldm_mirp.h.
-static ref_vals_map<double> ngldm_2d_ibsi_ref_vals
+static const ref_vals_map<double> ngldm_2d_ibsi_ref_vals
 {
 	{"NGLDM_LDE",		0.158},	// Low dependence emphasis, p.120, consensus - strong
 	{"NGLDM_HDE",		19.2},	// High dependence emphasis, p.121

--- a/tests/test_2d_ngldm_mirp.h
+++ b/tests/test_2d_ngldm_mirp.h
@@ -23,7 +23,7 @@
 // NGLDM_GLM and NGLDM_DCM are absent by design: mirp exposes no grey-level-mean or
 // dependence-count-mean column because they are not IBSI NGLDM features. They stay regression rows
 // in test_2d_ngldm_regression.h.
-static ref_vals_map<double> ngldm_2d_mirp_ref_vals
+static const ref_vals_map<double> ngldm_2d_mirp_ref_vals
 {
 	{"NGLDM_LDE", 0.15807024738501638},
 	{"NGLDM_HDE", 19.173821809425526},

--- a/tests/test_2d_ngldm_regression.h
+++ b/tests/test_2d_ngldm_regression.h
@@ -11,7 +11,7 @@
 
 // GLM and DCM are Nyxus mean-style rows that are not defined in the IBSI
 // NGLDM table, so only those two remain local regression references here.
-static ref_vals_map<double> ngldm_2d_regression_ref_vals
+static const ref_vals_map<double> ngldm_2d_regression_ref_vals
 {
 	{"NGLDM_GLM",		2.1178319573443410e+00},
 	{"NGLDM_DCM",		3.9832043343653250e+00}

--- a/tests/test_3d_firstorder_pyradiomics.h
+++ b/tests/test_3d_firstorder_pyradiomics.h
@@ -66,7 +66,7 @@ static double firstorder_3d_pyradiomics_band (const std::string& fname)
     return FO3D_PYRAD_EXACT;
 }
 
-static ref_vals_map<double> firstorder_3d_pyradiomics_ref_vals
+static const ref_vals_map<double> firstorder_3d_pyradiomics_ref_vals
 {
     {"3P10", 362.0}, // Case-1_original_firstorder_10Percentile
     {"3P90", 527.0}, // Case-1_original_firstorder_90Percentile
@@ -172,7 +172,7 @@ void assert_3d_firstorder_feature_pyradiomics (const Nyxus::Feature3D &expected_
     f.save_value (r.fvals);
 
     // (7) verdict
-    ASSERT_TRUE (agrees_gt(r.fvals[fcode][0], firstorder_3d_pyradiomics_ref_vals[fname],
+    ASSERT_TRUE (agrees_gt(r.fvals[fcode][0], firstorder_3d_pyradiomics_ref_vals.at(fname),
         firstorder_3d_pyradiomics_band(fname))) << fname;
 }
 

--- a/tests/test_3d_glcm_pyradiomics.h
+++ b/tests/test_3d_glcm_pyradiomics.h
@@ -86,7 +86,7 @@
 //        - 'SumSquares'
 //
 
-static ref_vals_map<double> glcm_3d_pyradiomics_ref_vals
+static const ref_vals_map<double> glcm_3d_pyradiomics_ref_vals
 {
     {"3GLCM_ACOR", 122.14708306342365},         // Case-1_original_glcm_Autocorrelation
     {"3GLCM_ASM", 0.0143339715631298},          // Case-1_original_glcm_JointEnergy
@@ -848,7 +848,7 @@ void assert_3d_glcm_ave_feature_pyradiomics (const Nyxus::Feature3D& ave_fcode,
     f.save_value(r.fvals);
 
     SCOPED_TRACE(std::string("PYRADIOMICS_ORACLE__") + base_fname + "_AVE");
-    const double want = glcm_3d_pyradiomics_ref_vals[base_fname];
+    const double want = glcm_3d_pyradiomics_ref_vals.at(base_fname);
     const double tol = glcm_3d_pyradiomics_tol(base_fname);
     ASSERT_NEAR(r.fvals[(int)ave_fcode][0], want, std::abs(want) * tol + 1e-12);
 }
@@ -1030,6 +1030,6 @@ void test_3d_glcm_ave_equivalence_pyradiomics()
         // (1) the identity holds on the stored _AVE features
         EXPECT_NEAR(va, vb, std::abs(vb) * 1e-6 + 1e-9) << p.an << " != " << p.bn;
         // (2) and the twin still matches its PyRadiomics golden, so the identity carries the claim
-        ASSERT_TRUE(agrees_gt(vb, glcm_3d_pyradiomics_ref_vals[p.golden], 10.));
+        ASSERT_TRUE(agrees_gt(vb, glcm_3d_pyradiomics_ref_vals.at(p.golden), 10.));
     }
 }

--- a/tests/test_3d_glcm_regression.h
+++ b/tests/test_3d_glcm_regression.h
@@ -22,7 +22,7 @@
 // are bounded in [0,1] by construction, and SUMVARIANCE == CLUTEND / DIS == DIFAVE hold exactly (to
 // ~1e-15). Why these values replaced the ones this file used to carry:
 // tests/vetting/audit/glcm_3d_pyradiomics_vetting_report.md.
-static ref_vals_map<double> glcm_3d_regression_ref_vals
+static const ref_vals_map<double> glcm_3d_regression_ref_vals
 {
     {"3GLCM_ACOR", 2864.4036927337511},
     {"3GLCM_ASM", 0.00075632811401173821},
@@ -139,7 +139,7 @@ void assert_3d_glcm_feature_regression (const Nyxus::Feature3D& expecting_fcode,
     // verdict, at rel=1e-8: a full-precision drift guard on Nyxus' own values, with headroom over
     // the fast_log10-derived (3d_glcm.cpp) compiler-rounding residuals measured on INFOMEAS1/2 and
     // DIFENTRO (up to rel 3.6e-9).
-    ASSERT_TRUE(agrees_gt(atot, glcm_3d_regression_ref_vals[fname], 1.e8)) << fname;
+    ASSERT_TRUE(agrees_gt(atot, glcm_3d_regression_ref_vals.at(fname), 1.e8)) << fname;
 }
 
 // Regenerates every golden in glcm_3d_regression_ref_vals at full precision, in the exact shape the
@@ -335,7 +335,7 @@ void test_3d_glcm_sum_variance_regression()
 // same-value identity trick documented there). This table claims no vetting of its own (SPEC 1):
 // it is a drift guard on the grey64 configuration, which nothing else in the tree exercises.
 // History: tests/vetting/audit/glcm_3d_golden_regen.md, "grey64 table and the retired Wave-9 sweep".
-static ref_vals_map<std::vector<double>> glcm_3d_regression_grey64_ref_vals
+static const ref_vals_map<std::vector<double>> glcm_3d_regression_grey64_ref_vals
 {
 	{ "3GLCM_ACOR_AVE", { 896.29490954682888 } },
 	{ "3GLCM_ASM_AVE", { 0.21714923037245615 } },

--- a/tests/test_3d_glrlm_pyradiomics.h
+++ b/tests/test_3d_glrlm_pyradiomics.h
@@ -39,7 +39,7 @@
 // Regenerate with tests/vetting/oracles/gen_glrlm3d_pyradiomics.py, which also re-verifies every
 // pin. See tests/vetting/audit/glrlm_3d_golden_regen.md.
 
-static ref_vals_map<double> glrlm_3d_pyradiomics_ref_vals
+static const ref_vals_map<double> glrlm_3d_pyradiomics_ref_vals
 {
     {"3GLRLM_GLN", 406.68709120394277},     // Case-1_original_glrlm_GrayLevelNonUniformity
     {"3GLRLM_GLNN", 0.09722976558135092},   // Case-1_original_glrlm_GrayLevelNonUniformityNormalized
@@ -578,9 +578,9 @@ void test_3d_glrlm_ave_pyradiomics()
     for (auto& a : aves)
     {
         double v = r.fvals[(int)a.ave][0];
-        ASSERT_TRUE(agrees_gt(v, glrlm_3d_pyradiomics_ref_vals[a.gt],
+        ASSERT_TRUE(agrees_gt(v, glrlm_3d_pyradiomics_ref_vals.at(a.gt),
                               glrlm_3d_pyradiomics_frac_tolerance(a.gt))) << a.gt << "_AVE = " << v
-            << " vs pyradiomics " << glrlm_3d_pyradiomics_ref_vals[a.gt];
+            << " vs pyradiomics " << glrlm_3d_pyradiomics_ref_vals.at(a.gt);
     }
 }
 

--- a/tests/test_ref_vals.h
+++ b/tests/test_ref_vals.h
@@ -21,6 +21,15 @@
 // Declaring the table through an alias is itself the rule, not a style preference -- a bare
 // std::unordered_map is invisible to the type-based detection above, so check_test_names.py rejects
 // a reference table spelled that way.
+//
+// Declare every table const, and read it with .at(). On a non-const map operator[] compiles, and a
+// key the table does not hold is default-inserted as 0 rather than failing: the assertion then
+// compares against a golden that does not exist, and passes whenever the computed value is also 0 --
+// a feature that silently produced nothing, which is the case the table is here to catch. The
+// inserted key then persists, so a later .count() guard on it succeeds too. const turns operator[]
+// into a compile error and .at() throws naming the missing key. check_test_names.py rejects a
+// reference table declared without const. A ref_vals_list is a vector: its operator[] reads rather
+// than inserts, so an index there is left alone.
 
 // Keyed by feature name -- the common shape.
 //   ref_vals_map<double> glcm_2d_ibsi_ref_vals { {"GLCM_ASM", 0.368}, ... };

--- a/tests/vetting/SPEC.md
+++ b/tests/vetting/SPEC.md
@@ -418,6 +418,16 @@ An assertion helper is bound to the table it reads, so it moves with it. A helpe
 oracle files is the shape to look for: it means one table is answering to several `<oracle>` claims,
 and the fix is to split the helper per oracle, not to relocate the table.
 
+**A table is `const`.** Reference data is read-only by definition, and here `const` does more than
+document that: without it `operator[]` compiles, and on a key the table does not hold it
+*default-inserts* 0 instead of failing. The assertion then compares against a golden that does not
+exist and passes whenever the computed value is also 0 — which is exactly the case a golden table is
+there to catch, a feature that silently produced nothing. The phantom key also survives for the rest
+of the run, so a later `.count()` guard on it succeeds. `const` makes `operator[]` a compile error
+and forces `.at()`, which throws naming the key it could not find. Read a table with `.at()`; use
+`.count()` first only where a clearer message is wanted. A `ref_vals_list` is a `std::vector`, whose
+`operator[]` reads rather than inserts, so an index into one is not part of this rule.
+
 A table's name is a claim, so `_regression` in it means the numbers are pinned Nyxus output and
 establish no vetting, exactly as for test functions (§1). It follows that **one table holds one
 oracle**: a table mixing imea-vetted keys with snapshot keys has no honest `<oracle>` to put in its
@@ -429,8 +439,8 @@ a §6.3.1 alias or reached through an accessor returning a function-local static
 deliberately includes the conforming suffixes, so a table cannot drift back to an old name without
 tripping the check. It rejects a missing suffix, a missing dim token, an `<oracle>` segment that is
 not a §4 token (`glcm_2d_mahotas_ref_vals` fails, since the registry does not accept mahotas), a
-reference table declared in a `_common.h`, and a reference table declared as a raw
-`std::unordered_map` rather than through an alias. That last one is what keeps the set closed: a
+reference table declared in a `_common.h`, a reference table declared without `const`, and a
+reference table declared as a raw `std::unordered_map` rather than through an alias. That last one is what keeps the set closed: a
 table identified only by the words in its name is one rename away from being invisible to the check,
 whereas `ref_vals_map<double>` says what it is regardless. One value type, `double`, for the same
 reason — `agrees_gt`/`ASSERT_NEAR` compare in double, so a `float` table narrowed its literals only

--- a/tests/vetting/check_test_names.py
+++ b/tests/vetting/check_test_names.py
@@ -173,6 +173,11 @@ TABLE_ACCESSOR = re.compile(
 
 INCLUDE = re.compile(r'^[ 	]*#include[ 	]+"(test_[^"]+)"', re.M)
 
+# A conforming table is const-qualified before its type, in whichever order the declaration puts
+# the other specifiers: "static const T x", "const T x", "static inline const T x", and the accessor
+# form "static const T& x()".
+TABLE_CONST = re.compile(r"^(?:(?:static|inline)[ 	]+)*const[ 	]")
+
 CPP_DEF = re.compile(
     r"^[ \t]*(?:static[ \t]+)?(?:inline[ \t]+)?void[ \t]+(test_[A-Za-z0-9_]*)[ \t]*\(([^)]*)\)", re.M)
 CPP_HELPER_DEF = re.compile(
@@ -434,6 +439,17 @@ def check(root):
                               f"declare it through a test_ref_vals.h alias "
                               f"({' / '.join(TABLE_ALIASES)}) so it is identifiable by type "
                               f"(SPEC 6.3.1)")
+            # 6.3.1: a reference table is read-only data, and const is what enforces it. Without
+            # const, operator[] compiles, so a key the table does not hold is default-inserted as 0
+            # instead of failing -- the assertion then compares against a golden that does not exist
+            # and passes whenever the computed value is also 0, which is the very case (a feature
+            # that silently returned nothing) the table exists to catch. It also leaves the phantom
+            # key behind for every later lookup in the run. const makes operator[] a compile error
+            # and forces .at(), which throws naming the key it could not find.
+            if not TABLE_CONST.match(line):
+                errors.append(f"{p.name}: golden table {name} is declared without const; a mutable "
+                              f"table permits operator[], which default-inserts a missing key as 0 "
+                              f"rather than failing (SPEC 6.3.1)")
             why = table_violation(name)
             if why:
                 errors.append(f"{p.name}: golden table {name} {why}")


### PR DESCRIPTION
30 files, all under `tests/`. No `src/nyx` change.

Rebased onto current `main` and reworked against it: the branch was 158 commits behind, and
two of its three commits had been overtaken in the meantime (see *What the rebase absorbed*
below). What is left is the part `main` still does not have.

Follow-up to #422, which gave every golden table one name, one location and one declaration
type. This adds the property those three could not express: the table is **read-only data**,
and saying so in the type closes a way for an assertion to pass against a golden that does
not exist.

## The defect

Of the 102 tables the §6.3.1 rules inspect, 34 were declared without `const`, and 25 read
sites reached them through `operator[]`:

```cpp
static ref_vals_map<double> firstorder_2d_ibsi_ref_vals { ... };
ASSERT_TRUE(agrees_gt(total, firstorder_2d_ibsi_ref_vals[feature_name], 100.));
```

On a key the table does not hold, `operator[]` **default-inserts 0** rather than failing. The
assertion then compares against a golden that was never written down — and `agrees_gt` derives
its band from the golden:

```cpp
auto diff = fval - ground_truth;
auto tolerance = ground_truth / frac_tolerance;
bool good = std::abs(diff) <= std::abs(tolerance);
```

So a golden of 0 passes exactly when the computed value is also 0. That is not an unreachable
corner: *"the feature was not computed and returned 0"* is one of the specific failures a
golden table exists to catch, and in that combination the test goes green against a reference
that isn't there. The inserted key also persists for the rest of the run, so a later
`.count()` guard on the same key succeeds too.

Same class the #422 review kept surfacing — an assertion that cannot fail on the thing it
claims to check — reached through the container's API instead of through naming or file
layout.

## The change

**`const` on the 34 remaining tables, `.at()` at the 25 read sites.** `operator[]` does not
exist on a `const` map, so every site needing attention arrived as a **compile error**, not as
a silent change in behaviour — which is what makes a sweep this wide safe to do mechanically.
A missing key now throws naming the key instead of inventing a zero. The clean build is itself
the proof that the set is closed: had a read site been missed, it would not have compiled.

`ref_vals_list` is a `std::vector`, and a const vector's `operator[]` reads rather than
inserts, so the two index sites in `test_3d_morphology_mechanics.h` are left alone. SPEC and
`test_ref_vals.h` say so rather than leaving the exception to be re-derived.

**Enforced.** `check_test_names.py` rejects a reference table declared without `const`, beside
the existing raw-container, `_common.h` and cross-family-include rules. The self-test plants a
table whose name, location and type all conform so that mutability is its only defect, and
asserts the rule does **not** fire on a `const` table — a rule that flags everything is as
useless as one that flags nothing. SPEC §6.3.1 and `test_ref_vals.h` record the rule and why
this is a correctness problem rather than a style one.

## What the rebase absorbed

Two of the three original commits are no longer needed, and are dropped rather than replayed:

- **The `test_2d_remaining_common.h` cleanup.** `main` has since folded that header into the
  morphology one (`baf6a6b6`), so the file it cleaned up does not exist any more.
- **The two neighbour oracle files that guarded a key they had already indexed.**
  `test_2d_neighbor_analytic.h` and `test_2d_neighbor_cellprofiler.h` now guard the label
  before reaching it, as `test_2d_neighbor_regression.h` already did.

Also worth noting: tables added to `main` in those 158 commits were written `const` from the
start, which is why 34 rather than 53 were left to convert. This PR closes the remainder and
makes reopening it a build failure.

## What this did and did not find

**No existing assertion was wrong.** Every test passes, and nothing threw from `.at()`, so no
test in the tree was relying on a default-inserted key today. The change closes the hole
prospectively; it did not uncover a live bad assertion.

## Verification

- gtest: **882 passed / 1 skipped** of 883 (Windows, MSVC/Ninja; the skip is
  `TEST_2D_GABOR_GPU_RUNS_MECHANICS` on a CPU-only build)
- ASan + UBSan (gcc 13, `-fsanitize=address,undefined -fno-sanitize-recover=undefined`, Linux):
  gtest **878 passed / 1 skipped** of 879 with **0 diagnostics**, wrapper exit 0. The four-test
  delta from Windows is the DICOM HU-loader mechanics tests, absent from a `NOEXTRAS=ON` build.
  The instrumented `pytest tests/python/` leg aborts at
  `test_nyxus.py::TestNyxus::test_nonimq_wsi_scalability` on a **pre-existing** UBSan finding on
  `main` — `src/nyx/features/glszm.cpp:426: signed integer overflow: 46341 * 46341 cannot be
  represented in type 'int'`, reached through the 2D whole-slide path. It cannot be attributable
  to this PR: the diff contains no `src/nyx` file and does not touch `test_nyxus.py`, so the
  instrumented module is built from bytes identical to `upstream/main`. With that one test
  deselected the leg runs clean: 87 passed / 1 skipped / 7 Arrow, **0 diagnostics**.
- `pytest tests/python/`: 88 passed / 1 skipped (7 pre-existing Arrow failures of a tiff-only
  build)
- `check_test_names.py --check` and `check_coverage.py --check` clean; 102 tables inspected,
  0 raw, 0 non-const, 0 in a `_common.h`; vetting self-tests 10/10 with the new case
- Diff entirely under `tests/` — no `src/nyx` change
- LF throughout; `git diff --shortstat` and `--ignore-all-space --shortstat` agree, so no
  whitespace-only churn

## Commits

1. `test(vetting): make every golden reference table const and read it with .at()`
2. `test(vetting): reject a golden reference table declared without const`

## Not in this PR

The `constexpr` form asked for in #422 review. `std::unordered_map` with `std::string` keys
allocates, so the compile-time shape is `constexpr std::array<std::pair<std::string_view,
double>, N>` with a `constexpr` accessor. The payoff usually claimed for it — a mistyped key
caught at build time — is not available while keys arrive as runtime `std::string` parameters
into the shared `assert_*` helpers, and after this PR it changes no behaviour. Recorded as
optional follow-up rather than dropped.
