### PR TITLE
chore: ignore the feature tables the test suites write into the working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -566,3 +566,8 @@ cython_debug/
 # setuptools-scm generated version file
 src/nyx/python/nyxus/_version.py
 .planning/
+
+# Feature tables written into the working directory by the test suites. NyxusFeatures is the
+# default result filename stem (Environment::nyxus_result_fname); the extension follows whichever
+# writer ran, so pytest leaves .arrow and .parquet behind on every run of tests/python/.
+NyxusFeatures.*


### PR DESCRIPTION
# Ignore the feature tables the test suites write into the working directory

`pytest tests/python/` writes `NyxusFeatures.arrow` and `NyxusFeatures.parquet` into the repository
root on every run, and nothing in `.gitignore` matches them. They appear as untracked files after
each run, which means a `git add -A` sweeps them into whatever commit is being prepared.

## The rule

```
# Feature tables written into the working directory by the test suites. NyxusFeatures is the
# default result filename stem (Environment::nyxus_result_fname); the extension follows whichever
# writer ran, so pytest leaves .arrow and .parquet behind on every run of tests/python/.
NyxusFeatures.*
```

It matches the **stem**, not the two extensions observed. `NyxusFeatures` is the default result
filename set in `Environment::nyxus_result_fname` (`src/nyx/environment.cpp`), and the extension is
whichever writer produced the table — so a build configured with a different writer drops a
differently-named file in the same place, and an extension-by-extension list would miss it.

## Checks

- Verified with real files: `NyxusFeatures.arrow`, `.parquet` and `.csv` created in the repository
  root are all matched by the new rule (`git check-ignore -v` resolves each to it), and none appear
  in `git status --untracked-files=all`.
- No tracked file matches the pattern, so nothing already in the repository is hidden by it.
- The rule sits with the other project-specific entries at the end of the file, below the stock
  GitHub VisualStudio/Python template.

The diff is five lines in `.gitignore` and touches nothing else.